### PR TITLE
Swing (JFileChooser) (fallback for Linux)

### DIFF
--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/FileKit.jvm.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/FileKit.jvm.kt
@@ -1,9 +1,6 @@
 package io.github.vinceglb.filekit.core
 
 import io.github.vinceglb.filekit.core.platform.PlatformFilePicker
-import io.github.vinceglb.filekit.core.platform.util.Platform
-import io.github.vinceglb.filekit.core.platform.util.PlatformUtil
-import io.github.vinceglb.filekit.core.platform.xdg.XdgFilePickerPortal
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -60,11 +57,7 @@ public actual object FileKit {
         file?.let { PlatformDirectory(it) }
     }
 
-    public actual fun isDirectoryPickerSupported(): Boolean = when (PlatformUtil.current) {
-        Platform.MacOS -> true
-        Platform.Windows -> true
-        Platform.Linux -> PlatformFilePicker.current is XdgFilePickerPortal
-    }
+    public actual fun isDirectoryPickerSupported(): Boolean = true
 
     public actual suspend fun saveFile(
         bytes: ByteArray?,

--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/PlatformFilePicker.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/PlatformFilePicker.kt
@@ -2,7 +2,9 @@ package io.github.vinceglb.filekit.core.platform
 
 import io.github.vinceglb.filekit.core.platform.awt.AwtFilePicker
 import io.github.vinceglb.filekit.core.platform.awt.AwtFileSaver
+import io.github.vinceglb.filekit.core.platform.linux.LinuxFilePicker
 import io.github.vinceglb.filekit.core.platform.mac.MacOSFilePicker
+import io.github.vinceglb.filekit.core.platform.swing.SwingFilePicker
 import io.github.vinceglb.filekit.core.platform.util.Platform
 import io.github.vinceglb.filekit.core.platform.util.PlatformUtil
 import io.github.vinceglb.filekit.core.platform.windows.WindowsFilePicker
@@ -53,12 +55,7 @@ internal interface PlatformFilePicker {
             return when (PlatformUtil.current) {
                 Platform.MacOS -> MacOSFilePicker()
                 Platform.Windows -> WindowsFilePicker()
-                Platform.Linux -> {
-                    val xdgPortalFilePicker = XdgFilePickerPortal()
-                    if (xdgPortalFilePicker.isAvailable()) xdgPortalFilePicker
-                    else AwtFilePicker()
-
-                }
+                Platform.Linux -> LinuxFilePicker(XdgFilePickerPortal(), AwtFilePicker(), SwingFilePicker())
             }
         }
     }

--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/linux/LinuxFilePicker.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/linux/LinuxFilePicker.kt
@@ -1,0 +1,54 @@
+package io.github.vinceglb.filekit.core.platform.linux
+
+import io.github.vinceglb.filekit.core.platform.PlatformFilePicker
+import io.github.vinceglb.filekit.core.platform.awt.AwtFilePicker
+import io.github.vinceglb.filekit.core.platform.swing.SwingFilePicker
+import io.github.vinceglb.filekit.core.platform.xdg.XdgFilePickerPortal
+import java.awt.Window
+import java.io.File
+
+/**
+ * Delegate file picker for Linux platform choosing between [XdgFilePickerPortal], [AwtFilePicker] and [SwingFilePicker]
+ * depending on what is available
+ * [XdgFilePickerPortal] is checked first, if unavailable then [AwtFilePicker] is used for [pickFile] and [pickFiles] and
+ * [SwingFilePicker] is used for [pickDirectory] because [AwtFilePicker] doesn't support picking directories
+ */
+internal class LinuxFilePicker(
+    private val xdgFilePickerPortal: XdgFilePickerPortal,
+    private val awtFilePicker: AwtFilePicker,
+    private val swingFilePicker: SwingFilePicker,
+) : PlatformFilePicker {
+
+    private val xdgFilePickerPortalAvailable by lazy { xdgFilePickerPortal.isAvailable() }
+
+    override suspend fun pickFile(
+        initialDirectory: String?,
+        fileExtensions: List<String>?,
+        title: String?,
+        parentWindow: Window?
+    ): File? = if (xdgFilePickerPortalAvailable) xdgFilePickerPortal.pickFile(
+        initialDirectory,
+        fileExtensions,
+        title,
+        parentWindow
+    ) else awtFilePicker.pickFile(initialDirectory, fileExtensions, title, parentWindow)
+
+    override suspend fun pickFiles(
+        initialDirectory: String?,
+        fileExtensions: List<String>?,
+        title: String?,
+        parentWindow: Window?
+    ): List<File>? = if (xdgFilePickerPortalAvailable) xdgFilePickerPortal.pickFiles(
+        initialDirectory,
+        fileExtensions,
+        title,
+        parentWindow
+    ) else awtFilePicker.pickFiles(initialDirectory, fileExtensions, title, parentWindow)
+
+    override suspend fun pickDirectory(initialDirectory: String?, title: String?, parentWindow: Window?): File? =
+        if (xdgFilePickerPortalAvailable) xdgFilePickerPortal.pickDirectory(
+            initialDirectory,
+            title,
+            parentWindow
+        ) else swingFilePicker.pickDirectory(initialDirectory, title, parentWindow)
+}

--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/swing/SwingFilePicker.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/swing/SwingFilePicker.kt
@@ -1,0 +1,88 @@
+package io.github.vinceglb.filekit.core.platform.swing
+
+import io.github.vinceglb.filekit.core.platform.PlatformFilePicker
+import kotlinx.coroutines.suspendCancellableCoroutine
+import java.awt.Window
+import java.io.File
+import javax.swing.JFileChooser
+import javax.swing.UIManager
+import javax.swing.filechooser.FileNameExtensionFilter
+import kotlin.coroutines.resume
+
+internal class SwingFilePicker : PlatformFilePicker {
+
+    init {
+        try {
+            UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
+        } catch (ex: Throwable) {
+            println("Failed to set native UI for JFileChooser")
+        }
+    }
+
+    override suspend fun pickFile(
+        initialDirectory: String?,
+        fileExtensions: List<String>?,
+        title: String?,
+        parentWindow: Window?
+    ): File? = callSwingFilePicker(
+        title = title,
+        mode = JFileChooser.FILES_ONLY,
+        isMultiSelectionEnabled = false,
+        initialDirectory = initialDirectory,
+        fileExtensions = fileExtensions,
+        parentWindow = parentWindow,
+    )?.firstOrNull()
+
+    override suspend fun pickFiles(
+        initialDirectory: String?,
+        fileExtensions: List<String>?,
+        title: String?,
+        parentWindow: Window?
+    ): List<File>? = callSwingFilePicker(
+        title = title,
+        mode = JFileChooser.FILES_ONLY,
+        isMultiSelectionEnabled = true,
+        initialDirectory = initialDirectory,
+        fileExtensions = fileExtensions,
+        parentWindow = parentWindow,
+    )
+
+    override suspend fun pickDirectory(initialDirectory: String?, title: String?, parentWindow: Window?): File? =
+        callSwingFilePicker(
+            title = title,
+            mode = JFileChooser.DIRECTORIES_ONLY,
+            isMultiSelectionEnabled = false,
+            initialDirectory = initialDirectory,
+            fileExtensions = null,
+            parentWindow = parentWindow,
+        )?.firstOrNull()
+
+    private suspend fun callSwingFilePicker(
+        title: String?,
+        mode: Int,
+        isMultiSelectionEnabled: Boolean,
+        initialDirectory: String?,
+        fileExtensions: List<String>?,
+        parentWindow: Window?,
+    ): List<File>? = suspendCancellableCoroutine { continuation ->
+        val jFileChooser = JFileChooser(initialDirectory)
+        jFileChooser.fileSelectionMode = mode
+        jFileChooser.isMultiSelectionEnabled = isMultiSelectionEnabled
+
+        if(fileExtensions != null) {
+            val filter = FileNameExtensionFilter(null, *fileExtensions.toTypedArray())
+            jFileChooser.addChoosableFileFilter(filter)
+        }
+
+        if (title != null) {
+            jFileChooser.dialogTitle = title
+        }
+
+        val returnValue = jFileChooser.showOpenDialog(parentWindow)
+        if (returnValue == JFileChooser.APPROVE_OPTION) {
+            continuation.resume(jFileChooser.selectedFiles.toList())
+        }
+
+        continuation.invokeOnCancellation { jFileChooser.cancelSelection() }
+    }
+}


### PR DESCRIPTION
Introduced Swing (JFileChooser) PlatformFilePicker implementation and use it on Linux platform as a fallback when XdgFilePickerPortal is not available for picking directories

JFileChooser looks really ugly, but on some linux distros even xdg-desktop-portal isn't available so we can use Swing JFileChooser as a fallback 