### PR TITLE
Fix Java 17 compatibility for published JVM artifacts

### DIFF
--- a/build-logic/convention/src/main/kotlin/io/github/vinceglb/filekit/convention/ConfigureKotlinMultiplatform.kt
+++ b/build-logic/convention/src/main/kotlin/io/github/vinceglb/filekit/convention/ConfigureKotlinMultiplatform.kt
@@ -4,6 +4,7 @@ import com.android.build.api.dsl.KotlinMultiplatformAndroidLibraryExtension
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 internal fun Project.configureKotlinMultiplatform(
@@ -61,7 +62,11 @@ internal fun Project.configureKotlinMultiplatform(
     // }
 
     // Desktop JVM
-    jvm()
+    jvm {
+        compilerOptions {
+            jvmTarget.set(JvmTarget.JVM_17)
+        }
+    }
 
     // JS
     js {


### PR DESCRIPTION
## Summary
- pin the shared Kotlin Multiplatform JVM target to Java 17
- keep the build running on the Java 21 toolchain while publishing Java 17-compatible bytecode

## Context
This fixes the Java 17 UnsupportedClassVersionError reported in #525.
Related: #530

## Verification
- verified locally before commit that the affected JVM classes compile to class file major version 61 (Java 17)
