### PR TITLE
fix: remove unnecessary JVM dependency

### DIFF
--- a/filekit-compose/build.gradle.kts
+++ b/filekit-compose/build.gradle.kts
@@ -49,16 +49,13 @@ kotlin {
         commonMain.dependencies {
             // Compose
             implementation(compose.runtime)
+            implementation(compose.ui)
 
             // Coroutines
             implementation(libs.kotlinx.coroutines.core)
 
             // FileKit Core
             api(projects.filekitCore)
-        }
-
-        jvmMain.dependencies {
-            implementation(compose.desktop.currentOs)
         }
 
         androidMain.dependencies {


### PR DESCRIPTION
The `compose.desktop.currentOs` dependency should only be used in applications. This dependency also has an issue where it transitively brings in Material 2 compose dependency. That can lead to applications depending on FileKit to have both Material 3 and Material 2 in the classpath