### PR TITLE
Fix Android file:// PlatformFile existence checks

### DIFF
--- a/filekit-core/src/androidHostTest/kotlin/io/github/vinceglb/filekit/PlatformFileAndroidTest.kt
+++ b/filekit-core/src/androidHostTest/kotlin/io/github/vinceglb/filekit/PlatformFileAndroidTest.kt
@@ -65,6 +65,20 @@ class PlatformFileAndroidTest {
     private val emptyFile = resourceDirectory / "empty-file"
     private val notExistingFile = resourceDirectory / "not-existing-file.pdf"
 
+    private fun createTempAudioFileWithEncodedSpacePath(): Pair<File, String> {
+        val directory = File.createTempFile("filekit-file-uri-", "").apply {
+            delete()
+            mkdirs()
+            deleteOnExit()
+        }
+        val file = File(directory, "encoded space audio.mp3").apply {
+            writeText("audio")
+            deleteOnExit()
+        }
+        val encodedFileUri = "file://${file.absolutePath.replace(" ", "%20")}"
+        return file to encodedFileUri
+    }
+
     @Test
     fun testPlatformMimeType() {
         assertEquals(
@@ -124,6 +138,51 @@ class PlatformFileAndroidTest {
             exception.message?.contains("Could not access Uri as directory") == true ||
                 exception.message?.contains("Could not create child file") == true,
         )
+    }
+
+    @Test
+    fun PlatformFile_fromFileSchemeString_existsAndUsesFileWrapper() {
+        val (backingFile, encodedFileUri) = createTempAudioFileWithEncodedSpacePath()
+
+        try {
+            val file = PlatformFile(encodedFileUri)
+            assertTrue(file.exists())
+            assertIs<AndroidFile.FileWrapper>(file.androidFile)
+            assertEquals(backingFile.absolutePath, file.path)
+        } finally {
+            backingFile.delete()
+            backingFile.parentFile?.delete()
+        }
+    }
+
+    @Test
+    fun PlatformFile_fromFileSchemeUri_existsAndUsesFileWrapper() {
+        val (backingFile, encodedFileUri) = createTempAudioFileWithEncodedSpacePath()
+
+        try {
+            val file = PlatformFile(Uri.parse(encodedFileUri))
+            assertTrue(file.exists())
+            assertIs<AndroidFile.FileWrapper>(file.androidFile)
+            assertEquals(backingFile.absolutePath, file.path)
+        } finally {
+            backingFile.delete()
+            backingFile.parentFile?.delete()
+        }
+    }
+
+    @Test
+    fun PlatformFile_fromBookmarkData_fileSchemeUriWithEncodedPath_restoresAccessibleFile() {
+        val (backingFile, encodedFileUri) = createTempAudioFileWithEncodedSpacePath()
+
+        try {
+            val restored = PlatformFile.fromBookmarkData(BookmarkData(encodedFileUri.encodeToByteArray()))
+            assertTrue(restored.exists())
+            assertIs<AndroidFile.FileWrapper>(restored.androidFile)
+            assertEquals(backingFile.absolutePath, restored.path)
+        } finally {
+            backingFile.delete()
+            backingFile.parentFile?.delete()
+        }
     }
 
     @Test

--- a/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
+++ b/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
@@ -75,7 +75,8 @@ public actual fun PlatformFile(path: Path): PlatformFile =
  * @return A [PlatformFile] instance.
  */
 public fun PlatformFile(uri: Uri): PlatformFile =
-    PlatformFile(AndroidFile.UriWrapper(uri))
+    uri.toFileOrNull()?.let(::PlatformFile)
+        ?: PlatformFile(AndroidFile.UriWrapper(uri))
 
 /**
  * Creates a [PlatformFile] from a Java [File].
@@ -89,11 +90,12 @@ public fun PlatformFile(file: File): PlatformFile =
 public actual fun PlatformFile(path: String): PlatformFile {
     // If the path looks like an Android Uri ("content://" or "file://" scheme),
     // parse it accordingly, otherwise treat it as a regular filesystem path.
+    // "file://" values are normalized to FileWrapper by PlatformFile(uri).
     return if (path.startsWith("content://", ignoreCase = true) ||
         path.startsWith("file://", ignoreCase = true)
     ) {
         @SuppressLint("UseKtx")
-        PlatformFile(AndroidFile.UriWrapper(Uri.parse(path)))
+        PlatformFile(Uri.parse(path))
     } else {
         PlatformFile(AndroidFile.FileWrapper(File(path)))
     }
@@ -561,9 +563,11 @@ public actual fun PlatformFile.Companion.fromBookmarkData(
         }
 
         // Very rarely used Uri, discouraged and deprecated, may starts with "file://"
+        // Parse through PlatformFile(Uri) so encoded paths (e.g. "%20") resolve correctly.
         str.startsWith("file://") -> {
-            val filePath = str.removePrefix("file://")
-            PlatformFile(File(filePath))
+            val uriString = str
+            @SuppressLint("UseKtx")
+            PlatformFile(Uri.parse(uriString))
         }
 
         // TODO remove this in future
@@ -848,4 +852,13 @@ private fun getDocumentFile(uri: Uri): DocumentFile? {
                 ?: DocumentFile.fromTreeUri(context, uri)
         }
     }
+}
+
+private fun Uri.toFileOrNull(): File? {
+    if (!scheme.equals("file", ignoreCase = true)) {
+        return null
+    }
+
+    val filePath = path ?: return null
+    return File(filePath)
 }


### PR DESCRIPTION
## Summary
- normalize Android `file://` URIs to file-backed `PlatformFile` instances
- route `PlatformFile(path: String)` URI parsing through `PlatformFile(Uri)` so `file://` and `content://` share the same normalization path
- restore `file://` bookmarks through URI parsing to correctly decode encoded paths such as `%20`
- add Android host regression tests for `PlatformFile(String)`, `PlatformFile(Uri)`, and `fromBookmarkData` with encoded `file://` paths

## Problem
Issue #520 reported that Android `PlatformFile("file://...")` and `PlatformFile(uri)` could return `exists() == false`, while using the raw filesystem path returned `true`.

The root cause was that `file://` inputs were treated as `UriWrapper`, and `exists()` for URI-backed files relies on `DocumentFile`, which is not suitable for filesystem `file://` paths.

## Validation
- reproduced the bug behavior before this change
- verified the fix locally
- ran:
  - `./gradlew :filekit-core:testAndroidHostTest --tests "io.github.vinceglb.filekit.PlatformFileAndroidTest"`
