### PR TITLE
Add macOs appearence config

### DIFF
--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitDialogSettings.jvm.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitDialogSettings.jvm.kt
@@ -14,4 +14,11 @@ public actual data class FileKitDialogSettings(
 public class FileKitMacOSSettings(
     public val resolvesAliases: Boolean? = null,
     public val canCreateDirectories: Boolean = true,
+    public val appearance: MacOsAppearance = MacOsAppearance.Auto,
 )
+
+public enum class MacOsAppearance {
+    Aqua,
+    DarkAqua,
+    Auto
+}

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/mac/MacOSFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/mac/MacOSFilePicker.kt
@@ -3,6 +3,7 @@ package io.github.vinceglb.filekit.dialogs.platform.mac
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitMacOSSettings
+import io.github.vinceglb.filekit.dialogs.MacOsAppearance
 import io.github.vinceglb.filekit.dialogs.platform.PlatformFilePicker
 import io.github.vinceglb.filekit.dialogs.platform.mac.foundation.Foundation
 import io.github.vinceglb.filekit.dialogs.platform.mac.foundation.ID
@@ -75,6 +76,16 @@ internal class MacOSFilePicker : PlatformFilePicker {
                 // Setup single, multiple selection or directory mode
                 mode.setupPickerMode(openPanel, macOSSettings.canCreateDirectories)
 
+                // Set the appearance
+                if (macOSSettings.appearance != MacOsAppearance.Auto) {
+                    val themeName = if (macOSSettings.appearance == MacOsAppearance.DarkAqua)
+                        "NSAppearanceNameDarkAqua"
+                    else "NSAppearanceNameAqua"
+                    val appearance = Foundation.invoke(
+                        "NSAppearance", "appearanceNamed:", Foundation.nsString(themeName)
+                    )
+                    Foundation.invoke(openPanel, "setAppearance:", appearance)
+                }
                 // Set the title
                 title?.let {
                     Foundation.invoke(openPanel, "setMessage:", Foundation.nsString(it))


### PR DESCRIPTION
On MacOs, `FileKit.openFilePicker(..)` always opens the picker in light mode, ignoring the os setting.

I added an enum to the already existing `FileKitMacOsSettings`, which allows specifying the mode, which is applied in the `jvmMain/../MacOSFilePicker`.

I'm on macOS 15.4.1, unfortunately I do not have a chance to test the other macOS versions, which is why i opted for the `enum` (with `Auto` not changing anything compared to what it is now), instead of a `Boolean`.