### PR TITLE
Fix compressImage with ImageFormat.PNG produces black background instead of transparency on JVM

### DIFF
--- a/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/FileKit.jvm.kt
+++ b/filekit-core/src/jvmMain/kotlin/io/github/vinceglb/filekit/FileKit.jvm.kt
@@ -148,7 +148,12 @@ public actual suspend fun FileKit.compressImage(
     )
 
     // Step 3: Resize the BufferedImage
-    val resizedImage = BufferedImage(newWidth, newHeight, BufferedImage.TYPE_INT_RGB)
+    val imageType = when (imageFormat) {
+        ImageFormat.JPEG -> BufferedImage.TYPE_INT_RGB
+        ImageFormat.PNG if originalImage.colorModel.hasAlpha() -> BufferedImage.TYPE_INT_ARGB
+        ImageFormat.PNG -> BufferedImage.TYPE_INT_RGB
+    }
+    val resizedImage = BufferedImage(newWidth, newHeight, imageType)
     val graphics: Graphics2D = resizedImage.createGraphics()
     graphics.drawImage(
         originalImage.getScaledInstance(newWidth, newHeight, Image.SCALE_SMOOTH),


### PR DESCRIPTION
- ref: #349