### PR TITLE
remove extra bytes when overriding a file with a smaller file in android

### DIFF
--- a/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/core/FileKit.android.kt
+++ b/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/core/FileKit.android.kt
@@ -14,6 +14,7 @@ import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
 import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.VideoOnly
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.io.FileOutputStream
 import java.lang.ref.WeakReference
 import java.util.UUID
 import kotlin.coroutines.resume
@@ -168,6 +169,14 @@ public actual object FileKit {
                     // Write the bytes to the file
                     bytes?.let { bytes ->
                         context.contentResolver.openOutputStream(it)?.use { output ->
+                            if(output is FileOutputStream) {
+                                // If we are overriding a file we want to make sure that we remove
+                                // any extra bytes. Eg. if file was originally 250kb and new file
+                                // would only be 200kb we need to truncate the size, if not the file
+                                // will contain 50kb of garbage which uses space unnecessarily and
+                                // can cause other issues.
+                                output.channel.truncate(bytes.size.toLong())
+                            }
                             output.write(bytes)
                         }
                     }


### PR DESCRIPTION
fix for https://github.com/vinceglb/FileKit/issues/117.

When overiding a fille with a smaller file in Android the file size would remain the same. Eg. 250kb file overriden with 200kb file, the file would continue being 250kb. This fix makes sure that we truncate the file before we change the bytes.