### PR TITLE
Added support for PlatformFile.lastModified for web targets

### DIFF
--- a/filekit-core/src/commonMain/kotlin/io/github/vinceglb/filekit/PlatformFile.kt
+++ b/filekit-core/src/commonMain/kotlin/io/github/vinceglb/filekit/PlatformFile.kt
@@ -2,6 +2,8 @@ package io.github.vinceglb.filekit
 
 import io.github.vinceglb.filekit.mimeType.MimeType
 import kotlinx.serialization.Serializable
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * Represents a file on a specific platform.
@@ -35,6 +37,14 @@ public expect val PlatformFile.nameWithoutExtension: String
  * Returns the size of the file in bytes.
  */
 public expect fun PlatformFile.size(): Long
+
+/**
+ * Returns the last modification time of this file.
+ *
+ * @return The [Instant] of the last modification.
+ */
+@OptIn(ExperimentalTime::class)
+public expect fun PlatformFile.lastModified(): Instant
 
 /**
  * Reads the content of the file as a byte array.

--- a/filekit-core/src/jsMain/kotlin/io/github/vinceglb/filekit/PlatformFile.js.kt
+++ b/filekit-core/src/jsMain/kotlin/io/github/vinceglb/filekit/PlatformFile.js.kt
@@ -8,11 +8,15 @@ import kotlinx.serialization.Serializable
 import org.khronos.webgl.ArrayBuffer
 import org.khronos.webgl.Uint8Array
 import org.khronos.webgl.get
+import org.w3c.files.Blob
 import org.w3c.files.File
+import org.w3c.files.FilePropertyBag
 import org.w3c.files.FileReader
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * Represents a file on the Web (JS) platform.
@@ -77,3 +81,18 @@ public actual suspend fun PlatformFile.readBytes(): ByteArray = withContext(Disp
 public actual fun PlatformFile.mimeType(): MimeType? =
     takeIf { file.type.isNotBlank() }
         ?.let { MimeType.parse(file.type) }
+
+@OptIn(ExperimentalTime::class, ExperimentalWasmJsInterop::class)
+public actual fun PlatformFile.lastModified(): Instant {
+    val ts = file.unsafeCast<io.github.vinceglb.filekit.File>()
+    return Instant.fromEpochMilliseconds(ts.lastModified.toLong())
+}
+
+@OptIn(ExperimentalWasmJsInterop::class)
+private open external class File(
+    fileBits: JsArray<JsAny? /* BufferSource|Blob|String */>,
+    fileName: String, options: FilePropertyBag = definedExternally
+) : Blob, JsAny {
+    val name: String
+    val lastModified: JsNumber
+}

--- a/filekit-core/src/jsMain/kotlin/io/github/vinceglb/filekit/PlatformFile.js.kt
+++ b/filekit-core/src/jsMain/kotlin/io/github/vinceglb/filekit/PlatformFile.js.kt
@@ -90,9 +90,11 @@ public actual fun PlatformFile.lastModified(): Instant {
 
 @OptIn(ExperimentalWasmJsInterop::class)
 private open external class File(
-    fileBits: JsArray<JsAny? /* BufferSource|Blob|String */>,
-    fileName: String, options: FilePropertyBag = definedExternally
-) : Blob, JsAny {
+    fileBits: JsArray<JsAny?>, // BufferSource|Blob|String
+    fileName: String,
+    options: FilePropertyBag = definedExternally,
+) : Blob,
+    JsAny {
     val name: String
     val lastModified: JsNumber
 }

--- a/filekit-core/src/nonWebMain/kotlin/io/github/vinceglb/filekit/PlatformFile.nonWeb.kt
+++ b/filekit-core/src/nonWebMain/kotlin/io/github/vinceglb/filekit/PlatformFile.nonWeb.kt
@@ -125,14 +125,6 @@ public expect fun PlatformFile.exists(): Boolean
 @OptIn(ExperimentalTime::class)
 public expect fun PlatformFile.createdAt(): Instant?
 
-/**
- * Returns the last modification time of this file.
- *
- * @return The [Instant] of the last modification.
- */
-@OptIn(ExperimentalTime::class)
-public expect fun PlatformFile.lastModified(): Instant
-
 public actual suspend fun PlatformFile.readBytes(): ByteArray =
     withContext(Dispatchers.IO) {
         this@readBytes

--- a/filekit-core/src/wasmJsMain/kotlin/io/github/vinceglb/filekit/PlatformFile.wasmJs.kt
+++ b/filekit-core/src/wasmJsMain/kotlin/io/github/vinceglb/filekit/PlatformFile.wasmJs.kt
@@ -92,9 +92,11 @@ public actual fun PlatformFile.lastModified(): Instant {
 
 @OptIn(ExperimentalWasmJsInterop::class)
 private open external class File(
-    fileBits: JsArray<JsAny? /* BufferSource|Blob|String */>,
-    fileName: String, options: FilePropertyBag = definedExternally
-) : Blob, JsAny {
+    fileBits: JsArray<JsAny?>, // BufferSource|Blob|String
+    fileName: String,
+    options: FilePropertyBag = definedExternally,
+) : Blob,
+    JsAny {
     val name: String
     val lastModified: JsNumber
 }

--- a/filekit-core/src/wasmJsMain/kotlin/io/github/vinceglb/filekit/PlatformFile.wasmJs.kt
+++ b/filekit-core/src/wasmJsMain/kotlin/io/github/vinceglb/filekit/PlatformFile.wasmJs.kt
@@ -8,11 +8,15 @@ import kotlinx.serialization.Serializable
 import org.khronos.webgl.ArrayBuffer
 import org.khronos.webgl.Uint8Array
 import org.khronos.webgl.get
+import org.w3c.files.Blob
 import org.w3c.files.File
+import org.w3c.files.FilePropertyBag
 import org.w3c.files.FileReader
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
 
 /**
  * Represents a file on the Web (Wasm) platform.
@@ -79,3 +83,18 @@ public actual suspend fun PlatformFile.readBytes(): ByteArray = withContext(Disp
 public actual fun PlatformFile.mimeType(): MimeType? =
     takeIf { file.type.isNotBlank() }
         ?.let { MimeType.parse(file.type) }
+
+@OptIn(ExperimentalTime::class, ExperimentalWasmJsInterop::class)
+public actual fun PlatformFile.lastModified(): Instant {
+    val ts = file.unsafeCast<io.github.vinceglb.filekit.File>()
+    return Instant.fromEpochMilliseconds(ts.lastModified.toDouble().toLong())
+}
+
+@OptIn(ExperimentalWasmJsInterop::class)
+private open external class File(
+    fileBits: JsArray<JsAny? /* BufferSource|Blob|String */>,
+    fileName: String, options: FilePropertyBag = definedExternally
+) : Blob, JsAny {
+    val name: String
+    val lastModified: JsNumber
+}

--- a/sample/shared/src/webMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filedetails/components/FileDetailsMetadata.web.kt
+++ b/sample/shared/src/webMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filedetails/components/FileDetailsMetadata.web.kt
@@ -2,6 +2,7 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.filedetails.componen
 
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.extension
+import io.github.vinceglb.filekit.lastModified
 import io.github.vinceglb.filekit.mimeType
 import io.github.vinceglb.filekit.name
 import io.github.vinceglb.filekit.nameWithoutExtension
@@ -28,5 +29,9 @@ internal actual fun PlatformFile.toMetadataItems(): List<FileMetadataItem> = lis
     FileMetadataItem(
         label = "Mime Type",
         value = this.mimeType().toString(),
+    ),
+    FileMetadataItem(
+        label = "Updated At",
+        value = this.lastModified().toString(),
     ),
 )


### PR DESCRIPTION
Moved `public expect fun PlatformFile.lastModified(): Instant` to common.
Added implementations for the web targets.
