### PR TITLE
📝 Add ProGuard configuration to JVM setup documentation

### DIFF
--- a/docs/core/setup.mdx
+++ b/docs/core/setup.mdx
@@ -16,15 +16,6 @@ FileKit Core provides the fundamental file operations for your Kotlin Multiplatf
 
 FileKit Core is designed to work out of the box for most platforms, but some targets require additional setup.
 
-### JVM setup
-
-<SetupJVMCore/>
-
-The application ID is used to create user-specific directories on different operating systems:
-- Windows: `%APPDATA%\your.application.id\`
-- macOS: `~/Library/Application Support/your.application.id/`
-- Linux: `~/.local/share/your.application.id/`
-
 ### Android setup
 
 FileKit Core is **automatically initialized** in Android applications. It uses [App Startup](https://developer.android.com/topic/libraries/app-startup) to initialize the library, ensuring that it is ready to use when your app starts.
@@ -41,6 +32,10 @@ class MainActivity : ComponentActivity() {
     }
 }
 ```
+
+### JVM setup
+
+<SetupJVMCore/>
 
 ### iOS, macOS, JS, WASM setup
 

--- a/docs/snippets/setup-jvm-core.mdx
+++ b/docs/snippets/setup-jvm-core.mdx
@@ -3,13 +3,29 @@ FileKit needs to have your application id to handle the app directory. Your appl
 We recommend you to initialize FileKit in your `main.kt` file:
 
 ```kotlin main.kt
-fun main() = application {
+fun main() {
   // Initialize FileKit
   FileKit.init(appId = "MyApplication")
 
   // Start your application
-  Window(onCloseRequest = ::exitApplication) {
-    // ...
+  application {
+      Window(onCloseRequest = ::exitApplication) {
+          // ...
+      }
   }
 }
+```
+
+The application ID is used to create user-specific directories on different operating systems:
+- Windows: `%APPDATA%\your.application.id\`
+- macOS: `~/Library/Application Support/your.application.id/`
+- Linux: `~/.local/share/your.application.id/`
+
+#### ProGuard Configuration
+
+If you're using ProGuard or code obfuscation on JVM platforms, add these rules to your `proguard-rules.pro`:
+
+```proguard
+-keep class com.sun.jna.** { *; }
+-keep class * implements com.sun.jna.** { *; }
 ```


### PR DESCRIPTION
- Add ProGuard rules for JNA classes to setup-jvm-core.mdx snippet
- Move JVM setup section after Android setup for better organization
- Include platform-specific directory information in JVM snippet