### PR TITLE
Improve copy/write robustness for unknown-size and provider-backed files

### DIFF
--- a/docs/core/platform-file.mdx
+++ b/docs/core/platform-file.mdx
@@ -83,6 +83,7 @@ val path: String = file.path // "/path/to/document.pdf"
 
 // Get the file size in bytes
 val size: Long = file.size()
+// Note: some provider-backed files may return -1 when size metadata is unavailable.
 
 // Get the parent directory
 val parent: PlatformFile? = file.parent()

--- a/docs/core/write-file.mdx
+++ b/docs/core/write-file.mdx
@@ -50,13 +50,17 @@ fun writeLargeFile() {
         // Write bytes
         val bytes = ByteArray(1024) { it.toByte() }
         bufferedSink.write(bytes)
-        
-        // Write from another source
-        val sourceFile = PlatformFile("/path/to/source.dat")
-        bufferedSink.write(sourceFile.source(), sourceFile.size())
     }
+
+    // Copy from another source file (safe for unknown-size provider-backed files)
+    val sourceFile = PlatformFile("/path/to/source.dat")
+    sourceFile.copyTo(file)
 }
 ```
+
+<Note>
+Some provider-backed files (for example, certain Android `content://` URIs) may not expose a reliable size ahead of time. Prefer `destination.write(sourceFile)` or `sourceFile.copyTo(destination)` for robust streaming copy behavior.
+</Note>
 
 ## Appending to Files
 

--- a/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
+++ b/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
@@ -585,7 +585,11 @@ private fun getUriFileSize(uri: Uri): Long? {
     val queryUri = uri.toDocumentUriForMetadata()
     return FileKit.context.contentResolver.query(queryUri, null, null, null, null)?.use { cursor ->
         val sizeIndex = cursor.getColumnIndex(OpenableColumns.SIZE)
-        if (cursor.moveToFirst()) cursor.getLong(sizeIndex) else null
+        if (sizeIndex == -1 || !cursor.moveToFirst() || cursor.isNull(sizeIndex)) {
+            null
+        } else {
+            cursor.getLong(sizeIndex)
+        }
     }
 }
 
@@ -593,7 +597,11 @@ private fun getUriFileName(uri: Uri): String {
     val queryUri = uri.toDocumentUriForMetadata()
     return FileKit.context.contentResolver.query(queryUri, null, null, null, null)?.use { cursor ->
         val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-        if (cursor.moveToFirst()) cursor.getString(nameIndex) else null
+        if (nameIndex == -1 || !cursor.moveToFirst() || cursor.isNull(nameIndex)) {
+            null
+        } else {
+            cursor.getString(nameIndex)
+        }
     } ?: uri.lastPathSegment ?: "" // Fallback to the Uri's last path segment
 }
 

--- a/filekit-core/src/nonWebTest/kotlin/io/github/vinceglb/filekit/PlatformFileNonWebTest.kt
+++ b/filekit-core/src/nonWebTest/kotlin/io/github/vinceglb/filekit/PlatformFileNonWebTest.kt
@@ -1,10 +1,14 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+
 package io.github.vinceglb.filekit
 
+import io.github.vinceglb.filekit.exceptions.FileKitException
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.IOException
 import kotlinx.io.files.FileNotFoundException
 import kotlinx.io.files.Path
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
@@ -126,6 +130,51 @@ class PlatformFileNonWebTest {
         // Delete
         newFile.delete()
         assertFalse { newFile.exists() }
+    }
+
+    @Suppress("ktlint:standard:function-naming")
+    @Test
+    fun PlatformFile_writePlatformFile_copiesContent() = runTest {
+        val destination = resourceDirectory / "copied-hello.txt"
+
+        try {
+            destination write textFile
+
+            assertTrue(destination.exists())
+            assertContentEquals(textFile.readBytes(), destination.readBytes())
+        } finally {
+            if (destination.exists()) {
+                destination.delete(mustExist = false)
+            }
+        }
+    }
+
+    @Test
+    fun PlatformFile_copyTo_sameFile_throws() = runTest {
+        assertFailsWith<FileKitException> {
+            textFile.copyTo(textFile)
+        }
+    }
+
+    @Test
+    fun PlatformFile_writePlatformFile_sameFile_throws() = runTest {
+        assertFailsWith<FileKitException> {
+            textFile write textFile
+        }
+    }
+
+    @Test
+    fun PlatformFile_writePlatformFile_directorySource_throws() = runTest {
+        val destination = resourceDirectory / "directory-source-target.txt"
+        try {
+            assertFailsWith<FileKitException> {
+                destination write resourceDirectory
+            }
+        } finally {
+            if (destination.exists()) {
+                destination.delete(mustExist = false)
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- replace size-dependent non-web copy/write with EOF-based streaming
- add explicit guards for directory source and same source/destination copy/write
- harden Android URI metadata reads when provider columns are missing
- reuse core `copyTo` in Android gallery save path (remove duplicate copy helper)
- add non-web + Android host tests for unknown-size provider-backed files
- update docs to recommend safe copy/write patterns and clarify `size()` may be `-1`

## Behavior changes
- `write(sourceFile)` and `copyTo` now work with readable unknown-size sources
- copying/writing directory sources now throws `FileKitException`
- copying/writing same source and destination now throws `FileKitException`
- Android URI-backed `size()` safely returns `-1` when provider size metadata is unavailable

## Validation
- `./gradlew :filekit-core:testAndroidHostTest --no-daemon`
- `./gradlew :filekit-core:compileAndroidHostTest :filekit-core:jvmTest --no-daemon`
- `./gradlew :filekit-core:check --no-daemon -x kotlinStoreYarnLock -x kotlinWasmStoreYarnLock`

## Notes
- full `:filekit-core:check` without exclusions currently hits existing Yarn lock task mismatch in this environment.
