### PR TITLE
🐛 Fix Compose preview crash with rememberShareFileLauncher

### DIFF
--- a/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitOpenCameraSettings.android.kt
+++ b/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitOpenCameraSettings.android.kt
@@ -1,16 +1,13 @@
 package io.github.vinceglb.filekit.dialogs
 
-import io.github.vinceglb.filekit.FileKit
-import io.github.vinceglb.filekit.context
-
 /**
  * Android implementation of [FileKitOpenCameraSettings].
  *
  * @property authority The content authority string used for creating a [android.net.Uri].
- * Defaults to "{applicationId}.FileKitFileProvider".
+ * Defaults to "{applicationId}.FileKitFileProvider" when null.
  */
 public actual class FileKitOpenCameraSettings(
-    public val authority: String = "${FileKit.context.packageName}.FileKitFileProvider",
+    public val authority: String? = null,
 ) {
     public actual companion object {
         /**

--- a/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitOpenFileSettings.android.kt
+++ b/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitOpenFileSettings.android.kt
@@ -1,16 +1,13 @@
 package io.github.vinceglb.filekit.dialogs
 
-import io.github.vinceglb.filekit.FileKit
-import io.github.vinceglb.filekit.context
-
 /**
  * Android implementation of [FileKitOpenFileSettings].
  *
  * @property authority The content authority string used for creating a [android.net.Uri].
- * Defaults to "{applicationId}.FileKitFileProvider".
+ * Defaults to "{applicationId}.FileKitFileProvider" when null.
  */
 public actual class FileKitOpenFileSettings(
-    public val authority: String = "${FileKit.context.packageName}.FileKitFileProvider",
+    public val authority: String? = null,
 ) {
     public actual companion object {
         /**

--- a/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitShareSettings.android.kt
+++ b/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitShareSettings.android.kt
@@ -1,18 +1,16 @@
 package io.github.vinceglb.filekit.dialogs
 
 import android.content.Intent
-import io.github.vinceglb.filekit.FileKit
-import io.github.vinceglb.filekit.context
 
 /**
  * Android implementation of [FileKitShareSettings].
  *
  * @property authority The content authority string used for creating a [android.net.Uri].
- * Defaults to "{applicationId}.FileKitFileProvider".
+ * Defaults to "{applicationId}.FileKitFileProvider" when null.
  * @property addOptionChooseIntent Callback to customize the choose intent.
  */
 public actual class FileKitShareSettings(
-    public val authority: String = "${FileKit.context.packageName}.FileKitFileProvider",
+    public val authority: String? = null,
     public val addOptionChooseIntent: (Intent) -> Unit = {},
 ) {
     public actual companion object {

--- a/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/PlatformFile.android.kt
+++ b/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/PlatformFile.android.kt
@@ -7,13 +7,20 @@ import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.context
 
-public fun PlatformFile.toAndroidUri(authority: String): Uri =
+/**
+ * Returns the default authority string for FileProvider operations.
+ * Uses the pattern "{applicationId}.FileKitFileProvider".
+ */
+internal fun getDefaultAuthority(): String =
+    "${FileKit.context.packageName}.FileKitFileProvider"
+
+public fun PlatformFile.toAndroidUri(authority: String? = null): Uri =
     when (val androidFile = androidFile) {
         is AndroidFile.UriWrapper -> androidFile.uri
 
         is AndroidFile.FileWrapper -> FileProvider.getUriForFile(
             FileKit.context,
-            authority,
+            authority ?: getDefaultAuthority(),
             androidFile.file,
         )
     }

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/debug/DebugScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/debug/DebugScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
@@ -23,6 +24,7 @@ import io.github.vinceglb.filekit.sample.shared.ui.components.AppScreenHeaderBut
 import io.github.vinceglb.filekit.sample.shared.ui.icons.LucideIcons
 import io.github.vinceglb.filekit.sample.shared.ui.icons.MessageCircleCode
 import io.github.vinceglb.filekit.sample.shared.ui.theme.AppMaxWidth
+import io.github.vinceglb.filekit.sample.shared.ui.theme.AppTheme
 import io.github.vinceglb.filekit.sample.shared.util.plus
 
 @Composable
@@ -44,9 +46,6 @@ private fun DebugScreen(
     var buttonState by remember { mutableStateOf(AppScreenHeaderButtonState.Enabled) }
     var files by remember { mutableStateOf(emptyList<PlatformFile>()) }
 
-    // ========================================
-    // CUSTOMIZE YOUR PICKER HERE
-    // ========================================
     val picker = rememberFilePickerLauncher { file ->
         buttonState = AppScreenHeaderButtonState.Enabled
         files = file?.let(::listOf) ?: emptyList()
@@ -82,10 +81,6 @@ private fun DebugScreen(
                 )
             }
 
-            // ========================================
-            // ADD YOUR CUSTOM DEBUG UI HERE
-            // ========================================
-
             item {
                 AppPickerResultsCard(
                     files = files,
@@ -96,5 +91,16 @@ private fun DebugScreen(
                 )
             }
         }
+    }
+}
+
+@Preview
+@Composable
+private fun DebugScreenPreview() {
+    AppTheme {
+        DebugScreen(
+            onNavigateBack = {},
+            onDisplayFileDetails = {},
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Defers `FileKit.context` access in Android settings classes until actually needed
- Makes `authority` parameter nullable with default `null` in `FileKitShareSettings`, `FileKitOpenCameraSettings`, and `FileKitOpenFileSettings`
- Adds `getDefaultAuthority()` helper to resolve the default authority when operations are executed

This prevents crashes in Android Studio Compose previews where the context is not initialized during composition.

Fixes #416

## Test plan
- [ ] Verify Compose previews work with `rememberShareFileLauncher()`
- [ ] Verify Compose previews work with `rememberCameraPickerLauncher()`
- [ ] Verify sharing files still works at runtime on Android
- [ ] Verify camera picker still works at runtime on Android
- [ ] Verify opening files with default application still works at runtime on Android

🤖 Generated with [Claude Code](https://claude.ai/code)