### PR TITLE
Override `saveFile()` in LinuxFilePicker

### DIFF
--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/linux/LinuxFilePicker.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/core/platform/linux/LinuxFilePicker.kt
@@ -51,4 +51,14 @@ internal class LinuxFilePicker(
             title,
             parentWindow
         ) else swingFilePicker.pickDirectory(initialDirectory, title, parentWindow)
+
+    override suspend fun saveFile(
+        bytes: ByteArray?,
+        baseName: String,
+        extension: String,
+        initialDirectory: String?,
+        parentWindow: Window?
+    ): File? = if (xdgFilePickerPortalAvailable) xdgFilePickerPortal.saveFile(
+        bytes, baseName, extension, initialDirectory, parentWindow
+    ) else awtFilePicker.saveFile(bytes, baseName, extension, initialDirectory, parentWindow)
 }


### PR DESCRIPTION
`saveFile()` isn't currently overridden in LinuxFilePicker, which causes it to open the default AWT dialog when saving files instead of trying to use the XDG picker. This overrides the method to follow the behavior of the other overrides.