### PR TITLE
fix: fall back to single `file` value if multi `files` value is empty in AWT and Swing

### DIFF
--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtFilePicker.kt
@@ -67,14 +67,14 @@ internal class AwtFilePicker : PlatformFilePicker {
             is Dialog -> object : FileDialog(parentWindow, title, LOAD) {
                 override fun setVisible(value: Boolean) {
                     super.setVisible(value)
-                    handleResult(value, files)
+                    handleResult(value, files.takeIf { it.isNotEmpty() } ?: arrayOf(File(file)))
                 }
             }
 
             else -> object : FileDialog(parentWindow as? Frame, title, LOAD) {
                 override fun setVisible(value: Boolean) {
                     super.setVisible(value)
-                    handleResult(value, files)
+                    handleResult(value, files.takeIf { it.isNotEmpty() } ?: arrayOf(File(file)))
                 }
             }
         }

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/swing/SwingFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/swing/SwingFilePicker.kt
@@ -86,7 +86,7 @@ internal class SwingFilePicker : PlatformFilePicker {
 
         val returnValue = jFileChooser.showOpenDialog(dialogSettings.parentWindow)
         if (returnValue == JFileChooser.APPROVE_OPTION) {
-            continuation.resume(jFileChooser.selectedFiles.toList())
+            continuation.resume(jFileChooser.selectedFiles.toList().takeIf { it.isNotEmpty() } ?: listOf(jFileChooser.selectedFile))
         }
 
         continuation.invokeOnCancellation { jFileChooser.cancelSelection() }


### PR DESCRIPTION
At least for `JFileChooser`, it looks like if multi-selection is disabled, then `getSelectedFiles()` won't return anything, and the single result will be in `getSelectedFile()`.

The Java documentation really isn't very explicit on this: the comment for `getSelectedFiles()` says

> Returns a list of selected files if the file chooser is set to allow multiple selection.

and doesn't mention that constraint anywhere else. But at least in some JDKs, `getSelectedFiles()` returns an empty array if multi-select is disabled, which breaks picking directories on Linux if the XDG picker isn't available.

Since I'm not sure that it's a good idea to rely on `isMultipleMode` for whether to use `getSelectedFiles()` or `getSelectedFile()`, I made the code use `getSelectedFiles()` and fall back to `getSelectedFile()` if the former is empty. Also, while AWT doesn't support directory picking at this point, it seems to have a similar API structure, and the docs are even more vague, so I think it's a good idea to use the same fallback method there as well.