### PR TITLE
Add entry for all supported files on XDG

### DIFF
--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/xdg/XdgFilePickerPortal.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/xdg/XdgFilePickerPortal.kt
@@ -200,10 +200,14 @@ internal class XdgFilePickerPortal : PlatformFilePicker {
         FileChooserDbusInterface::class.java
     )
 
-    private fun createFilterOption(extensions: Set<String>) = Variant(
-        extensions.map { extension -> Pair(extension, listOf(Pair(0, "*.$extension"))) },
-        "a(sa(us))"
-    )
+    private fun createFilterOption(extensions: Set<String>): Variant<*> {
+        val allExtensions = Pair("Supported files", extensions.map { extension -> Pair(0, "*.$extension") })
+        val individualExtensions = extensions.map { extension -> Pair(extension, listOf(Pair(0, "*.$extension"))) }
+        return Variant(
+            listOf(allExtensions) + individualExtensions,
+            "a(sa(us))"
+        )
+    }
 
     private fun createCurrentFolderOption(currentFolder: PlatformFile): Variant<*> {
         val stringBytes = currentFolder.path.encodeToByteArray()


### PR DESCRIPTION
Fixes #239 

From the [docs](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.FileChooser.html#org-freedesktop-portal-filechooser-openfile):

> `filters` `(a(sa(us)))`
> 
> List of serialized file filters.
> 
> Each item in the array specifies a single filter to offer to the user.
> 
> The first string is a user-visible name for the filter. The `a(us)` specifies a list of filter strings, which can be either a glob-style pattern (indicated by 0) or a MIME type (indicated by 1). Patterns are case-sensitive.
> 
> To match different capitalizations of, e.g. `'*.ico'`, use a pattern like: `'*.[iI][cC][oO]'`.
> 
> Example: `[('Images', [(0, '*.ico'), (1, 'image/png')]), ('Text', [(0, '*.txt')])]`
> 
> Note that filters are purely there to aid the user in making a useful selection. The portal may still allow the user to select files that don’t match any filter criteria, and applications must be prepared to handle that.