### PR TITLE
fix: trigger onchange event Safari

### DIFF
--- a/filekit-core/src/jsMain/kotlin/io/github/vinceglb/filekit/core/FileKit.js.kt
+++ b/filekit-core/src/jsMain/kotlin/io/github/vinceglb/filekit/core/FileKit.js.kt
@@ -26,7 +26,7 @@ public actual object FileKit {
             // Create input element
             val input = document.createElement("input") as HTMLInputElement
             // Visually hide the element
-            input.style.setProperty("display", "none")
+            input.style.display = "none"
 
             document.body?.appendChild(input)
 

--- a/filekit-core/src/jsMain/kotlin/io/github/vinceglb/filekit/core/FileKit.js.kt
+++ b/filekit-core/src/jsMain/kotlin/io/github/vinceglb/filekit/core/FileKit.js.kt
@@ -14,21 +14,6 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
 
-public fun createVisuallyHiddenInput(): HTMLInputElement {
-    val input = document.createElement("input") as HTMLInputElement
-    input.style.setProperty("position", "absolute")
-    input.style.setProperty("width", "1px")
-    input.style.setProperty("height", "1px")
-    input.style.setProperty("border", "0")
-    input.style.setProperty("padding", "0")
-    input.style.setProperty("margin", "-1px")
-    input.style.setProperty("white-space", "nowrap")
-    input.style.setProperty("clip-path", "inset(100%)")
-    input.style.setProperty("clip", "rect(0, 0, 0, 0)")
-    input.style.setProperty("overflow", "hidden")
-    return input
-}
-
 public actual object FileKit {
     public actual suspend fun <Out> pickFile(
         type: PickerType,
@@ -38,8 +23,10 @@ public actual object FileKit {
         platformSettings: FileKitPlatformSettings?,
     ): Out? = withContext(Dispatchers.Default) {
         suspendCoroutine { continuation ->
-            // Create visually hidden input element
-            val input = createVisuallyHiddenInput()
+            // Create input element
+            val input = document.createElement("input") as HTMLInputElement
+            // Visually hide the element
+            input.style.setProperty("display", "none")
 
             document.body?.appendChild(input)
 

--- a/filekit-core/src/wasmJsMain/kotlin/io/github/vinceglb/filekit/core/FileKit.wasmJs.kt
+++ b/filekit-core/src/wasmJsMain/kotlin/io/github/vinceglb/filekit/core/FileKit.wasmJs.kt
@@ -25,6 +25,8 @@ public actual object FileKit {
         suspendCoroutine { continuation ->
             // Create input element
             val input = document.createElement("input") as HTMLInputElement
+            // Visually hide the element
+            input.style.setProperty("display", "none")
 
             // Configure the input element
             input.apply {
@@ -60,11 +62,14 @@ public actual object FileKit {
                     continuation.resume(mode.parseResult(result))
                 } catch (e: Throwable) {
                     continuation.resumeWithException(e)
+                } finally {
+                    document.body?.removeChild(input)
                 }
             }
 
             input.oncancel = {
                 continuation.resume(null)
+                document.body?.removeChild(input)
             }
 
             // Trigger the file picker

--- a/filekit-core/src/wasmJsMain/kotlin/io/github/vinceglb/filekit/core/FileKit.wasmJs.kt
+++ b/filekit-core/src/wasmJsMain/kotlin/io/github/vinceglb/filekit/core/FileKit.wasmJs.kt
@@ -26,7 +26,7 @@ public actual object FileKit {
             // Create input element
             val input = document.createElement("input") as HTMLInputElement
             // Visually hide the element
-            input.style.setProperty("display", "none")
+            input.style.display = "none"
 
             // Configure the input element
             input.apply {


### PR DESCRIPTION
Hi!
I encountered a small bug while using FileKit for the JS target in Safari. To open the file picker programmatically in Safari, it is not enough to simply trigger a click on the input element. Safari doesn't always trigger the onchange event in this case. The input element must also be added to the DOM for the event to work properly.

This bug can be reproduced by running the following command:
./gradlew samples:sample-core:composeApp:jsBrowserDevelopmentRun
After running the command, attempt to upload a file in the Safari browser, and the issue will be evident.
![bug](https://github.com/user-attachments/assets/2fcffd81-da13-40fb-955f-29e63144d10b)

Solution:
The solution is to add the file input element to the DOM and then remove it after the file(s) are processed or if the user cancels the upload. The input should be hidden visually as well, as display: none alone might not suffice.
After applying the fix, the issue is resolved, as shown below:

![solved](https://github.com/user-attachments/assets/c185f8e2-b031-4afb-861a-299d168dcc88)
