### PR TITLE
🐛 Fix openFileSaver on iOS when suggestedName contains "/"

### DIFF
--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -126,9 +126,12 @@ public actual suspend fun FileKit.openFileSaver(
             }
         )
 
+        // suggestedName cannot include "/" because the OS interprets it as a directory separator.
+        // However, "Files" renders ":" as "/", so we can just use ":" and the user will see "/".
+        val sanitizedFileName = suggestedName.replace("/", ":")
         val fileName = when {
-            extension != null -> "$suggestedName.$extension"
-            else -> suggestedName
+            extension != null -> "$sanitizedFileName.$extension"
+            else -> sanitizedFileName
         }
 
         // Get the fileManager

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -128,10 +128,10 @@ public actual suspend fun FileKit.openFileSaver(
 
         // suggestedName cannot include "/" because the OS interprets it as a directory separator.
         // However, "Files" renders ":" as "/", so we can just use ":" and the user will see "/".
-        val sanitizedFileName = suggestedName.replace("/", ":")
+        val sanitizedSuggestedName = suggestedName.replace("/", ":")
         val fileName = when {
-            extension != null -> "$sanitizedFileName.$extension"
-            else -> sanitizedFileName
+            extension != null -> "$sanitizedSuggestedName.$extension"
+            else -> sanitizedSuggestedName
         }
 
         // Get the fileManager


### PR DESCRIPTION
The `FileKit.openFileSaver` function throws a `kotlin.IllegalStateException: Failed to write to file URL` when the `suggestedName` contains a `/`.

The implemented fix replaces `/` with a valid character. I found [this discussion](https://discussions.apple.com/thread/677339) where they say `:` is rendered as `/` in the UI. I tested it on my iPhone and it seems to be true. I don't see any potential problem with `:`, but if you have another preference, we can choose a different character.

I also tested the macOS sample app, and the crash doesn't occur there, so this fix regards only iOS.