### PR TITLE
Don't init FileKit if in inspection mode

### DIFF
--- a/filekit-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/compose/FileKitCompose.android.kt
+++ b/filekit-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/compose/FileKitCompose.android.kt
@@ -5,11 +5,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
 import io.github.vinceglb.filekit.core.FileKit
+import androidx.compose.ui.platform.LocalInspectionMode
 
 @Composable
 internal actual fun InitFileKit() {
-    val componentActivity = LocalContext.current as ComponentActivity
-    LaunchedEffect(Unit) {
-        FileKit.init(componentActivity)
+    if (!LocalInspectionMode.current) {
+        val componentActivity = LocalContext.current as ComponentActivity
+        LaunchedEffect(Unit) {
+            FileKit.init(componentActivity)
+        }
     }
 }


### PR DESCRIPTION
Fixes #51

Don't initialize FileKit if the app is currently in inspection (preview) mode