### PR TITLE
Fix crashes on Android inside Compose dialogs

### DIFF
--- a/filekit-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/compose/FileKitCompose.android.kt
+++ b/filekit-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/compose/FileKitCompose.android.kt
@@ -1,18 +1,25 @@
 package io.github.vinceglb.filekit.compose
 
-import androidx.activity.ComponentActivity
+import androidx.activity.compose.LocalActivityResultRegistryOwner
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.platform.LocalContext
-import io.github.vinceglb.filekit.core.FileKit
 import androidx.compose.ui.platform.LocalInspectionMode
+import io.github.vinceglb.filekit.core.FileKit
 
 @Composable
 internal actual fun InitFileKit() {
     if (!LocalInspectionMode.current) {
-        val componentActivity = LocalContext.current as ComponentActivity
-        LaunchedEffect(Unit) {
-            FileKit.init(componentActivity)
+        val context = LocalContext.current
+        val registry = LocalActivityResultRegistryOwner.current?.activityResultRegistry
+
+        // if null then MainActivity is not an Activity that implements ActivityResultRegistryOwner e.g. ComponentActivity
+        // This should not generally happen
+        // Calls to launcher should fail with FileKitNotInitializedException if it wasn't previously initialized
+        if (registry != null) {
+            LaunchedEffect(Unit) {
+                FileKit.init(context, registry)
+            }
         }
     }
 }

--- a/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/core/FileKit.android.kt
+++ b/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/core/FileKit.android.kt
@@ -27,6 +27,11 @@ public actual object FileKit {
         registry = activity.activityResultRegistry
     }
 
+    public fun init(context: Context, registry: ActivityResultRegistry) {
+        this.context = WeakReference(context)
+        this.registry = registry
+    }
+
     public actual suspend fun <Out> pickFile(
         type: PickerType,
         mode: PickerMode<Out>,


### PR DESCRIPTION
Fixes crashes on Android when rememberFilePickerLauncher() is called inside `androidx.compose.ui.window.Dialog`

When dialog is created Context is wrapped in `ContextThemeWrapper` and when attempt is made to cast it to `ComponentActivity` it crashes with `java.lang.ClassCastException`

Use `LocalActivityResultRegistryOwner` as a fix. 
It either stores a composition local instance of `ActivityResultRegistryOwner` or unwraps compositon local context until it finds activity that implements `ActivityResultRegistryOwner` (most oftent it is `ComponentActivity`)

Example to reproduce the crash:
``` kotlin
@Composable
fun App() {
    MaterialTheme {
        var showDialog by remember { mutableStateOf(false) }
        Button(onClick = { showDialog = true }) {
            Text("Show dialog")
        }
        if (showDialog) {
            Dialog(onDismissRequest = { showDialog = false }) {

                var files: Set<PlatformFile> by remember { mutableStateOf(emptySet()) }
                val singleFilePicker = rememberFilePickerLauncher(
                    type = PickerType.Image,
                    title = "Single file picker",
                    onResult = { file -> file?.let { files += it } }
                )
                Button(onClick = { singleFilePicker.launch() }) {
                    Text("Single file picker")
                }
            }
        }
    }
}
```