### PR TITLE
✏️ Fix compile error by modifying compileOptions and setting JVM target to 17

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
+
 plugins {
     alias(libs.plugins.androidLibrary) apply false
     alias(libs.plugins.androidApplication) apply false
@@ -5,4 +8,30 @@ plugins {
     alias(libs.plugins.jetbrainsCompose) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.mavenPublishVanniktech) apply false
+}
+
+allprojects {
+
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile> {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
+    tasks.withType<JavaCompile> {
+        sourceCompatibility = "${JavaVersion.VERSION_17}"
+        targetCompatibility = "${JavaVersion.VERSION_17}"
+    }
+}
+subprojects {
+    afterEvaluate {
+        tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile> {
+            compilerOptions {
+                jvmTarget.set(JvmTarget.JVM_17)
+            }
+        }
+        tasks.withType<JavaCompile> {
+            sourceCompatibility = "${JavaVersion.VERSION_17}"
+            targetCompatibility = "${JavaVersion.VERSION_17}"
+        }
+    }
 }

--- a/samples/sample-compose/composeApp/build.gradle.kts
+++ b/samples/sample-compose/composeApp/build.gradle.kts
@@ -101,8 +101,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 }
 


### PR DESCRIPTION
Resolved an inconsistency in JVM target compatibility between 'compileDebugJavaWithJavac' (11) and 'compileDebugKotlinAndroid' (17) by updating the compile options to use JVM target 17.