### PR TITLE
🐛 Fix Android file truncation when writing shorter content

### DIFF
--- a/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
+++ b/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
@@ -163,10 +163,13 @@ public actual fun PlatformFile.source(): RawSource = when (androidFile) {
 public actual fun PlatformFile.sink(append: Boolean): RawSink = when (androidFile) {
     is AndroidFile.FileWrapper -> SystemFileSystem.sink(toKotlinxIoPath(), append)
 
-    is AndroidFile.UriWrapper -> FileKit.context.contentResolver
-        .openOutputStream(androidFile.uri)
-        ?.asSink()
-        ?: throw FileKitException("Could not open output stream for Uri")
+    is AndroidFile.UriWrapper -> {
+        val mode = if (append) "wa" else "wt"
+        FileKit.context.contentResolver
+            .openOutputStream(androidFile.uri, mode)
+            ?.asSink()
+            ?: throw FileKitException("Could not open output stream for Uri")
+    }
 }
 
 public actual fun PlatformFile.startAccessingSecurityScopedResource(): Boolean = true

--- a/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
+++ b/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
@@ -164,6 +164,8 @@ public actual fun PlatformFile.sink(append: Boolean): RawSink = when (androidFil
     is AndroidFile.FileWrapper -> SystemFileSystem.sink(toKotlinxIoPath(), append)
 
     is AndroidFile.UriWrapper -> {
+        // Use "wt" (write+truncate) for overwrite, "wa" (write+append) for append
+        // This ensures existing file content is properly truncated when overwriting
         val mode = if (append) "wa" else "wt"
         FileKit.context.contentResolver
             .openOutputStream(androidFile.uri, mode)

--- a/filekit-core/src/nonWebTest/kotlin/io/github/vinceglb/filekit/PlatformFileNonWebTest.kt
+++ b/filekit-core/src/nonWebTest/kotlin/io/github/vinceglb/filekit/PlatformFileNonWebTest.kt
@@ -129,6 +129,36 @@ class PlatformFileNonWebTest {
     }
 
     @Test
+    fun testPlatformFileWriteTruncation() = runTest {
+        val newFile = resourceDirectory / "truncation-test.txt"
+        val longContent = "This is a very long content that should be truncated when shorter content is written."
+        val shortContent = "Short!"
+
+        try {
+            // Write long content first
+            newFile.writeString(longContent)
+            assertEquals(expected = longContent, actual = newFile.readString())
+            assertEquals(expected = longContent.length.toLong(), actual = newFile.size())
+
+            // Write shorter content - should truncate, not append
+            newFile.writeString(shortContent)
+            val actualContent = newFile.readString()
+            assertEquals(expected = shortContent, actual = actualContent)
+            assertEquals(expected = shortContent.length.toLong(), actual = newFile.size())
+
+            // Verify no leftover bytes from previous content
+            assertTrue("File should contain exactly the short content, no leftover bytes") {
+                actualContent == shortContent
+            }
+        } finally {
+            // Clean up
+            if (newFile.exists()) {
+                newFile.delete()
+            }
+        }
+    }
+
+    @Test
     fun testPlatformFileEquality() {
         val textFile2 = resourceDirectory / "hello.txt"
         val textFile3 = resourceDirectory / "hello.txt"


### PR DESCRIPTION
On Android, when writing to an existing file via URI, if the new data was shorter than existing content, leftover bytes from previous data remained. This occurred because openOutputStream(uri) defaults to append mode without truncation.

- Fix sink() method for AndroidFile.UriWrapper to use proper mode parameter
- Use "wt" (write+truncate) for non-append writes, "wa" for append writes
- Add test case to verify proper file truncation behavior

Related to #332 