### PR TITLE
📝 Update FileProvider documentation with authority parameter usage

### DIFF
--- a/docs/dialogs/camera-picker.mdx
+++ b/docs/dialogs/camera-picker.mdx
@@ -4,6 +4,8 @@ sidebarTitle: 'Camera picker'
 description: 'Open a camera picker dialog in a Kotlin Multiplatform project'
 ---
 
+import AndroidFileProviderSetup from '/snippets/android-fileprovider-setup.mdx'
+
 <Check>Supported on Android and iOS targets</Check>
 
 ## Quick start
@@ -25,6 +27,8 @@ Button(onClick = { launcher.launch() }) {
 }
 ```
 </CodeGroup>
+
+The captured media file is automatically saved to the specified location (or cache directory by default). If you need to keep the file permanently, make sure to copy it to a permanent storage location.
 
 ## Camera type
 
@@ -114,7 +118,38 @@ Button(onClick = { launcher.launch(destinationFile = customFile) }) {
 ```
 </CodeGroup>
 
-<Info>
-The captured media file is automatically saved to a temporary location. If you need to keep the file permanently, make sure to copy it to a permanent storage location.
-</Info>
+<Warning>
+On Android, when using a custom `destinationFile`, you must provide the `openCameraSettings` parameter with your app's FileProvider authority. This ensures the camera app has permission to write to your specified location.
+</Warning>
 
+## Destination file Android Setup
+
+<AndroidFileProviderSetup />
+
+3. When using a custom `destinationFile`, provide the `openCameraSettings` parameter with your app's FileProvider authority:
+
+<CodeGroup>
+```kotlin filekit-dialogs
+val customFile = FileKit.filesDir / "my_photo.jpg"
+val file = FileKit.openCameraPicker(
+    destinationFile = customFile,
+    openCameraSettings = FileKitOpenCameraSettings(
+        authority = "${context.packageName}.fileprovider"
+    )
+)
+```
+
+```kotlin filekit-dialogs-compose
+val customFile = FileKit.filesDir / "my_photo.jpg"
+Button(onClick = { 
+    launcher.launch(
+        destinationFile = customFile,
+        openCameraSettings = FileKitOpenCameraSettings(
+            authority = "${context.packageName}.fileprovider"
+        )
+    )
+}) {
+    Text("Take a photo to custom location")
+}
+```
+</CodeGroup>

--- a/docs/dialogs/share-file.mdx
+++ b/docs/dialogs/share-file.mdx
@@ -4,6 +4,8 @@ sidebarTitle: 'Share file'
 description: 'Open a file sharing dialog in a Kotlin Multiplatform project'
 ---
 
+import AndroidFileProviderSetup from '/snippets/android-fileprovider-setup.mdx'
+
 <Check>Supported on Android and iOS targets</Check>
 
 <div className="flex justify-center gap-6">
@@ -46,10 +48,6 @@ Ensure the file you are sharing exists and is accessible. Sharing a non-existent
 
 Using the share file dialog on Android requires additional FileProvider configuration to securely share files with other applications. Starting from Android 7.0 (API level 24), Android restricts the sharing of file URIs between apps for security reasons. FileProvider generates secure content URIs that allow temporary access to specific files.
 
-<Info>
-For detailed information about FileProvider, see the [official Android documentation](https://developer.android.com/reference/androidx/core/content/FileProvider).
-</Info>
-
 ### Why FileProvider is required
 
 Android uses FileProvider to:
@@ -57,44 +55,34 @@ Android uses FileProvider to:
 - **Control access**: Grants temporary, limited access to specific files only
 - **Maintain compatibility**: Required for sharing files on Android 7.0+ due to `FileUriExposedException`
 
-### Step 1: Declare FileProvider in AndroidManifest.xml
+<AndroidFileProviderSetup />
 
-Add the following FileProvider declaration inside the `<application>` tag in your Android manifest:
+3. When sharing files from custom locations, provide the `shareSettings` parameter with your app's FileProvider authority:
 
-```xml AndroidManifest.xml
-<provider
-    android:name="androidx.core.content.FileProvider"
-    android:authorities="${applicationId}.fileprovider"
-    android:exported="false"
-    android:grantUriPermissions="true">
-    <meta-data
-        android:name="android.support.FILE_PROVIDER_PATHS"
-        android:resource="@xml/file_paths" />
-</provider>
+<CodeGroup>
+```kotlin filekit-dialogs
+val file = FileKit.filesDir / "my_file.txt"
+FileKit.shareFile(
+    file = file,
+    shareSettings = FileKitShareSettings(
+        authority = "${context.packageName}.fileprovider"
+    )
+)
 ```
 
+```kotlin filekit-dialogs-compose
+val launcher = rememberShareFileLauncher()
 
-### Step 2: Create file_paths.xml
-
-Create or update `res/xml/file_paths.xml` to match the FileKit directory you use in your code:
-
-```xml res/xml/file_paths.xml
-<paths>
-    <!-- For FileKit.filesDir -->
-    <files-path name="filekit_files" path="." />
-    
-    <!-- For FileKit.cacheDir -->
-    <cache-path name="filekit_cache" path="." />
-</paths>
+val file = FileKit.filesDir / "my_file.txt"
+Button(onClick = { 
+    launcher.launch(
+        file = file,
+        shareSettings = FileKitShareSettings(
+            authority = "${context.packageName}.fileprovider"
+        )
+    )
+}) {
+    Text("Share file")
+}
 ```
-
-<Warning>
-**Important**: Include only the path type that matches your FileKit usage:
-- Use `<files-path>` if you use `FileKit.filesDir`
-- Use `<cache-path>` if you use `FileKit.cacheDir`
-- Include both if you use both directories
-</Warning>
-
-<Info>
-**Recommendation**: Use `FileKit.cacheDir` for temporary files that can be cleared by the system, and `FileKit.filesDir` for files that should persist until explicitly deleted.
-</Info>
+</CodeGroup>

--- a/docs/snippets/android-fileprovider-setup.mdx
+++ b/docs/snippets/android-fileprovider-setup.mdx
@@ -1,0 +1,35 @@
+When using custom file locations on Android, you need to configure a FileProvider in your app:
+
+<Info>
+For detailed information about FileProvider, see the [official Android documentation](https://developer.android.com/reference/androidx/core/content/FileProvider).
+</Info>
+
+1. Add the FileProvider to your `AndroidManifest.xml`:
+
+```xml
+<provider
+    android:name="androidx.core.content.FileProvider"
+    android:authorities="${applicationId}.fileprovider"
+    android:exported="false"
+    android:grantUriPermissions="true">
+    <meta-data
+        android:name="android.support.FILE_PROVIDER_PATHS"
+        android:resource="@xml/file_paths" />
+</provider>
+```
+
+2. Create `androidMain/res/xml/file_paths.xml`:
+
+```xml
+<paths>
+    <cache-path name="filekit_cache" path="." />
+    <files-path name="filekit_files" path="." />
+</paths>
+```
+
+<Info>
+**Important**: Include only the path type that matches your FileKit usage:
+- Use `<files-path>` if you use `FileKit.filesDir`
+- Use `<cache-path>` if you use `FileKit.cacheDir`
+- Include both if you use both directories
+</Info>


### PR DESCRIPTION
- Create reusable android-fileprovider-setup.mdx snippet
- Document FileKitOpenCameraSettings.authority usage for custom destinationFile
- Document FileKitShareSettings.authority usage for custom file locations
- Add 3-step Android setup guides for both camera-picker and share-file
- Improve documentation structure and reduce duplication