### PR TITLE
Fix Awt FileDialog runs on EDT inside suspending function

### DIFF
--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtFilePicker.kt
@@ -6,6 +6,7 @@ import io.github.vinceglb.filekit.dialogs.platform.PlatformFilePicker
 import io.github.vinceglb.filekit.path
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.awt.Dialog
+import java.awt.EventQueue
 import java.awt.FileDialog
 import java.awt.FileDialog.LOAD
 import java.awt.Frame
@@ -62,7 +63,7 @@ internal class AwtFilePicker : PlatformFilePicker {
             else -> FileDialog(parentWindow as? Frame, title, LOAD)
         }
 
-        java.awt.EventQueue.invokeLater {
+        EventQueue.invokeLater {
             // Set multiple mode
             dialog.isMultipleMode = isMultipleMode
 


### PR DESCRIPTION
Fixed an issue where Awt FileDialog on Linux was being opened outside the Event Dispatch Thread (EDT),
which could cause UI freezes or unexpected behavior in Swing/AWT applications.

I reproduced it on Debian 13 in Edconv software in AppImage version.

https://github.com/user-attachments/assets/bdd5c3a4-4607-4a82-b7c5-f0f8e8fe4c0c

#356 