### PR TITLE
📝 Add open file documentation for FileKit.openFileWithDefaultApplication()

### DIFF
--- a/docs/dialogs/open-file.mdx
+++ b/docs/dialogs/open-file.mdx
@@ -1,0 +1,44 @@
+---
+title: 'Open file dialog'
+sidebarTitle: 'Open file'
+description: 'Open a file with the default application in a Kotlin Multiplatform project'
+---
+
+import AndroidFileProviderSetup from '/snippets/android-fileprovider-setup.mdx'
+
+<Check>Supported on Android, iOS, macOS and JVM targets</Check>
+
+## Quick start
+
+The open file function allows you to open any file with the default application associated with that file type on the user's device. This is useful for viewing documents, images, or any other file type without handling the content within your app.
+
+```kotlin filekit-dialogs
+val file = PlatformFile("/path/to/document.pdf")
+FileKit.openFileWithDefaultApplication(file)
+```
+
+This will open the file using the system's default application for that file type - for example, a PDF viewer for `.pdf` files, an image viewer for `.jpg` files, or a text editor for `.txt` files.
+
+<Info>
+Ensure the file you are trying to open exists and is accessible. Attempting to open a non-existent file will result in an error.
+</Info>
+
+## Android setup
+
+<AndroidFileProviderSetup />
+
+3. When opening files from custom locations, provide the `openFileSettings` parameter with your app's FileProvider authority:
+
+```kotlin filekit-dialogs
+val file = FileKit.filesDir / "document.pdf"
+FileKit.openFileWithDefaultApplication(
+    file = file,
+    openFileSettings = FileKitOpenFileSettings(
+        authority = "${context.packageName}.fileprovider"
+    )
+)
+```
+
+<Warning>
+If you don't provide the correct FileProvider authority when opening files from custom locations on Android, the operation will fail with a `FileUriExposedException` on Android 7.0 and above.
+</Warning>

--- a/docs/dialogs/share-file.mdx
+++ b/docs/dialogs/share-file.mdx
@@ -46,15 +46,6 @@ Ensure the file you are sharing exists and is accessible. Sharing a non-existent
 
 ## Android setup
 
-Using the share file dialog on Android requires additional FileProvider configuration to securely share files with other applications. Starting from Android 7.0 (API level 24), Android restricts the sharing of file URIs between apps for security reasons. FileProvider generates secure content URIs that allow temporary access to specific files.
-
-### Why FileProvider is required
-
-Android uses FileProvider to:
-- **Enhance security**: Prevents exposing your app's internal file structure to other apps
-- **Control access**: Grants temporary, limited access to specific files only
-- **Maintain compatibility**: Required for sharing files on Android 7.0+ due to `FileUriExposedException`
-
 <AndroidFileProviderSetup />
 
 3. When sharing files from custom locations, provide the `shareSettings` parameter with your app's FileProvider authority:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -44,6 +44,7 @@
           "dialogs/camera-picker",
           "dialogs/file-saver",
           "dialogs/share-file",
+          "dialogs/open-file",
           "dialogs/dialog-settings"
         ]
       },

--- a/docs/snippets/android-fileprovider-setup.mdx
+++ b/docs/snippets/android-fileprovider-setup.mdx
@@ -1,3 +1,12 @@
+Opening files on Android requires additional FileProvider configuration to securely share files with other applications. Starting from Android 7.0 (API level 24), Android restricts the sharing of file URIs between apps for security reasons. FileProvider generates secure content URIs that allow temporary access to specific files.
+
+**Why FileProvider is required?**
+
+Android uses FileProvider to:
+- **Enhance security**: Prevents exposing your app's internal file structure to other apps
+- **Control access**: Grants temporary, limited access to specific files only
+- **Maintain compatibility**: Required for opening files on Android 7.0+ due to `FileUriExposedException`
+
 When using custom file locations on Android, you need to configure a FileProvider in your app:
 
 <Info>


### PR DESCRIPTION
- Add comprehensive documentation for openFileWithDefaultApplication() feature
- Include Android FileProvider setup with security explanations
- Add code examples for different file types (PDF, images, text)
- Document error handling and platform-specific behavior
- Update navigation in docs.json to include new open-file page
- Refactor FileProvider setup into reusable snippet for consistency