### PR TITLE
[codex] Preserve photo-picker fallback extension

### DIFF
--- a/filekit-core/src/androidHostTest/kotlin/io/github/vinceglb/filekit/PlatformFileAndroidTest.kt
+++ b/filekit-core/src/androidHostTest/kotlin/io/github/vinceglb/filekit/PlatformFileAndroidTest.kt
@@ -305,11 +305,28 @@ class PlatformFileAndroidTest {
     }
 
     @Test
-    fun PlatformFile_name_photoPickerMediaStoreLookupFails_usesStableFallback() {
+    fun PlatformFile_name_photoPickerMediaStoreLookupFails_usesStableFallbackWithExtension() {
         val pickerUri = Uri.parse("content://media/picker/0/com.android.providers.media.photopicker/media/18")
         val provider = PhotoPickerNameContentProvider(
             pickerUri = pickerUri,
             pickerDisplayName = "18.jpg",
+            mediaStoreDisplayName = null,
+            throwOnMediaStoreQuery = true,
+        )
+        ShadowContentResolver.registerProviderInternal("media", provider)
+
+        val file = PlatformFile(pickerUri)
+        assertEquals(expected = "photopicker-18.jpg", actual = file.name)
+        assertEquals(expected = "jpg", actual = file.extension)
+        assertEquals(expected = "photopicker-18", actual = file.nameWithoutExtension)
+    }
+
+    @Test
+    fun PlatformFile_name_photoPickerWithoutDisplayName_usesStableFallback() {
+        val pickerUri = Uri.parse("content://media/picker/0/com.android.providers.media.photopicker/media/18")
+        val provider = PhotoPickerNameContentProvider(
+            pickerUri = pickerUri,
+            pickerDisplayName = null,
             mediaStoreDisplayName = null,
             throwOnMediaStoreQuery = true,
         )
@@ -338,8 +355,8 @@ class PlatformFileAndroidTest {
         val firstFile = PlatformFile(firstPickerUri)
         val secondFile = PlatformFile(secondPickerUri)
 
-        assertEquals(expected = "photopicker-18", actual = firstFile.name)
-        assertEquals(expected = "photopicker-19", actual = secondFile.name)
+        assertEquals(expected = "photopicker-18.jpg", actual = firstFile.name)
+        assertEquals(expected = "photopicker-19.jpg", actual = secondFile.name)
     }
 
     @Test
@@ -498,13 +515,13 @@ private class MissingSizeContentProvider(
 
 private class PhotoPickerNameContentProvider(
     pickerUri: Uri,
-    pickerDisplayName: String,
+    pickerDisplayName: String?,
     private val mediaStoreDisplayName: String?,
     private val throwOnMediaStoreQuery: Boolean = false,
 ) : ContentProvider() {
     private val pickerDisplayNamesByUri = mutableMapOf(pickerUri to pickerDisplayName)
 
-    fun registerPickerDisplayName(uri: Uri, displayName: String) {
+    fun registerPickerDisplayName(uri: Uri, displayName: String?) {
         pickerDisplayNamesByUri[uri] = displayName
     }
 

--- a/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
+++ b/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
@@ -657,6 +657,13 @@ private object UriMetadataResolver {
         }
 
         return queryPhotoPickerMediaStoreDisplayName(uri)
+            ?: fallbackDisplayName(
+                uri = uri,
+                extension = openableDisplayName
+                    ?.takeIf(::isSyntheticPhotoPickerDisplayName)
+                    ?.substringAfterLast('.', "")
+                    ?.takeIf(String::isNotEmpty),
+            )
     }
 
     private fun queryPhotoPickerMediaStoreDisplayName(uri: Uri): String? {
@@ -715,18 +722,23 @@ private object UriMetadataResolver {
         )
     }
 
-    private fun fallbackDisplayName(uri: Uri): String = when {
+    private fun fallbackDisplayName(
+        uri: Uri,
+        extension: String? = null,
+    ): String = when {
         uri.isPhotoPickerUri() -> {
             val providerName = uri.photoPickerProviderName()
             val uniqueSuffix = uri.extractPhotoPickerMediaId()?.toString()
                 ?: uri.lastPathSegment
 
-            when {
+            val baseName = when {
                 providerName != null && uniqueSuffix != null -> "$providerName-$uniqueSuffix"
                 providerName != null -> providerName
                 uniqueSuffix != null -> uniqueSuffix
                 else -> ""
             }
+
+            baseName.withExtension(extension)
         }
 
         else -> {
@@ -736,6 +748,14 @@ private object UriMetadataResolver {
 
     private fun isSyntheticPhotoPickerDisplayName(displayName: String): Boolean =
         SYNTHETIC_PHOTO_PICKER_NAME_REGEX.matches(displayName)
+
+    private fun String.withExtension(extension: String?): String {
+        if (isEmpty() || extension.isNullOrBlank()) {
+            return this
+        }
+
+        return "$this.$extension"
+    }
 
     private fun Uri.extractPhotoPickerMediaId(): Long? {
         lastPathSegment?.toLongOrNull()?.let { return it }


### PR DESCRIPTION
This fixes the Android photo-picker regression behind issue #526.

On Android photo-picker URIs, FileKit tries to replace synthetic picker names like `18.jpg` with the real MediaStore display name. That is the right first choice because it preserves the user-visible filename when the lookup succeeds. The problem is the failure path: when the MediaStore query is blocked or returns no row, simply surfacing the synthetic picker display name restores the extension but reintroduces the ambiguity that the stable fallback was meant to avoid. Different picker URIs can still be distinct files even when they expose the same synthetic display name pattern, so reusing that value directly is not a safe fallback.

The root cause was that the fallback strategy mixed together two separate concerns: preserving uniqueness and preserving the extension. The provider/id-based fallback solved the uniqueness problem, while the synthetic picker name still contained useful extension metadata. Treating the whole synthetic name as the final fallback discarded the stability guarantees; treating only the provider/id fallback as final discarded the extension.

This change keeps the existing priority order. FileKit still prefers the real MediaStore display name when it can resolve it, and still returns non-synthetic openable display names directly. When the URI is a photo-picker URI and only a synthetic picker display name is available, the code now keeps the stable provider/id-based fallback name and appends only the synthetic extension if one exists. That produces names such as `photopicker-18.jpg`, which remain stable and distinct while allowing `PlatformFile.extension` to stay populated.

The Android host tests were updated to cover the intended contract: MediaStore lookup failures now resolve to a stable fallback with the original extension, the no-display-name case still falls back to the stable provider/id name without an extension, and multiple synthetic picker names still resolve to distinct stable names.

Validation used `./gradlew :filekit-core:testAndroidHostTest --tests 'io.github.vinceglb.filekit.PlatformFileAndroidTest'` and `./gradlew :filekit-core:check`, both of which passed.