### PR TITLE
🐛 Fix Apple PlatformInputStream

### DIFF
--- a/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.apple.kt
+++ b/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/core/PlatformFile.apple.kt
@@ -16,11 +16,9 @@ import kotlinx.coroutines.withContext
 import platform.Foundation.NSData
 import platform.Foundation.NSDataReadingUncached
 import platform.Foundation.NSError
-import platform.Foundation.NSInputStream
 import platform.Foundation.NSURL
 import platform.Foundation.NSURLFileSizeKey
 import platform.Foundation.dataWithContentsOfURL
-import platform.Foundation.lastPathComponent
 import platform.posix.memcpy
 
 public actual data class PlatformFile(
@@ -54,7 +52,7 @@ public actual data class PlatformFile(
     }
 
     public actual fun getStream(): PlatformInputStream {
-        return PlatformInputStream(NSInputStream(nsUrl))
+        return PlatformInputStream(nsUrl)
     }
 
     @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)

--- a/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/core/PlatformInputStream.apple.kt
+++ b/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/core/PlatformInputStream.apple.kt
@@ -5,12 +5,14 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.allocArray
 import kotlinx.cinterop.get
 import kotlinx.cinterop.memScoped
+import platform.Foundation.NSURL
 import platform.Foundation.NSInputStream
 import platform.posix.uint8_tVar
 
-public actual class PlatformInputStream(private val nsInputStream: NSInputStream) : AutoCloseable {
-
+public actual class PlatformInputStream(private val nsUrl: NSURL) : AutoCloseable {
+    public val nsInputStream: NSInputStream = NSInputStream(nsUrl)
     init {
+        nsUrl.startAccessingSecurityScopedResource()
         nsInputStream.open()
     }
 
@@ -26,11 +28,12 @@ public actual class PlatformInputStream(private val nsInputStream: NSInputStream
             for (i in 0 until numRead) {
                 buffer[i] = pointerBuffer[i].toByte()
             }
-            numRead
+            numRead.takeIf { it > 0 } ?: -1
         }
     }
 
     actual override fun close() {
         nsInputStream.close()
+        nsUrl.stopAccessingSecurityScopedResource()
     }
 }


### PR DESCRIPTION
tldr; skill issue

Full commentary:
According to [Apple's documentation](https://developer.apple.com/documentation/foundation/nsinputstream/1411544-read), NSInputStream.read returns 0 when reaching end of buffer, in which case Java's implementation returns -1 instead.
In addition, NSURL.startAccessingSecurityScopedResource should be called in response to the OSX privacy sandbox