### PR TITLE
fix: handle nullable file picker results

### DIFF
--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtFilePicker.kt
@@ -67,14 +67,14 @@ internal class AwtFilePicker : PlatformFilePicker {
             is Dialog -> object : FileDialog(parentWindow, title, LOAD) {
                 override fun setVisible(value: Boolean) {
                     super.setVisible(value)
-                    handleResult(value, files.takeIf { it.isNotEmpty() } ?: arrayOf(File(file)))
+                    handleResult(value, files.takeIf { it.isNotEmpty() } ?: file?.let { arrayOf(File(it)) })
                 }
             }
 
             else -> object : FileDialog(parentWindow as? Frame, title, LOAD) {
                 override fun setVisible(value: Boolean) {
                     super.setVisible(value)
-                    handleResult(value, files.takeIf { it.isNotEmpty() } ?: arrayOf(File(file)))
+                    handleResult(value, files.takeIf { it.isNotEmpty() } ?: file?.let { arrayOf(File(it)) })
                 }
             }
         }

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/swing/SwingFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/swing/SwingFilePicker.kt
@@ -86,7 +86,7 @@ internal class SwingFilePicker : PlatformFilePicker {
 
         val returnValue = jFileChooser.showOpenDialog(dialogSettings.parentWindow)
         if (returnValue == JFileChooser.APPROVE_OPTION) {
-            continuation.resume(jFileChooser.selectedFiles.toList().takeIf { it.isNotEmpty() } ?: listOf(jFileChooser.selectedFile))
+            continuation.resume(jFileChooser.selectedFiles.toList().takeIf { it.isNotEmpty() } ?: jFileChooser.selectedFile?.let { listOf(it) })
         }
 
         continuation.invokeOnCancellation { jFileChooser.cancelSelection() }


### PR DESCRIPTION
I got a crash report in my app when using 0.10 beta 2 which reminded me that the singular `file`/`selectedFile` result of the Java pickers is nullable and needs to be handled properly, which I overlooked in my previous PR.