### PR TITLE
Facilitate accessing iOS and macOS file information

### DIFF
--- a/filekit-core/build.gradle.kts
+++ b/filekit-core/build.gradle.kts
@@ -73,6 +73,8 @@ kotlin {
         val webMain by creating { dependsOn(commonMain.get()) }
         val webTest by creating { dependsOn(commonTest.get()) }
 
+        val jvmAndNativeMain by creating { dependsOn(nonWebMain) }
+
         androidMain {
             dependsOn(nonWebMain)
             dependencies {
@@ -82,9 +84,9 @@ kotlin {
             }
         }
         androidUnitTest.get().dependsOn(nonWebTest)
-        jvmMain.get().dependsOn(nonWebMain)
+        jvmMain.get().dependsOn(jvmAndNativeMain)
         jvmTest.get().dependsOn(nonWebTest)
-        nativeMain.get().dependsOn(nonWebMain)
+        nativeMain.get().dependsOn(jvmAndNativeMain)
         nativeTest.get().dependsOn(nonWebTest)
 
         jsMain.get().dependsOn(webMain)

--- a/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
+++ b/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
@@ -138,6 +138,10 @@ public actual fun PlatformFile.sink(append: Boolean): RawSink = when (androidFil
         ?: throw FileKitException("Could not open output stream for Uri")
 }
 
+public actual fun PlatformFile.startAccessingSecurityScopedResource(): Boolean = true
+
+public actual fun PlatformFile.stopAccessingSecurityScopedResource() {}
+
 private fun getUriFileSize(uri: Uri): Long? {
     return FileKit.context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
         val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)

--- a/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/PlatformFile.apple.kt
+++ b/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/PlatformFile.apple.kt
@@ -1,10 +1,7 @@
 package io.github.vinceglb.filekit
 
 import io.github.vinceglb.filekit.utils.toKotlinxPath
-import kotlinx.io.RawSink
-import kotlinx.io.RawSource
 import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
 import platform.Foundation.NSURL
 
 public actual data class PlatformFile(
@@ -14,13 +11,10 @@ public actual data class PlatformFile(
 }
 
 public actual fun PlatformFile(path: Path): PlatformFile =
-    PlatformFile(NSURL(string = path.toString()))
+    PlatformFile(NSURL.fileURLWithPath(path = path.toString()))
 
 public actual fun PlatformFile.toKotlinxIoPath(): Path =
     nsUrl.toKotlinxPath()
-
-public actual val PlatformFile.name: String
-    get() = toKotlinxIoPath().name
 
 public actual val PlatformFile.extension: String
     get() = nsUrl.pathExtension ?: ""
@@ -28,43 +22,11 @@ public actual val PlatformFile.extension: String
 public actual val PlatformFile.nameWithoutExtension: String
     get() = name.substringBeforeLast(".", name)
 
-public actual val PlatformFile.path: String
-    get() = toKotlinxIoPath().toString()
-
-public actual fun PlatformFile.isRegularFile(): Boolean =
-    SystemFileSystem.metadataOrNull(toKotlinxIoPath())?.isRegularFile ?: false
-
-public actual fun PlatformFile.isDirectory(): Boolean =
-    SystemFileSystem.metadataOrNull(toKotlinxIoPath())?.isDirectory ?: false
-
-public actual fun PlatformFile.isAbsolute(): Boolean =
-    toKotlinxIoPath().isAbsolute
-
-public actual fun PlatformFile.exists(): Boolean =
-    SystemFileSystem.exists(toKotlinxIoPath())
-
-public actual fun PlatformFile.size(): Long =
-    SystemFileSystem.metadataOrNull(toKotlinxIoPath())?.size ?: -1
-
-public actual fun PlatformFile.parent(): PlatformFile? =
-    toKotlinxIoPath().parent?.let(::PlatformFile)
-
-public actual fun PlatformFile.absoluteFile(): PlatformFile =
-    PlatformFile(SystemFileSystem.resolve(toKotlinxIoPath()))
-
 public actual fun PlatformFile.absolutePath(): String =
     nsUrl.absoluteString ?: ""
 
-public actual fun PlatformFile.source(): RawSource = try {
+public actual fun PlatformFile.startAccessingSecurityScopedResource(): Boolean =
     nsUrl.startAccessingSecurityScopedResource()
-    SystemFileSystem.source(toKotlinxIoPath())
-} finally {
-    nsUrl.stopAccessingSecurityScopedResource()
-}
 
-public actual fun PlatformFile.sink(append: Boolean): RawSink = try {
-    nsUrl.startAccessingSecurityScopedResource()
-    SystemFileSystem.sink(toKotlinxIoPath(), append)
-} finally {
+public actual fun PlatformFile.stopAccessingSecurityScopedResource(): Unit =
     nsUrl.stopAccessingSecurityScopedResource()
-}

--- a/filekit-core/src/jvmAndNativeMain/kotlin/io/github/vinceglb/filekit/PlatformFile.jvmAndNative.kt
+++ b/filekit-core/src/jvmAndNativeMain/kotlin/io/github/vinceglb/filekit/PlatformFile.jvmAndNative.kt
@@ -1,0 +1,44 @@
+package io.github.vinceglb.filekit
+
+import kotlinx.io.RawSink
+import kotlinx.io.RawSource
+import kotlinx.io.files.SystemFileSystem
+
+public actual val PlatformFile.name: String
+    get() = toKotlinxIoPath().name
+
+public actual val PlatformFile.path: String
+    get() = toKotlinxIoPath().toString()
+
+public actual fun PlatformFile.isRegularFile(): Boolean = withScopedAccess {
+    SystemFileSystem.metadataOrNull(toKotlinxIoPath())?.isRegularFile ?: false
+}
+
+public actual fun PlatformFile.isDirectory(): Boolean = withScopedAccess {
+    SystemFileSystem.metadataOrNull(toKotlinxIoPath())?.isDirectory ?: false
+}
+
+public actual fun PlatformFile.isAbsolute(): Boolean =
+    toKotlinxIoPath().isAbsolute
+
+public actual fun PlatformFile.exists(): Boolean =
+    SystemFileSystem.exists(toKotlinxIoPath())
+
+public actual fun PlatformFile.size(): Long = withScopedAccess {
+    SystemFileSystem.metadataOrNull(toKotlinxIoPath())?.size ?: -1
+}
+
+public actual fun PlatformFile.parent(): PlatformFile? =
+    toKotlinxIoPath().parent?.let(::PlatformFile)
+
+public actual fun PlatformFile.absoluteFile(): PlatformFile = withScopedAccess {
+    PlatformFile(SystemFileSystem.resolve(toKotlinxIoPath()))
+}
+
+public actual fun PlatformFile.source(): RawSource = withScopedAccess {
+    SystemFileSystem.source(toKotlinxIoPath())
+}
+
+public actual fun PlatformFile.sink(append: Boolean): RawSink = withScopedAccess {
+    SystemFileSystem.sink(toKotlinxIoPath(), append)
+}

--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/PlatformFile.jvm.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/PlatformFile.jvm.kt
@@ -2,10 +2,7 @@ package io.github.vinceglb.filekit
 
 import io.github.vinceglb.filekit.utils.toFile
 import io.github.vinceglb.filekit.utils.toKotlinxIoPath
-import kotlinx.io.RawSink
-import kotlinx.io.RawSource
 import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
 import java.io.File
 
 public actual data class PlatformFile(
@@ -20,44 +17,15 @@ public actual fun PlatformFile(path: Path): PlatformFile =
 public actual fun PlatformFile.toKotlinxIoPath(): Path =
     file.toKotlinxIoPath()
 
-public actual val PlatformFile.name: String
-    get() = toKotlinxIoPath().name
-
 public actual val PlatformFile.extension: String
     get() = file.extension
 
 public actual val PlatformFile.nameWithoutExtension: String
     get() = file.nameWithoutExtension
 
-public actual val PlatformFile.path: String
-    get() = toKotlinxIoPath().toString()
-
-public actual fun PlatformFile.isRegularFile(): Boolean =
-    SystemFileSystem.metadataOrNull(toKotlinxIoPath())?.isRegularFile ?: false
-
-public actual fun PlatformFile.isDirectory(): Boolean =
-    SystemFileSystem.metadataOrNull(toKotlinxIoPath())?.isDirectory ?: false
-
-public actual fun PlatformFile.isAbsolute(): Boolean =
-    toKotlinxIoPath().isAbsolute
-
-public actual fun PlatformFile.exists(): Boolean =
-    SystemFileSystem.exists(toKotlinxIoPath())
-
-public actual fun PlatformFile.size(): Long =
-    SystemFileSystem.metadataOrNull(toKotlinxIoPath())?.size ?: -1
-
-public actual fun PlatformFile.parent(): PlatformFile? =
-    toKotlinxIoPath().parent?.let(::PlatformFile)
-
 public actual fun PlatformFile.absolutePath(): String =
     file.absolutePath
 
-public actual fun PlatformFile.absoluteFile(): PlatformFile =
-    PlatformFile(SystemFileSystem.resolve(toKotlinxIoPath()))
+public actual fun PlatformFile.startAccessingSecurityScopedResource(): Boolean = true
 
-public actual fun PlatformFile.source(): RawSource =
-    SystemFileSystem.source(toKotlinxIoPath())
-
-public actual fun PlatformFile.sink(append: Boolean): RawSink =
-    SystemFileSystem.sink(toKotlinxIoPath(), append)
+public actual fun PlatformFile.stopAccessingSecurityScopedResource() {}


### PR DESCRIPTION
Introduce new methods for iOS, macOS, JVM, Android:
- `PlatformFile.startAccessingSecurityScopedResource()`
- `PlatformFile.stopAccessingSecurityScopedResource()`
- `PlatformFile.withScopedAccess { }`

And improve file access control on iOS and macOS.