### PR TITLE
Fix Android camera permission handling for camera picker

### DIFF
--- a/docs/dialogs/camera-picker.mdx
+++ b/docs/dialogs/camera-picker.mdx
@@ -30,6 +30,17 @@ Button(onClick = { launcher.launch() }) {
 
 The captured media file is automatically saved to the specified location (or cache directory by default). If you need to keep the file permanently, make sure to copy it to a permanent storage location.
 
+## Android camera permission behavior
+
+On Android, camera capture is launched with `ACTION_IMAGE_CAPTURE`.
+If your app declares `android.permission.CAMERA`, FileKit checks runtime permission before launching the camera:
+
+- If camera permission is already granted, FileKit opens the camera as usual.
+- If camera permission is not granted, FileKit requests it first.
+- If the user denies the permission, FileKit returns `null` (same as cancel) and does not crash.
+
+If your app only launches the external camera app through this picker, you usually do not need to declare `android.permission.CAMERA`.
+
 ## Camera type
 
 You can specify the type of media to capture using the `type` parameter:

--- a/filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.android.kt
+++ b/filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.android.kt
@@ -2,6 +2,7 @@
 
 package io.github.vinceglb.filekit.dialogs.compose
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -22,9 +23,12 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitAndroidCameraPermissionInternal
+import io.github.vinceglb.filekit.dialogs.FileKitCameraFacing
 import io.github.vinceglb.filekit.dialogs.FileKitAndroidDialogsInternal
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitMode
@@ -280,6 +284,10 @@ public actual fun rememberCameraPickerLauncher(
     // Store the destination file URI string to survive process death.
     // If the user launches again before a callback, latest launch wins.
     var pendingDestinationUri by rememberSaveable { mutableStateOf<String?>(null) }
+    var pendingCameraFacingName by rememberSaveable { mutableStateOf(FileKitCameraFacing.System.name) }
+    var hasPendingPermissionRequest by rememberSaveable { mutableStateOf(false) }
+
+    val context = LocalContext.current
 
     // Updated callback
     val currentOnResult by rememberUpdatedState(onResult)
@@ -294,20 +302,102 @@ public actual fun rememberCameraPickerLauncher(
         currentOnResult(resolveCameraResult(success, pendingUri))
     }
 
+    val permissionLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { permissionGranted ->
+            if (!hasPendingPermissionRequest) return@rememberLauncherForActivityResult
+            hasPendingPermissionRequest = false
+
+            when (
+                val resolution = resolveCameraPermissionResult(
+                    permissionGranted = permissionGranted,
+                    pendingDestinationUri = pendingDestinationUri,
+                )
+            ) {
+                CameraPermissionResolution.NoOp -> {
+                    Unit
+                }
+
+                CameraPermissionResolution.ReturnNullResult -> {
+                    pendingDestinationUri = null
+                    currentOnResult(null)
+                }
+
+                is CameraPermissionResolution.LaunchCamera -> {
+                    val cameraFacing = runCatching {
+                        FileKitCameraFacing.valueOf(pendingCameraFacingName)
+                    }.getOrDefault(FileKitCameraFacing.System)
+
+                    contract.setCameraFacing(cameraFacing)
+                    val isLaunched = launchCameraSafely(
+                        uri = resolution.uri,
+                        launch = launcher::launch,
+                    )
+                    if (!isLaunched) {
+                        pendingDestinationUri = null
+                        currentOnResult(null)
+                    }
+                }
+            }
+        }
+
     // Return the PhotoResultLauncher wrapper
-    return remember(launcher, contract) {
-        PhotoResultLauncher { type, cameraFacing, destinationFile ->
+    return remember(launcher, permissionLauncher, contract, context) {
+        PhotoResultLauncher { _, cameraFacing, destinationFile ->
             // Store the destination URI for retrieval after potential activity recreation
             val uri = destinationFile.toAndroidUri(openCameraSettings.authority)
             pendingDestinationUri = uri.toString()
+            pendingCameraFacingName = cameraFacing.name
+
+            if (FileKitAndroidCameraPermissionInternal.needsRuntimeCameraPermission(context)) {
+                hasPendingPermissionRequest = true
+                permissionLauncher.launch(Manifest.permission.CAMERA)
+                return@PhotoResultLauncher
+            }
 
             // Set the camera facing on the contract before launching
             contract.setCameraFacing(cameraFacing)
 
             // Launch the camera
-            launcher.launch(uri)
+            val isLaunched = launchCameraSafely(
+                uri = uri,
+                launch = launcher::launch,
+            )
+            if (!isLaunched) {
+                pendingDestinationUri = null
+                currentOnResult(null)
+            }
         }
     }
+}
+
+internal sealed interface CameraPermissionResolution {
+    data object NoOp : CameraPermissionResolution
+
+    data object ReturnNullResult : CameraPermissionResolution
+
+    data class LaunchCamera(
+        val uri: Uri,
+    ) : CameraPermissionResolution
+}
+
+internal fun resolveCameraPermissionResult(
+    permissionGranted: Boolean,
+    pendingDestinationUri: String?,
+): CameraPermissionResolution {
+    if (!permissionGranted) return CameraPermissionResolution.ReturnNullResult
+
+    val pendingUri = pendingDestinationUri ?: return CameraPermissionResolution.NoOp
+    return CameraPermissionResolution.LaunchCamera(pendingUri.toUri())
+}
+
+internal fun launchCameraSafely(
+    uri: Uri,
+    launch: (Uri) -> Unit,
+): Boolean = try {
+    launch(uri)
+    true
+} catch (_: SecurityException) {
+    false
 }
 
 internal fun resolveCameraResult(

--- a/filekit-dialogs/build.gradle.kts
+++ b/filekit-dialogs/build.gradle.kts
@@ -20,6 +20,10 @@ kotlin {
             implementation(libs.androidx.activity.ktx)
         }
 
+        androidHostTest.dependencies {
+            implementation(libs.test.android.robolectric)
+        }
+
         jvmMain.dependencies {
             implementation(libs.jna)
             implementation(libs.jna.platform)

--- a/filekit-dialogs/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/AndroidCameraPermissionTest.kt
+++ b/filekit-dialogs/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/AndroidCameraPermissionTest.kt
@@ -1,0 +1,55 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+@file:OptIn(io.github.vinceglb.filekit.dialogs.FileKitDialogsInternalApi::class)
+
+package io.github.vinceglb.filekit.dialogs
+
+import android.os.Build
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AndroidCameraPermissionTest {
+    @Test
+    fun CameraPermission_sdkBelowM_doesNotRequestRuntimePermission() {
+        val shouldRequest = FileKitAndroidCameraPermissionInternal.shouldRequestRuntimeCameraPermission(
+            apiLevel = Build.VERSION_CODES.LOLLIPOP_MR1,
+            isCameraPermissionDeclared = true,
+            isCameraPermissionGranted = false,
+        )
+
+        assertFalse(shouldRequest)
+    }
+
+    @Test
+    fun CameraPermission_declaredAndDenied_requestsRuntimePermission() {
+        val shouldRequest = FileKitAndroidCameraPermissionInternal.shouldRequestRuntimeCameraPermission(
+            apiLevel = Build.VERSION_CODES.M,
+            isCameraPermissionDeclared = true,
+            isCameraPermissionGranted = false,
+        )
+
+        assertTrue(shouldRequest)
+    }
+
+    @Test
+    fun CameraPermission_notDeclared_doesNotRequestRuntimePermission() {
+        val shouldRequest = FileKitAndroidCameraPermissionInternal.shouldRequestRuntimeCameraPermission(
+            apiLevel = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+            isCameraPermissionDeclared = false,
+            isCameraPermissionGranted = false,
+        )
+
+        assertFalse(shouldRequest)
+    }
+
+    @Test
+    fun CameraPermission_declaredAndGranted_doesNotRequestRuntimePermission() {
+        val shouldRequest = FileKitAndroidCameraPermissionInternal.shouldRequestRuntimeCameraPermission(
+            apiLevel = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+            isCameraPermissionDeclared = true,
+            isCameraPermissionGranted = true,
+        )
+
+        assertFalse(shouldRequest)
+    }
+}

--- a/sample/androidApp/src/main/AndroidManifest.xml
+++ b/sample/androidApp/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.CAMERA" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
## Summary
- add Android camera permission preflight for camera picker flows in dialogs and compose
- request CAMERA at runtime only when it is declared and currently denied
- return null instead of crashing when permission is denied or a SecurityException occurs
- add Android host tests for permission decision logic and compose permission/camera launch resolution
- document Android camera permission behavior and add camera permission in sample app for manual verification

## Linked issue
- Closes #462

## Validation
- ./gradlew :filekit-dialogs:check :filekit-dialogs-compose:check --no-daemon
- ./gradlew :sample:androidApp:assembleDebug --no-daemon