### PR TITLE
Add watchOS tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,26 @@ jobs:
       - name: 🧪 Run iOS Tests
         run: ./gradlew iosSimulatorArm64Test
 
+  test-watchos:
+    name: ⌚️ Test watchOS
+    needs: build
+    runs-on: macos-latest
+    steps:
+      - name: 🛎️ Check out repository
+        uses: actions/checkout@v6
+
+      - name: 🍉 Configure JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: 🐘 Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: 🧪 Run watchOS Tests
+        run: ./gradlew watchosSimulatorArm64Test
+
   test-macos:
     name: 🍏 Test macOS
     needs: build


### PR DESCRIPTION
Summary
- add a watchOS test job that runs on macOS with the necessary Gradle setup and watchOS simulator task
- reuses the existing build dependency so it executes after the main compilation finishes

Testing
- Not run (not requested)