### PR TITLE
Document Linux FileKit Dialogs ProGuard rules

### DIFF
--- a/docs/snippets/setup-jvm-core.mdx
+++ b/docs/snippets/setup-jvm-core.mdx
@@ -40,9 +40,15 @@ fun main() {
 
 #### ProGuard Configuration
 
-If you're using ProGuard or code obfuscation on JVM platforms, add these rules to your `proguard-rules.pro`:
+If you're using ProGuard or code obfuscation on JVM platforms, add the relevant rules to your `proguard-rules.pro`:
 
 ```proguard
+# Required on JVM for JNA-based integrations.
 -keep class com.sun.jna.** { *; }
 -keep class * implements com.sun.jna.** { *; }
+
+# Required when using FileKit Dialogs on Linux (XDG Desktop Portal / DBus).
+-keep class org.freedesktop.dbus.** { *; }
+-keep class io.github.vinceglb.filekit.dialogs.platform.xdg.** { *; }
+-keepattributes Signature,InnerClasses,RuntimeVisibleAnnotations
 ```


### PR DESCRIPTION
## Summary
- document the extra ProGuard/R8 rules needed for FileKit Dialogs on Linux
- keep the existing JVM JNA rules and clarify when the Linux DBus/XDG rules apply
- fix the documentation gap reported in #529

Closes #529