### PR TITLE
Refactor: Switch default file contentType IOS

### DIFF
--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -57,6 +57,7 @@ import platform.UniformTypeIdentifiers.UTType
 import platform.UniformTypeIdentifiers.UTTypeContent
 import platform.UniformTypeIdentifiers.UTTypeFolder
 import platform.UniformTypeIdentifiers.UTTypeImage
+import platform.UniformTypeIdentifiers.UTTypeItem
 import platform.UniformTypeIdentifiers.UTTypeMovie
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -470,11 +471,8 @@ private val FileKitType.contentTypes: List<UTType>
         is FileKitType.ImageAndVideo -> listOf(UTTypeImage, UTTypeMovie)
         is FileKitType.File -> extensions
             ?.mapNotNull { UTType.typeWithFilenameExtension(it) }
-            .ifNullOrEmpty { listOf(UTTypePublicItem) }
+            .ifNullOrEmpty { listOf(UTTypeItem) }
     }
-
-private val UTTypePublicItem: UTType
-    get() = UTType.typeWithIdentifier("public.item") ?: UTTypeContent
 
 private fun <R> List<R>?.ifNullOrEmpty(block: () -> List<R>): List<R> =
     if (this.isNullOrEmpty()) block() else this

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -470,8 +470,11 @@ private val FileKitType.contentTypes: List<UTType>
         is FileKitType.ImageAndVideo -> listOf(UTTypeImage, UTTypeMovie)
         is FileKitType.File -> extensions
             ?.mapNotNull { UTType.typeWithFilenameExtension(it) }
-            .ifNullOrEmpty { listOf(UTTypeContent) }
+            .ifNullOrEmpty { listOf(UTTypePublicItem) }
     }
+
+private val UTTypePublicItem: UTType
+    get() = UTType.typeWithIdentifier("public.item") ?: UTTypeContent
 
 private fun <R> List<R>?.ifNullOrEmpty(block: () -> List<R>): List<R> =
     if (this.isNullOrEmpty()) block() else this


### PR DESCRIPTION
This change mitigates issues where certain files were not available for pickup.

Switch default file contentType: UTTypeContent -> UTTypeItem.