### PR TITLE
🐛 Fix Android PlatformFile.bookmarkData for files

### DIFF
--- a/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
+++ b/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
@@ -261,12 +261,20 @@ public actual suspend fun PlatformFile.bookmarkData(): BookmarkData = withContex
         is AndroidFile.UriWrapper -> {
             val uri = androidFile.uri
             val authority = uri.authority ?: throw FileKitException("Uri authority is null")
-            val documentId = DocumentsContract.getTreeDocumentId(uri)
-            val treeUri = DocumentsContract.buildTreeDocumentUri(authority, documentId)
-
-            val flags =
-                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-            FileKit.context.contentResolver.takePersistableUriPermission(treeUri, flags)
+            
+            val flags = Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            
+            // Check if this is a tree URI (directory) or document URI (file)
+            val uriToPermission = if (isDirectory()) {
+                // For directories, we need to get the tree URI
+                val documentId = DocumentsContract.getTreeDocumentId(uri)
+                DocumentsContract.buildTreeDocumentUri(authority, documentId)
+            } else {
+                // For files, use the URI directly
+                uri
+            }
+            
+            FileKit.context.contentResolver.takePersistableUriPermission(uriToPermission, flags)
             val data = "$BOOKMARK_URI_PREFIX${androidFile.uri}"
             BookmarkData(data.encodeToByteArray())
         }


### PR DESCRIPTION
## Summary
- Fixed crash in Android `PlatformFile.bookmarkData()` when bookmarking regular files
- The method was incorrectly using `DocumentsContract.getTreeDocumentId()` for all URIs, but this only works for directories
- Now properly detects file vs directory URIs and handles each case appropriately

## Changes
- Added directory check using `isDirectory()` in `bookmarkData()` method
- For directories: Use existing tree URI logic with `getTreeDocumentId()` and `buildTreeDocumentUri()` 
- For files: Use the URI directly without tree URI conversion
- Apply appropriate persistent URI permissions based on URI type

Related #346