### PR TITLE
Feature/add getSize function to PlatformFile

### DIFF
--- a/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.android.kt
+++ b/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.android.kt
@@ -3,7 +3,9 @@ package io.github.vinceglb.filekit.core
 import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
+import android.os.Build
 import android.provider.OpenableColumns
+import androidx.annotation.RequiresApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -26,6 +28,14 @@ public actual data class PlatformFile(
             .use { stream -> stream?.readBytes() }
             ?: throw IllegalStateException("Failed to read file")
     }
+
+    public actual fun getSize(): Long? = runCatching {
+        context.contentResolver.query(uri, null, null, null, null)
+            ?.use { cursor ->
+                cursor.moveToFirst()
+                cursor.getColumnIndex(OpenableColumns.SIZE).let(cursor::getLong)
+            }
+    }.getOrNull()
 
     private fun Context.getFileName(uri: Uri): String? = when (uri.scheme) {
         ContentResolver.SCHEME_CONTENT -> getContentFileName(uri)

--- a/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.apple.kt
+++ b/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.apple.kt
@@ -36,6 +36,10 @@ public actual data class PlatformFile(
             }
         }
     }
+
+    public actual fun getSize(): Long? {
+        TODO("implement on Mac")
+    }
 }
 
 public actual data class PlatformDirectory(

--- a/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.apple.kt
+++ b/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.apple.kt
@@ -1,13 +1,23 @@
 package io.github.vinceglb.filekit.core
 
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.CPointer
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.ObjCObjectVar
 import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.pointed
+import kotlinx.cinterop.ptr
 import kotlinx.cinterop.usePinned
+import kotlinx.cinterop.value
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 import platform.Foundation.NSData
+import platform.Foundation.NSError
 import platform.Foundation.NSURL
+import platform.Foundation.NSURLFileSizeKey
 import platform.Foundation.dataWithContentsOfURL
 import platform.Foundation.lastPathComponent
 import platform.posix.memcpy
@@ -37,8 +47,15 @@ public actual data class PlatformFile(
         }
     }
 
+    @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
     public actual fun getSize(): Long? {
-        TODO("implement on Mac")
+        memScoped {
+            val valuePointer: CPointer<ObjCObjectVar<Any?>> = alloc<ObjCObjectVar<Any?>>().ptr
+            val errorPointer: CPointer<ObjCObjectVar<NSError?>> =
+                alloc<ObjCObjectVar<NSError?>>().ptr
+            nsUrl.getResourceValue(valuePointer, NSURLFileSizeKey, errorPointer)
+            return valuePointer.pointed.value as? Long?
+        }
     }
 }
 

--- a/filekit-core/src/commonMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.kt
+++ b/filekit-core/src/commonMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.kt
@@ -5,6 +5,7 @@ public expect class PlatformFile {
     public val path: String?
 
     public suspend fun readBytes(): ByteArray
+    public fun getSize(): Long?
 }
 
 public val PlatformFile.baseName: String

--- a/filekit-core/src/jsMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.js.kt
+++ b/filekit-core/src/jsMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.js.kt
@@ -53,6 +53,8 @@ public actual data class PlatformFile(
             reader.readAsArrayBuffer(file)
         }
     }
+
+    public actual fun getSize(): Long? = file.size.toLong()
 }
 
 public actual data class PlatformDirectory(

--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.jvm.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.jvm.kt
@@ -3,6 +3,7 @@ package io.github.vinceglb.filekit.core
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.nio.file.Files
 
 public actual data class PlatformFile(
 	val file: File,
@@ -15,6 +16,8 @@ public actual data class PlatformFile(
 
 	public actual suspend fun readBytes(): ByteArray =
 		withContext(Dispatchers.IO) { file.readBytes() }
+
+	public actual fun getSize(): Long? = Files.size(file.toPath())
 }
 
 public actual data class PlatformDirectory(

--- a/filekit-core/src/wasmJsMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.wasmJs.kt
+++ b/filekit-core/src/wasmJsMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.wasmJs.kt
@@ -53,6 +53,8 @@ public actual data class PlatformFile(
 			reader.readAsArrayBuffer(file)
 		}
 	}
+
+	public actual fun getSize(): Long? = file.size.toDouble().toLong()
 }
 
 public actual data class PlatformDirectory(


### PR DESCRIPTION
Added `fun getSize(): Long?` to `PlatformFile`. This allow accessing the size of a file without having to `readBytes` first. 

- [x] Implement
- [x] Test (missing test on iOS) Can't test right now because I don't have an iOS device and I can't run the app on an emulator. Do you have the same problem that running on an emulator crashes the app as soon as you select a file?