### PR TITLE
fix library name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <br>
 </div>
 
-Picker Kotlin is a library that allows you to pick and save files in a simple way. On each platform, it uses the native file picker API to provide a consistent experience.
+FileKit is a library that allows you to pick and save files in a simple way. On each platform, it uses the native file picker API to provide a consistent experience.
 
 ## 🚀 Quick Start
 


### PR DESCRIPTION
I think you had a leftover "Picker Kotlin" from before the name change