### PR TITLE
🐛 Fix shareFile to use file URL

### DIFF
--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -25,7 +25,6 @@ import platform.Foundation.NSData
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
 import platform.Foundation.NSUUID
-import platform.Foundation.dataWithContentsOfURL
 import platform.Foundation.temporaryDirectory
 import platform.Foundation.writeToURL
 import platform.Photos.PHPhotoLibrary.Companion.sharedPhotoLibrary
@@ -224,7 +223,7 @@ public actual suspend fun FileKit.shareFile(
 
     // Ensure we always pass a file URL to the activity items; otherwise iOS may treat the
     // provided value as plain text and share the path string instead of the actual file.
-    val shareItem = platform.Foundation.NSURL.fileURLWithPath(file.path)
+    val shareItem = NSURL.fileURLWithPath(file.path)
 
     val shareVC = UIActivityViewController(
         activityItems = listOf(shareItem),

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -222,8 +222,12 @@ public actual suspend fun FileKit.shareFile(
     val viewController = UIApplication.sharedApplication.firstKeyWindow?.rootViewController
         ?: return
 
+    // Ensure we always pass a file URL to the activity items; otherwise iOS may treat the
+    // provided value as plain text and share the path string instead of the actual file.
+    val shareItem = platform.Foundation.NSURL.fileURLWithPath(file.path)
+
     val shareVC = UIActivityViewController(
-        activityItems = listOf(file.nsUrl),
+        activityItems = listOf(shareItem),
         applicationActivities = null
     )
 


### PR DESCRIPTION
Fix `shareFile` on iOS to correctly share newly created files by ensuring a proper file URL is always provided to `UIActivityViewController`.

#306 
