### PR TITLE
Return Tree DocumentFile in getDocumentFile() if it's a directory (issue #418)

### DIFF
--- a/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
+++ b/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
@@ -492,6 +492,11 @@ private fun getUriFileName(uri: Uri): String {
 }
 
 private fun getDocumentFile(uri: Uri): DocumentFile? {
-    return DocumentFile.fromSingleUri(FileKit.context, uri)
-        ?: DocumentFile.fromTreeUri(FileKit.context, uri)
+    val tree = DocumentFile.fromTreeUri(FileKit.context, uri)
+
+    return if (tree?.isDirectory == true) {
+        tree
+    } else {
+        DocumentFile.fromSingleUri(FileKit.context, uri)
+    }
 }


### PR DESCRIPTION
Full background in #418

I found an issue located in `getDocumentFile()`:

```
private fun getDocumentFile(uri: Uri): DocumentFile? {
    return DocumentFile.fromSingleUri(FileKit.context, uri)
        ?: DocumentFile.fromTreeUri(FileKit.context, uri)
}
```

For folders, the `DocumentFile.fromSingleUri()` will succeed, however its `isDirectory() or exists()` are both false, even for a directory!
This, in turns, makes `PlatformFile.isExists()` return false and makes `PlatformFile.fromBookmarkData()` throw.

As a result, I believe getDocumentFile should check if it's a directory or File first:

```
private fun getDocumentFile(uri: Uri): DocumentFile? {
    val tree = DocumentFile.fromTreeUri(FileKit.context, uri)

    return if (tree?.isDirectory == true) {
        tree
    } else {
        DocumentFile.fromSingleUri(FileKit.context, uri)
    }
}
```