### PR TITLE
Xdg Desktop FileChooser Portal

### DIFF
--- a/filekit-core/build.gradle.kts
+++ b/filekit-core/build.gradle.kts
@@ -53,6 +53,8 @@ kotlin {
 
         jvmMain.dependencies {
             implementation(libs.jna)
+            implementation(libs.dbus.java.core)
+            implementation(libs.dbus.java.transport.native.unixsocket)
         }
     }
 

--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/FileKit.jvm.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/FileKit.jvm.kt
@@ -1,9 +1,9 @@
 package io.github.vinceglb.filekit.core
 
 import io.github.vinceglb.filekit.core.platform.PlatformFilePicker
-import io.github.vinceglb.filekit.core.platform.awt.AwtFileSaver
 import io.github.vinceglb.filekit.core.platform.util.Platform
 import io.github.vinceglb.filekit.core.platform.util.PlatformUtil
+import io.github.vinceglb.filekit.core.platform.xdg.XdgFilePickerPortal
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -63,7 +63,7 @@ public actual object FileKit {
     public actual fun isDirectoryPickerSupported(): Boolean = when (PlatformUtil.current) {
         Platform.MacOS -> true
         Platform.Windows -> true
-        Platform.Linux -> false
+        Platform.Linux -> PlatformFilePicker.current is XdgFilePickerPortal
     }
 
     public actual suspend fun saveFile(
@@ -73,13 +73,14 @@ public actual object FileKit {
         initialDirectory: String?,
         platformSettings: FileKitPlatformSettings?,
     ): PlatformFile? = withContext(Dispatchers.IO) {
-        AwtFileSaver.saveFile(
+        val result = PlatformFilePicker.current.saveFile(
             bytes = bytes,
             baseName = baseName,
             extension = extension,
             initialDirectory = initialDirectory,
             parentWindow = platformSettings?.parentWindow,
         )
+        result?.let { PlatformFile(result) }
     }
 
     public actual suspend fun isSaveFileWithoutBytesSupported(): Boolean = true

--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/PlatformFilePicker.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/PlatformFilePicker.kt
@@ -1,43 +1,65 @@
 package io.github.vinceglb.filekit.core.platform
 
 import io.github.vinceglb.filekit.core.platform.awt.AwtFilePicker
+import io.github.vinceglb.filekit.core.platform.awt.AwtFileSaver
 import io.github.vinceglb.filekit.core.platform.mac.MacOSFilePicker
 import io.github.vinceglb.filekit.core.platform.util.Platform
 import io.github.vinceglb.filekit.core.platform.util.PlatformUtil
 import io.github.vinceglb.filekit.core.platform.windows.WindowsFilePicker
+import io.github.vinceglb.filekit.core.platform.xdg.XdgFilePickerPortal
 import java.awt.Window
 import java.io.File
 
 internal interface PlatformFilePicker {
-	suspend fun pickFile(
-		initialDirectory: String?,
-		fileExtensions: List<String>?,
-		title: String?,
-		parentWindow: Window?,
-	): File?
+    suspend fun pickFile(
+        initialDirectory: String?,
+        fileExtensions: List<String>?,
+        title: String?,
+        parentWindow: Window?,
+    ): File?
 
-	suspend fun pickFiles(
-		initialDirectory: String?,
-		fileExtensions: List<String>?,
-		title: String?,
-		parentWindow: Window?,
-	): List<File>?
+    suspend fun pickFiles(
+        initialDirectory: String?,
+        fileExtensions: List<String>?,
+        title: String?,
+        parentWindow: Window?,
+    ): List<File>?
 
-	fun pickDirectory(
-		initialDirectory: String?,
-		title: String?,
-		parentWindow: Window?,
-	): File?
+    suspend fun pickDirectory(
+        initialDirectory: String?,
+        title: String?,
+        parentWindow: Window?,
+    ): File?
 
-	companion object {
-		val current: PlatformFilePicker by lazy { createPlatformFilePicker() }
+    suspend fun saveFile(
+        bytes: ByteArray?,
+        baseName: String,
+        extension: String,
+        initialDirectory: String?,
+        parentWindow: Window?,
+    ): File? = AwtFileSaver.saveFile(
+        bytes = bytes,
+        baseName = baseName,
+        extension = extension,
+        initialDirectory = initialDirectory,
+        parentWindow = parentWindow,
+    )
 
-		private fun createPlatformFilePicker(): PlatformFilePicker {
-			return when (PlatformUtil.current) {
-				Platform.MacOS -> MacOSFilePicker()
-				Platform.Windows -> WindowsFilePicker()
-				Platform.Linux -> AwtFilePicker()
-			}
-		}
-	}
+
+    companion object {
+        val current: PlatformFilePicker by lazy { createPlatformFilePicker() }
+
+        private fun createPlatformFilePicker(): PlatformFilePicker {
+            return when (PlatformUtil.current) {
+                Platform.MacOS -> MacOSFilePicker()
+                Platform.Windows -> WindowsFilePicker()
+                Platform.Linux -> {
+                    val xdgPortalFilePicker = XdgFilePickerPortal()
+                    if (xdgPortalFilePicker.isAvailable()) xdgPortalFilePicker
+                    else AwtFilePicker()
+
+                }
+            }
+        }
+    }
 }

--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/awt/AwtFilePicker.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/awt/AwtFilePicker.kt
@@ -37,7 +37,7 @@ internal class AwtFilePicker : PlatformFilePicker {
         parentWindow = parentWindow
     )
 
-    override fun pickDirectory(
+    override suspend fun pickDirectory(
         initialDirectory: String?,
         title: String?,
         parentWindow: Window?,

--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/awt/AwtFileSaver.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/awt/AwtFileSaver.kt
@@ -1,6 +1,5 @@
 package io.github.vinceglb.filekit.core.platform.awt
 
-import io.github.vinceglb.filekit.core.PlatformFile
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.awt.Dialog
 import java.awt.FileDialog
@@ -16,13 +15,13 @@ internal object AwtFileSaver {
         extension: String,
         initialDirectory: String?,
         parentWindow: Window?,
-    ): PlatformFile? = suspendCancellableCoroutine { continuation ->
+    ): File? = suspendCancellableCoroutine { continuation ->
         fun handleResult(value: Boolean, files: Array<File>?) {
             if (value) {
                 val file = files?.firstOrNull()?.let { file ->
                     // Write bytes to file, or create a new file
                     bytes?.let { file.writeBytes(bytes) } ?: file.createNewFile()
-                    PlatformFile(file)
+                    file
                 }
                 continuation.resume(file)
             }

--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/mac/MacOSFilePicker.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/mac/MacOSFilePicker.kt
@@ -35,7 +35,7 @@ internal class MacOSFilePicker : PlatformFilePicker {
 		)
 	}
 
-	override fun pickDirectory(
+	override suspend fun pickDirectory(
 		initialDirectory: String?,
 		title: String?,
 		parentWindow: Window?,

--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/windows/WindowsFilePicker.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/windows/WindowsFilePicker.kt
@@ -62,7 +62,7 @@ internal class WindowsFilePicker : PlatformFilePicker {
 			.ifEmpty { null }
 	}
 
-	override fun pickDirectory(
+	override suspend fun pickDirectory(
 		initialDirectory: String?,
 		title: String?,
 		parentWindow: Window?,

--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/xdg/XdgFilePickerPortal.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/xdg/XdgFilePickerPortal.kt
@@ -1,0 +1,225 @@
+package io.github.vinceglb.filekit.core.platform.xdg
+
+import com.sun.jna.Native
+import io.github.vinceglb.filekit.core.platform.PlatformFilePicker
+import kotlinx.coroutines.CompletableDeferred
+import org.freedesktop.dbus.DBusMap
+import org.freedesktop.dbus.DBusMatchRule
+import org.freedesktop.dbus.DBusPath
+import org.freedesktop.dbus.Tuple
+import org.freedesktop.dbus.annotations.DBusBoundProperty
+import org.freedesktop.dbus.annotations.DBusInterfaceName
+import org.freedesktop.dbus.annotations.DBusProperty.Access
+import org.freedesktop.dbus.annotations.Position
+import org.freedesktop.dbus.connections.impl.DBusConnection
+import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
+import org.freedesktop.dbus.interfaces.DBusInterface
+import org.freedesktop.dbus.interfaces.DBusSigHandler
+import org.freedesktop.dbus.interfaces.Properties
+import org.freedesktop.dbus.messages.DBusSignal
+import org.freedesktop.dbus.types.UInt32
+import org.freedesktop.dbus.types.Variant
+import java.awt.Window
+import java.io.File
+import java.net.URI
+import java.util.*
+
+//https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.FileChooser.html
+internal class XdgFilePickerPortal : PlatformFilePicker {
+
+    fun isAvailable(): Boolean {
+        try {
+            DBusConnectionBuilder.forSessionBus().build().use { connection ->
+                connection.getRemoteObject(
+                    "org.freedesktop.portal.Desktop",
+                    "/org/freedesktop/portal/desktop",
+                    Properties::class.java
+                ).Get<UInt32>("org.freedesktop.portal.FileChooser", "version")
+                return true
+            }
+        } catch (e: Exception) {
+            return false
+        }
+    }
+
+    override suspend fun pickFile(
+        initialDirectory: String?,
+        fileExtensions: List<String>?,
+        title: String?,
+        parentWindow: Window?
+    ): File? {
+        return pickFiles(
+            initialDirectory = initialDirectory,
+            fileExtensions = fileExtensions,
+            title = title,
+            parentWindow = parentWindow,
+            multiple = false,
+            directory = false
+        )?.firstOrNull()
+    }
+
+    override suspend fun pickFiles(
+        initialDirectory: String?,
+        fileExtensions: List<String>?,
+        title: String?,
+        parentWindow: Window?
+    ): List<File>? {
+        return pickFiles(
+            initialDirectory = initialDirectory,
+            fileExtensions = fileExtensions,
+            title = title,
+            parentWindow = parentWindow,
+            multiple = true,
+            directory = false
+        )
+    }
+
+    override suspend fun pickDirectory(
+        initialDirectory: String?,
+        title: String?,
+        parentWindow: Window?
+    ): File? {
+        return pickFiles(
+            initialDirectory = initialDirectory,
+            fileExtensions = null,
+            title = title,
+            parentWindow = parentWindow,
+            multiple = false,
+            directory = true
+        )?.firstOrNull()
+    }
+
+    private suspend fun pickFiles(
+        initialDirectory: String?,
+        fileExtensions: List<String>?,
+        title: String?,
+        parentWindow: Window?,
+        multiple: Boolean,
+        directory: Boolean,
+    ): List<File>? {
+        DBusConnectionBuilder.forSessionBus().build().use { connection ->
+            val handleToken = UUID.randomUUID().toString().replace("-", "")
+            val options: MutableMap<String, Variant<*>> = HashMap()
+            options["handle_token"] = Variant(handleToken)
+            options["multiple"] = Variant(multiple)
+            options["directory"] = Variant(directory)
+            fileExtensions?.let { options["filters"] = createFilterOption(it) }
+            initialDirectory?.let { options["current_folder"] = createCurrentFolderOption(it) }
+
+            val deferredResult = registerResponseHandler(connection, handleToken)
+            getFileChooserObject(connection).OpenFile(
+                parentWindow = getWindowIdentifier(parentWindow) ?: "",
+                title = title ?: "",
+                options = options
+            )
+            val files = deferredResult.await()?.map { File(it) }
+            return files
+        }
+    }
+
+    override suspend fun saveFile(
+        bytes: ByteArray?,
+        baseName: String,
+        extension: String,
+        initialDirectory: String?,
+        parentWindow: Window?,
+    ): File? {
+        DBusConnectionBuilder.forSessionBus().build().use { connection ->
+            val handleToken = UUID.randomUUID().toString().replace("-", "")
+            val options: MutableMap<String, Variant<*>> = HashMap()
+            options["handle_token"] = Variant(handleToken)
+            options["current_name"] = Variant("$baseName.$extension")
+            initialDirectory?.let { options["current_folder"] = createCurrentFolderOption(it) }
+
+            val deferredResult = registerResponseHandler(connection, handleToken)
+            getFileChooserObject(connection).SaveFile(
+                parentWindow = getWindowIdentifier(parentWindow) ?: "",
+                title = "",
+                options = options
+            )
+
+            val file = deferredResult.await()?.first()?.let { File(it) }
+            if (bytes != null && file != null) file.writeBytes(bytes)
+            else file?.createNewFile()
+
+            return file
+        }
+    }
+
+    //https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Request.html
+    private fun registerResponseHandler(
+        connection: DBusConnection,
+        handleToken: String
+    ): CompletableDeferred<List<URI>?> {
+        val sender = connection.uniqueName.substring(1).replace('.', '_')
+        val path = "/org/freedesktop/portal/desktop/request/$sender/$handleToken"
+
+        val result = CompletableDeferred<List<URI>?>()
+        val matchRule = DBusMatchRule("signal", "org.freedesktop.portal.Request", "Response")
+        val handler = ResponseHandler(path) { uris, handler ->
+            connection.removeGenericSigHandler(matchRule, handler)
+            result.complete(uris)
+        }
+        connection.addGenericSigHandler(matchRule, handler)
+        return result;
+    }
+
+    private class ResponseHandler(
+        private val path: String,
+        private val onComplete: (result: List<URI>?, thisHandler: ResponseHandler) -> Unit
+    ) : DBusSigHandler<DBusSignal> {
+
+        @Suppress("UNCHECKED_CAST")
+        override fun handle(signal: DBusSignal) {
+            if (path == signal.path) {
+                val params = signal.parameters
+                val response = params[0] as UInt32
+                val results = params[1] as DBusMap<String, Variant<*>>
+
+                if (response.toInt() == 0) {
+                    val uris = (results["uris"]!!.value as List<String>).map { URI(it) }
+                    onComplete(uris, this)
+                } else {
+                    onComplete(null, this)
+                }
+            }
+        }
+    }
+
+    // awt only supports X11
+    private fun getWindowIdentifier(parentWindow: Window?) = parentWindow?.let { "X11:${Native.getWindowID(it)}" }
+
+    private fun getFileChooserObject(connection: DBusConnection) = connection.getRemoteObject(
+        "org.freedesktop.portal.Desktop",
+        "/org/freedesktop/portal/desktop",
+        FileChooserDbusInterface::class.java
+    )
+
+    private fun createFilterOption(extensions: List<String>) = Variant(
+        extensions.map { extension -> Pair(extension, listOf(Pair(0, "*.$extension"))) },
+        "a(sa(us))"
+    )
+
+    private fun createCurrentFolderOption(currentFolder: String): Variant<*> {
+        val stringBytes = currentFolder.encodeToByteArray()
+        val nullTerminated = ByteArray(stringBytes.size + 1)
+        System.arraycopy(stringBytes, 0, nullTerminated, 0, stringBytes.size);
+        return Variant(nullTerminated)
+    }
+}
+
+@DBusInterfaceName(value = "org.freedesktop.portal.FileChooser")
+@Suppress("FunctionName")
+internal interface FileChooserDbusInterface : DBusInterface {
+    fun OpenFile(parentWindow: String, title: String, options: MutableMap<String, Variant<*>>): DBusPath
+    fun SaveFile(parentWindow: String, title: String, options: MutableMap<String, Variant<*>>): DBusPath
+    fun SaveFiles(parentWindow: String, title: String, options: MutableMap<String, Variant<*>>): DBusPath
+
+    @DBusBoundProperty(name = "version", access = Access.READ)
+    fun GetVersion(): UInt32
+}
+
+internal class Pair<A, B>(
+    @field:Position(0) val a: A,
+    @field:Position(1) val b: B
+) : Tuple()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ android-activity-ktx = "1.9.0"
 android-compose = "1.9.0"
 coilCompose = "3.0.0-alpha07"
 compose-plugin = "1.6.11"
+dbus-java = "5.0.0"
 jna = "5.14.0"
 observable-viewmodel = "1.0.0-BETA-3"
 koinCompose = "1.2.0-Beta4"
@@ -15,6 +16,8 @@ mavenPublishVanniktech = "0.29.0"
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "android-compose" }
 androidx-activity-ktx = { group = "androidx.activity", name = "activity-ktx", version.ref = "android-activity-ktx" }
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coilCompose" }
+dbus-java-core = { module = "com.github.hypfvieh:dbus-java-core", version.ref = "dbus-java" }
+dbus-java-transport-native-unixsocket = { module = "com.github.hypfvieh:dbus-java-transport-native-unixsocket", version.ref = "dbus-java" }
 jna = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 observable-viewmodel = { module = "com.rickclephas.kmp:kmp-observableviewmodel-core", version.ref = "observable-viewmodel" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koinCompose" }


### PR DESCRIPTION
Adds support for Xdg Desktop File Chooser portal for Linux
https://flatpak.github.io/xdg-desktop-portal/docs/reasons-to-use-portals.html
https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.FileChooser.html

It uses dbus-java which in turn uses Jvm implementation of domain unix sockets https://inside.java/2021/02/03/jep380-unix-domain-sockets-channels/ No additional native code added

If portal service is not available it will fallback to AWT filepciker
Tested on Ubuntu 22.04 with Gnome and on Archlinux with Kde Plasma
closes #64 