### PR TITLE
Add Windows native (mingwX64) target

### DIFF
--- a/build-logic/convention/src/main/kotlin/KotlinMultiplatformLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KotlinMultiplatformLibraryConventionPlugin.kt
@@ -26,6 +26,7 @@ class KotlinMultiplatformLibraryConventionPlugin : Plugin<Project> {
                     moduleName = moduleName,
                     addMacosTargets = true,
                     addWatchosTargets = path == ":filekit-core",
+                    addMingwTargets = path == ":filekit-core" || path == ":filekit-dialogs",
                 )
             }
         }

--- a/build-logic/convention/src/main/kotlin/io/github/vinceglb/filekit/convention/ConfigureKotlinMultiplatform.kt
+++ b/build-logic/convention/src/main/kotlin/io/github/vinceglb/filekit/convention/ConfigureKotlinMultiplatform.kt
@@ -13,6 +13,7 @@ internal fun Project.configureKotlinMultiplatform(
     moduleName: String,
     addMacosTargets: Boolean,
     addWatchosTargets: Boolean,
+    addMingwTargets: Boolean = false,
 ) = extension.apply {
     // Force visibility of public API
     explicitApi()
@@ -40,6 +41,11 @@ internal fun Project.configureKotlinMultiplatform(
             baseName = "${moduleName}Kit"
             binaryOption("bundleId", modulePackage)
         }
+    }
+
+    // Windows native target
+    if (addMingwTargets) {
+        mingwX64()
     }
 
     // If one day we need to disable watchOS tests

--- a/filekit-core/build.gradle.kts
+++ b/filekit-core/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
         val jvmAndNativeMain by creating { dependsOn(nonWebMain.get()) }
         jvmMain.get().dependsOn(desktopMain)
         macosMain.get().dependsOn(desktopMain)
-        getByName("mingwX64Main").dependsOn(desktopMain)
+        mingwX64Main.get().dependsOn(desktopMain)
         jvmMain.get().dependsOn(jvmAndNativeMain)
         nativeMain.get().dependsOn(jvmAndNativeMain)
 

--- a/filekit-core/build.gradle.kts
+++ b/filekit-core/build.gradle.kts
@@ -10,6 +10,7 @@ kotlin {
         val jvmAndNativeMain by creating { dependsOn(nonWebMain.get()) }
         jvmMain.get().dependsOn(desktopMain)
         macosMain.get().dependsOn(desktopMain)
+        getByName("mingwX64Main").dependsOn(desktopMain)
         jvmMain.get().dependsOn(jvmAndNativeMain)
         nativeMain.get().dependsOn(jvmAndNativeMain)
 

--- a/filekit-core/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/FileKit.mingw.kt
+++ b/filekit-core/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/FileKit.mingw.kt
@@ -1,0 +1,170 @@
+@file:Suppress("UnusedReceiverParameter")
+
+package io.github.vinceglb.filekit
+
+import io.github.vinceglb.filekit.exceptions.FileKitException
+import io.github.vinceglb.filekit.utils.runSuspendCatchingFileKit
+import kotlinx.cinterop.CPointerVarOf
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UShortVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.toKString
+import kotlinx.cinterop.toKStringFromUtf16
+import kotlinx.cinterop.value
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import platform.posix.getenv
+import platform.windows.CoTaskMemFree
+import platform.windows.FOLDERID_Documents
+import platform.windows.FOLDERID_Downloads
+import platform.windows.FOLDERID_Music
+import platform.windows.FOLDERID_Pictures
+import platform.windows.FOLDERID_Videos
+import platform.windows.KNOWNFOLDERID
+import platform.windows.SHGetKnownFolderPath
+
+public actual object FileKit {
+    private var _appId: String? = null
+    internal var customCacheDir: Path? = null
+    internal var customFilesDir: Path? = null
+
+    public val appId: String
+        get() = _appId
+            ?: throw FileKitException("FileKit not initialized. Please call FileKit.init(appId) first.")
+
+    public fun init(appId: String) {
+        _appId = appId
+        customCacheDir = null
+        customFilesDir = null
+    }
+
+    public fun init(
+        filesDir: PlatformFile,
+        cacheDir: PlatformFile,
+    ) {
+        _appId = null
+        customCacheDir = cacheDir.toKotlinxIoPath()
+        customFilesDir = filesDir.toKotlinxIoPath()
+    }
+
+    public fun init(
+        appId: String,
+        filesDir: PlatformFile? = null,
+        cacheDir: PlatformFile? = null,
+    ) {
+        _appId = appId
+        customCacheDir = cacheDir?.toKotlinxIoPath()
+        customFilesDir = filesDir?.toKotlinxIoPath()
+    }
+}
+
+public actual val FileKit.filesDir: PlatformFile
+    get() {
+        val folder = FileKit.customFilesDir
+            ?: (getEnv("APPDATA") / appId)
+        folder.assertExists()
+        return PlatformFile(folder)
+    }
+
+public actual val FileKit.cacheDir: PlatformFile
+    get() {
+        val folder = FileKit.customCacheDir
+            ?: (getEnv("LOCALAPPDATA") / appId / "Cache")
+        folder.assertExists()
+        return PlatformFile(folder)
+    }
+
+public actual val FileKit.databasesDir: PlatformFile
+    get() = FileKit.filesDir / "databases"
+
+public actual val FileKit.projectDir: PlatformFile
+    get() = PlatformFile(".")
+
+@OptIn(ExperimentalForeignApi::class)
+internal actual fun FileKit.platformUserDirectoryOrNull(type: FileKitUserDirectory): PlatformFile? {
+    val knownFolderId = when (type) {
+        FileKitUserDirectory.Downloads -> FOLDERID_Downloads
+        FileKitUserDirectory.Pictures -> FOLDERID_Pictures
+        FileKitUserDirectory.Videos -> FOLDERID_Videos
+        FileKitUserDirectory.Music -> FOLDERID_Music
+        FileKitUserDirectory.Documents -> FOLDERID_Documents
+    }
+
+    // Primary: SHGetKnownFolderPath
+    val path = resolveKnownFolder(knownFolderId)
+    if (path != null) {
+        path.assertExists()
+        return PlatformFile(path)
+    }
+
+    // Fallback: USERPROFILE + default folder name (same as JVM)
+    val userProfile = getenv("USERPROFILE")?.toKString() ?: return null
+    val fallbackDir = when (type) {
+        FileKitUserDirectory.Downloads -> "Downloads"
+        FileKitUserDirectory.Pictures -> "Pictures"
+        FileKitUserDirectory.Videos -> "Videos"
+        FileKitUserDirectory.Music -> "Music"
+        FileKitUserDirectory.Documents -> "Documents"
+    }
+    val fallbackPath = Path(userProfile) / fallbackDir
+    fallbackPath.assertExists()
+    return PlatformFile(fallbackPath)
+}
+
+public actual suspend fun FileKit.saveImageToGallery(
+    bytes: ByteArray,
+    filename: String,
+): Result<Unit> = runSuspendCatchingFileKit {
+    FileKit.picturesDir / filename write bytes
+}
+
+public actual suspend fun FileKit.saveVideoToGallery(
+    file: PlatformFile,
+    filename: String,
+): Result<Unit> = runSuspendCatchingFileKit {
+    FileKit.videosDir / filename write file
+}
+
+public actual suspend fun FileKit.compressImage(
+    bytes: ByteArray,
+    imageFormat: ImageFormat,
+    @androidx.annotation.IntRange(from = 0, to = 100) quality: Int,
+    maxWidth: Int?,
+    maxHeight: Int?,
+): ByteArray =
+    throw FileKitException("Image compression is not supported on Windows native target")
+
+@OptIn(ExperimentalForeignApi::class)
+private fun getEnv(key: String): Path {
+    val value = getenv(key)?.toKString()
+        ?: throw IllegalStateException("Environment variable $key not found.")
+    return Path(value)
+}
+
+private operator fun Path.div(child: String): Path = Path(this, child)
+
+private fun Path.assertExists() {
+    if (!SystemFileSystem.exists(this)) {
+        SystemFileSystem.createDirectories(this)
+    }
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun resolveKnownFolder(folderId: KNOWNFOLDERID): Path? = memScoped {
+    val ppszPath = alloc<CPointerVarOf<kotlinx.cinterop.CPointer<UShortVar>>>()
+    val hr = SHGetKnownFolderPath(
+        rfid = folderId.ptr,
+        dwFlags = 0u,
+        hToken = null,
+        ppszPath = ppszPath.ptr,
+    )
+    if (hr == 0) {
+        val pathStr = ppszPath.value?.toKStringFromUtf16()
+        CoTaskMemFree(ppszPath.value)
+        pathStr?.let { Path(it) }
+    } else {
+        null
+    }
+}

--- a/filekit-core/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/PlatformFile.mingw.kt
+++ b/filekit-core/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/PlatformFile.mingw.kt
@@ -1,0 +1,198 @@
+package io.github.vinceglb.filekit
+
+import io.github.vinceglb.filekit.mimeType.MimeType
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.UShortVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.toKStringFromUtf16
+import kotlinx.cinterop.value
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.serialization.Serializable
+import platform.windows.DWORDVar
+import platform.windows.FILETIME
+import platform.windows.GET_FILEEX_INFO_LEVELS
+import platform.windows.GetFileAttributesExW
+import platform.windows.GetFullPathNameW
+import platform.windows.HKEYVar
+import platform.windows.HKEY_CLASSES_ROOT
+import platform.windows.KEY_READ
+import platform.windows.MAX_PATH
+import platform.windows.RegCloseKey
+import platform.windows.RegOpenKeyExW
+import platform.windows.RegQueryValueExW
+import platform.windows.WIN32_FILE_ATTRIBUTE_DATA
+import kotlin.time.ExperimentalTime
+import kotlin.time.Instant
+
+/**
+ * Wrapper for a file path on Windows native platform.
+ */
+public class WindowsPath(
+    public val path: Path,
+)
+
+/**
+ * Represents a file on the Windows native platform.
+ *
+ * @property windowsPath The underlying wrapped [Path] object.
+ */
+@Serializable(with = PlatformFileSerializer::class)
+public actual class PlatformFile(
+    public val windowsPath: WindowsPath,
+) {
+    public actual override fun toString(): String = windowsPath.path.toString()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PlatformFile) return false
+        return windowsPath.path.toString() == other.windowsPath.path.toString()
+    }
+
+    override fun hashCode(): Int = windowsPath.path.toString().hashCode()
+
+    public actual companion object
+}
+
+public actual fun PlatformFile(path: Path): PlatformFile =
+    PlatformFile(windowsPath = WindowsPath(path))
+
+public actual fun PlatformFile.toKotlinxIoPath(): Path =
+    windowsPath.path
+
+public actual val PlatformFile.extension: String
+    get() = name.substringAfterLast('.', "")
+
+public actual val PlatformFile.nameWithoutExtension: String
+    get() = name.substringBeforeLast('.', name)
+
+@OptIn(ExperimentalForeignApi::class)
+public actual fun PlatformFile.absolutePath(): String {
+    val rawPath = windowsPath.path.toString()
+    // Already absolute (drive letter or UNC path)
+    if (rawPath.length >= 2 && rawPath[1] == ':') return rawPath
+    if (rawPath.startsWith("\\\\")) return rawPath
+
+    // Resolve relative path using Win32 API (Unicode-safe)
+    return memScoped {
+        val buffer = allocArray<UShortVar>(MAX_PATH)
+        val len = GetFullPathNameW(rawPath, MAX_PATH.toUInt(), buffer, null)
+        if (len > 0u) buffer.toKStringFromUtf16() else rawPath
+    }
+}
+
+public actual inline fun PlatformFile.list(block: (List<PlatformFile>) -> Unit): Unit =
+    withScopedAccess {
+        val directoryFiles = SystemFileSystem
+            .list(toKotlinxIoPath())
+            .map { PlatformFile(it) }
+        block(directoryFiles)
+    }
+
+public actual fun PlatformFile.list(): List<PlatformFile> =
+    withScopedAccess {
+        SystemFileSystem
+            .list(toKotlinxIoPath())
+            .map { PlatformFile(it) }
+    }
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalTime::class)
+public actual fun PlatformFile.createdAt(): Instant? =
+    getFileAttributeData()?.ftCreationTime?.toInstant()
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalTime::class)
+public actual fun PlatformFile.lastModified(): Instant {
+    val data = getFileAttributeData()
+        ?: return Instant.fromEpochMilliseconds(0L)
+    return data.ftLastWriteTime.toInstant()
+}
+
+@OptIn(ExperimentalForeignApi::class)
+public actual fun PlatformFile.mimeType(): MimeType? {
+    val ext = extension.lowercase()
+    if (ext.isBlank()) return null
+    return mimeTypeFromRegistry(".$ext")
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun mimeTypeFromRegistry(dotExtension: String): MimeType? = memScoped {
+    val hKey = alloc<HKEYVar>()
+    val result = RegOpenKeyExW(
+        HKEY_CLASSES_ROOT,
+        dotExtension,
+        0u,
+        KEY_READ.toUInt(),
+        hKey.ptr,
+    )
+    if (result != 0) return null
+
+    try {
+        val bufferSize = alloc<DWORDVar>()
+        bufferSize.value = 512u
+        val buffer = allocArray<ByteVar>(512)
+
+        val queryResult = RegQueryValueExW(
+            hKey.value,
+            "Content Type",
+            null,
+            null,
+            buffer.reinterpret(),
+            bufferSize.ptr,
+        )
+        if (queryResult != 0) return null
+
+        val mimeString = buffer.reinterpret<UShortVar>().toKStringFromUtf16()
+        if (mimeString.isBlank()) return null
+        MimeType.parse(mimeString)
+    } finally {
+        RegCloseKey(hKey.value)
+    }
+}
+
+public actual fun PlatformFile.startAccessingSecurityScopedResource(): Boolean = true
+
+public actual fun PlatformFile.stopAccessingSecurityScopedResource() {}
+
+public actual suspend fun PlatformFile.bookmarkData(): BookmarkData =
+    withContext(Dispatchers.IO) {
+        BookmarkData(absolutePath().encodeToByteArray())
+    }
+
+public actual fun PlatformFile.releaseBookmark() {}
+
+public actual fun PlatformFile.Companion.fromBookmarkData(
+    bookmarkData: BookmarkData,
+): PlatformFile {
+    val restoredPath = bookmarkData.bytes.decodeToString()
+    return PlatformFile(windowsPath = WindowsPath(Path(restoredPath)))
+}
+
+@OptIn(ExperimentalForeignApi::class)
+private fun PlatformFile.getFileAttributeData(): WIN32_FILE_ATTRIBUTE_DATA? = memScoped {
+    val data = alloc<WIN32_FILE_ATTRIBUTE_DATA>()
+    val filePath = absolutePath()
+    val success = GetFileAttributesExW(
+        filePath,
+        GET_FILEEX_INFO_LEVELS.GetFileExInfoStandard,
+        data.ptr,
+    )
+    if (success != 0) data else null
+}
+
+@OptIn(ExperimentalForeignApi::class, ExperimentalTime::class)
+private fun FILETIME.toInstant(): Instant {
+    // Windows FILETIME: 100-nanosecond intervals since January 1, 1601
+    // Unix epoch: January 1, 1970
+    // Difference: 11644473600 seconds
+    val windowsTicks = dwHighDateTime.toLong().shl(32) or dwLowDateTime.toLong()
+    val epochMillis = (windowsTicks / 10_000L) - 11_644_473_600_000L
+    return Instant.fromEpochMilliseconds(epochMillis)
+}

--- a/filekit-core/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/PlatformFile.mingw.kt
+++ b/filekit-core/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/PlatformFile.mingw.kt
@@ -78,14 +78,31 @@ public actual val PlatformFile.nameWithoutExtension: String
 public actual fun PlatformFile.absolutePath(): String {
     val rawPath = windowsPath.path.toString()
     // Already absolute (drive letter or UNC path)
-    if (rawPath.length >= 2 && rawPath[1] == ':') return rawPath
+    if (rawPath.isDriveAbsolutePath()) return rawPath
     if (rawPath.startsWith("\\\\")) return rawPath
 
     // Resolve relative path using Win32 API (Unicode-safe)
-    return memScoped {
-        val buffer = allocArray<UShortVar>(MAX_PATH)
-        val len = GetFullPathNameW(rawPath, MAX_PATH.toUInt(), buffer, null)
-        if (len > 0u) buffer.toKStringFromUtf16() else rawPath
+    return resolveFullPath(rawPath) ?: rawPath
+}
+
+private fun String.isDriveAbsolutePath(): Boolean =
+    length >= 3 &&
+        this[1] == ':' &&
+        (this[2] == '\\' || this[2] == '/')
+
+@OptIn(ExperimentalForeignApi::class)
+private fun resolveFullPath(rawPath: String): String? = memScoped {
+    val initialBuffer = allocArray<UShortVar>(MAX_PATH)
+    val requiredLength = GetFullPathNameW(rawPath, MAX_PATH.toUInt(), initialBuffer, null)
+
+    when {
+        requiredLength == 0u -> null
+        requiredLength < MAX_PATH.toUInt() -> initialBuffer.toKStringFromUtf16()
+        else -> {
+            val fullBuffer = allocArray<UShortVar>(requiredLength.toInt())
+            val resolvedLength = GetFullPathNameW(rawPath, requiredLength, fullBuffer, null)
+            if (resolvedLength == 0u) null else fullBuffer.toKStringFromUtf16()
+        }
     }
 }
 

--- a/filekit-dialogs/build.gradle.kts
+++ b/filekit-dialogs/build.gradle.kts
@@ -10,6 +10,16 @@ kotlin {
         }
     }
 
+    mingwX64 {
+        compilations.getByName("main") {
+            cinterops {
+                val comdialogs by creating {
+                    defFile(project.file("src/mingwX64Main/cinterop/comdialogs.def"))
+                }
+            }
+        }
+    }
+
     sourceSets {
         commonMain.dependencies {
             api(projects.filekitCore)

--- a/filekit-dialogs/src/mingwX64Main/cinterop/comdialogs.def
+++ b/filekit-dialogs/src/mingwX64Main/cinterop/comdialogs.def
@@ -1,0 +1,112 @@
+headers = windows.h shobjidl.h
+headerFilter = **
+compilerOpts = -DCOBJMACROS -DCINTEROP_FILE_DIALOG
+linkerOpts = -lole32 -lshell32 -luuid
+
+---
+
+#include <windows.h>
+#include <shobjidl.h>
+#include <initguid.h>
+
+// Define GUIDs
+DEFINE_GUID(CLSID_FileOpenDialog_,  0xDC1C5A9C, 0xE88A, 0x4DDE, 0xA5, 0xA1, 0x60, 0xF8, 0x2A, 0x20, 0xAE, 0xF7);
+DEFINE_GUID(CLSID_FileSaveDialog_,  0xC0B4E2F3, 0xBA21, 0x4773, 0x8D, 0xBA, 0x33, 0x5E, 0xC9, 0x46, 0xEB, 0x8B);
+DEFINE_GUID(IID_IFileOpenDialog_,   0xD57C7288, 0xD4AD, 0x4768, 0xBE, 0x02, 0x9D, 0x96, 0x95, 0x32, 0xD9, 0x60);
+DEFINE_GUID(IID_IFileSaveDialog_,   0x84BCCD23, 0x5FDE, 0x4CDB, 0xAE, 0xA4, 0xAF, 0x64, 0xB8, 0x3D, 0x78, 0xAB);
+DEFINE_GUID(IID_IShellItem_,        0x43826D1E, 0xE718, 0x42EE, 0xBC, 0x55, 0xA1, 0xE2, 0x61, 0xC3, 0x7B, 0xFE);
+
+// FOS constants
+#define FK_FOS_OVERWRITEPROMPT  0x2
+#define FK_FOS_PICKFOLDERS      0x20
+#define FK_FOS_FORCEFILESYSTEM  0x40
+#define FK_FOS_ALLOWMULTISELECT 0x200
+#define FK_FOS_PATHMUSTEXIST    0x800
+#define FK_FOS_FILEMUSTEXIST    0x1000
+
+#define FK_SIGDN_FILESYSPATH           0x80058000
+#define FK_SIGDN_DESKTOPABSOLUTEPARSING 0x80028000
+
+static inline HRESULT fk_create_open_dialog(IFileOpenDialog** ppDialog) {
+    return CoCreateInstance(&CLSID_FileOpenDialog_, NULL, CLSCTX_ALL, &IID_IFileOpenDialog_, (void**)ppDialog);
+}
+
+static inline HRESULT fk_create_save_dialog(IFileSaveDialog** ppDialog) {
+    return CoCreateInstance(&CLSID_FileSaveDialog_, NULL, CLSCTX_ALL, &IID_IFileSaveDialog_, (void**)ppDialog);
+}
+
+static inline HRESULT fk_dialog_show(IFileDialog* dlg, HWND hwnd) {
+    return IFileDialog_Show(dlg, hwnd);
+}
+
+static inline HRESULT fk_dialog_set_options(IFileDialog* dlg, DWORD opts) {
+    return IFileDialog_SetOptions(dlg, opts);
+}
+
+static inline HRESULT fk_dialog_get_options(IFileDialog* dlg, DWORD* opts) {
+    return IFileDialog_GetOptions(dlg, opts);
+}
+
+static inline HRESULT fk_dialog_set_title(IFileDialog* dlg, LPCWSTR title) {
+    return IFileDialog_SetTitle(dlg, title);
+}
+
+static inline HRESULT fk_dialog_set_filename(IFileDialog* dlg, LPCWSTR name) {
+    return IFileDialog_SetFileName(dlg, name);
+}
+
+static inline HRESULT fk_dialog_set_default_extension(IFileDialog* dlg, LPCWSTR ext) {
+    return IFileDialog_SetDefaultExtension(dlg, ext);
+}
+
+static inline HRESULT fk_dialog_set_folder(IFileDialog* dlg, IShellItem* folder) {
+    return IFileDialog_SetFolder(dlg, folder);
+}
+
+static inline HRESULT fk_dialog_set_file_types(IFileDialog* dlg, UINT count, const COMDLG_FILTERSPEC* specs) {
+    return IFileDialog_SetFileTypes(dlg, count, specs);
+}
+
+static inline HRESULT fk_dialog_get_result(IFileDialog* dlg, IShellItem** ppItem) {
+    return IFileDialog_GetResult(dlg, ppItem);
+}
+
+static inline HRESULT fk_open_dialog_get_results(IFileOpenDialog* dlg, IShellItemArray** ppItems) {
+    return IFileOpenDialog_GetResults(dlg, ppItems);
+}
+
+static inline HRESULT fk_shell_item_get_display_name(IShellItem* item, SIGDN sigdn, LPWSTR* ppName) {
+    return IShellItem_GetDisplayName(item, sigdn, ppName);
+}
+
+static inline void fk_shell_item_release(IShellItem* item) {
+    IShellItem_Release(item);
+}
+
+static inline void fk_dialog_release(IFileDialog* dlg) {
+    IFileDialog_Release(dlg);
+}
+
+static inline void fk_open_dialog_release(IFileOpenDialog* dlg) {
+    IFileOpenDialog_Release(dlg);
+}
+
+static inline void fk_save_dialog_release(IFileSaveDialog* dlg) {
+    IFileSaveDialog_Release(dlg);
+}
+
+static inline void fk_shell_item_array_release(IShellItemArray* arr) {
+    IShellItemArray_Release(arr);
+}
+
+static inline HRESULT fk_shell_item_array_get_count(IShellItemArray* arr, DWORD* count) {
+    return IShellItemArray_GetCount(arr, count);
+}
+
+static inline HRESULT fk_shell_item_array_get_item_at(IShellItemArray* arr, DWORD index, IShellItem** ppItem) {
+    return IShellItemArray_GetItemAt(arr, index, ppItem);
+}
+
+static inline HRESULT fk_create_shell_item_from_path(LPCWSTR path, IShellItem** ppItem) {
+    return SHCreateItemFromParsingName(path, NULL, &IID_IShellItem_, (void**)ppItem);
+}

--- a/filekit-dialogs/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.mingw.kt
+++ b/filekit-dialogs/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.mingw.kt
@@ -1,0 +1,246 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package io.github.vinceglb.filekit.dialogs
+
+import comdialogs.FK_FOS_ALLOWMULTISELECT
+import comdialogs.FK_FOS_FILEMUSTEXIST
+import comdialogs.FK_FOS_FORCEFILESYSTEM
+import comdialogs.FK_FOS_OVERWRITEPROMPT
+import comdialogs.FK_FOS_PATHMUSTEXIST
+import comdialogs.FK_FOS_PICKFOLDERS
+import comdialogs.FK_SIGDN_DESKTOPABSOLUTEPARSING
+import comdialogs.FK_SIGDN_FILESYSPATH
+import comdialogs.fk_create_open_dialog
+import comdialogs.fk_create_save_dialog
+import comdialogs.fk_create_shell_item_from_path
+import comdialogs.fk_dialog_get_options
+import comdialogs.fk_dialog_get_result
+import comdialogs.fk_dialog_set_default_extension
+import comdialogs.fk_dialog_set_file_types
+import comdialogs.fk_dialog_set_filename
+import comdialogs.fk_dialog_set_folder
+import comdialogs.fk_dialog_set_options
+import comdialogs.fk_dialog_set_title
+import comdialogs.fk_dialog_show
+import comdialogs.fk_open_dialog_get_results
+import comdialogs.fk_open_dialog_release
+import comdialogs.fk_save_dialog_release
+import comdialogs.fk_shell_item_array_get_count
+import comdialogs.fk_shell_item_array_get_item_at
+import comdialogs.fk_shell_item_array_release
+import comdialogs.fk_shell_item_get_display_name
+import comdialogs.fk_shell_item_release
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.path
+import kotlinx.cinterop.ByteVar
+import kotlinx.cinterop.CPointer
+import kotlinx.cinterop.CPointerVar
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.MemScope
+import kotlinx.cinterop.UShortVar
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.allocArray
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.set
+import kotlinx.cinterop.toKStringFromUtf16
+import kotlinx.cinterop.value
+import kotlinx.cinterop.wcstr
+import kotlinx.coroutines.flow.Flow
+import platform.windows.COINIT_APARTMENTTHREADED
+import platform.windows.COINIT_DISABLE_OLE1DDE
+import platform.windows.CoInitializeEx
+import platform.windows.CoTaskMemFree
+import platform.windows.CoUninitialize
+import platform.windows.DWORDVar
+import platform.windows.S_OK
+import platform.windows.ShellExecuteW
+
+// Opaque pointer type for COM objects (cinterop doesn't export C++ interfaces)
+private typealias ComPtr = CPointer<ByteVar>
+private typealias ComPtrVar = CPointerVar<ByteVar>
+
+internal actual suspend fun FileKit.platformOpenFilePicker(
+    type: FileKitType,
+    mode: PickerMode,
+    directory: PlatformFile?,
+    dialogSettings: FileKitDialogSettings,
+): Flow<FileKitPickerState<List<PlatformFile>>> {
+    val extensions = when (type) {
+        FileKitType.Image -> imageExtensions
+        FileKitType.Video -> videoExtensions
+        FileKitType.ImageAndVideo -> imageExtensions + videoExtensions
+        is FileKitType.File -> type.extensions
+    }
+    return showOpenDialog(extensions, directory, dialogSettings.title, pickFolders = false, mode is PickerMode.Multiple)
+        .toPickerStateFlow()
+}
+
+public actual suspend fun FileKit.openDirectoryPicker(
+    directory: PlatformFile?,
+    dialogSettings: FileKitDialogSettings,
+): PlatformFile? =
+    showOpenDialog(null, directory, dialogSettings.title, pickFolders = true, allowMultiple = false)
+        ?.firstOrNull()
+
+public actual suspend fun FileKit.openFileSaver(
+    suggestedName: String,
+    extension: String?,
+    directory: PlatformFile?,
+    dialogSettings: FileKitDialogSettings,
+): PlatformFile? {
+    val ext = normalizeFileSaverExtension(extension)
+    return showSaveDialog(buildFileSaverSuggestedName(suggestedName, ext), ext, directory, dialogSettings.title)
+}
+
+public actual fun FileKit.openFileWithDefaultApplication(
+    file: PlatformFile,
+    openFileSettings: FileKitOpenFileSettings,
+) {
+    ShellExecuteW(null, "open", file.path, null, null, 1)
+}
+
+private fun showOpenDialog(
+    extensions: Set<String>?,
+    directory: PlatformFile?,
+    title: String?,
+    pickFolders: Boolean,
+    allowMultiple: Boolean,
+): List<PlatformFile>? = memScoped {
+    CoInitializeEx(null, (COINIT_APARTMENTTHREADED or COINIT_DISABLE_OLE1DDE).toUInt())
+    val ppDlg = alloc<ComPtrVar>()
+    try {
+        if (fk_create_open_dialog(ppDlg.ptr.reinterpret()) != S_OK) return@memScoped null
+        val dlg = ppDlg.value ?: return@memScoped null
+
+        // Options
+        val optsVar = alloc<DWORDVar>()
+        fk_dialog_get_options(dlg.reinterpret(), optsVar.ptr)
+        var opts = optsVar.value.toInt() or FK_FOS_FORCEFILESYSTEM or FK_FOS_PATHMUSTEXIST
+        if (pickFolders) opts = opts or FK_FOS_PICKFOLDERS else opts = opts or FK_FOS_FILEMUSTEXIST
+        if (allowMultiple) opts = opts or FK_FOS_ALLOWMULTISELECT
+        fk_dialog_set_options(dlg.reinterpret(), opts.toUInt())
+
+        title?.let { fk_dialog_set_title(dlg.reinterpret(), it) }
+        directory?.let { setFolder(dlg, it) }
+        if (!extensions.isNullOrEmpty() && !pickFolders) setFileTypes(dlg, extensions)
+
+        val hr = fk_dialog_show(dlg.reinterpret(), null)
+        if (hr != S_OK) return@memScoped null
+
+        if (allowMultiple) {
+            getMultipleResults(dlg)
+        } else {
+            val sigdn = if (pickFolders) FK_SIGDN_DESKTOPABSOLUTEPARSING.toInt() else FK_SIGDN_FILESYSPATH.toInt()
+            getSingleResult(dlg, sigdn)?.let { listOf(it) }
+        }
+    } finally {
+        ppDlg.value?.let { fk_open_dialog_release(it.reinterpret()) }
+        CoUninitialize()
+    }
+}
+
+private fun showSaveDialog(
+    suggestedName: String,
+    extension: String?,
+    directory: PlatformFile?,
+    title: String?,
+): PlatformFile? = memScoped {
+    CoInitializeEx(null, (COINIT_APARTMENTTHREADED or COINIT_DISABLE_OLE1DDE).toUInt())
+    val ppDlg = alloc<ComPtrVar>()
+    try {
+        if (fk_create_save_dialog(ppDlg.ptr.reinterpret()) != S_OK) return@memScoped null
+        val dlg = ppDlg.value ?: return@memScoped null
+
+        val optsVar = alloc<DWORDVar>()
+        fk_dialog_get_options(dlg.reinterpret(), optsVar.ptr)
+        val opts = optsVar.value.toInt() or FK_FOS_FORCEFILESYSTEM or FK_FOS_PATHMUSTEXIST or FK_FOS_OVERWRITEPROMPT
+        fk_dialog_set_options(dlg.reinterpret(), opts.toUInt())
+
+        title?.let { fk_dialog_set_title(dlg.reinterpret(), it) }
+        fk_dialog_set_filename(dlg.reinterpret(), suggestedName)
+        extension?.let {
+            fk_dialog_set_default_extension(dlg.reinterpret(), it)
+            setFileTypes(dlg, setOf(it))
+        }
+        directory?.let { setFolder(dlg, it) }
+
+        val hr = fk_dialog_show(dlg.reinterpret(), null)
+        if (hr != S_OK) return@memScoped null
+        getSingleResult(dlg, FK_SIGDN_FILESYSPATH.toInt())
+    } finally {
+        ppDlg.value?.let { fk_save_dialog_release(it.reinterpret()) }
+        CoUninitialize()
+    }
+}
+
+// region Helpers
+
+private fun MemScope.setFolder(dlg: ComPtr, dir: PlatformFile) {
+    val ppsi = alloc<ComPtrVar>()
+    if (fk_create_shell_item_from_path(dir.path, ppsi.ptr.reinterpret()) != S_OK) return
+    val folder = ppsi.value ?: return
+    try {
+        fk_dialog_set_folder(dlg.reinterpret(), folder.reinterpret())
+    } finally {
+        fk_shell_item_release(folder.reinterpret())
+    }
+}
+
+private fun MemScope.setFileTypes(dlg: ComPtr, exts: Set<String>) {
+    val display = exts.joinToString(", ") { "*.$it" }
+    val pattern = exts.joinToString(";") { "*.$it" }
+    // COMDLG_FILTERSPEC = { LPCWSTR pszName; LPCWSTR pszSpec; } = two consecutive pointers
+    val spec = allocArray<CPointerVar<UShortVar>>(2)
+    spec[0] = display.wcstr.ptr
+    spec[1] = pattern.wcstr.ptr
+    fk_dialog_set_file_types(dlg.reinterpret(), 1u, spec.reinterpret())
+}
+
+private fun MemScope.getSingleResult(dlg: ComPtr, sigdn: Int): PlatformFile? {
+    val ppsi = alloc<ComPtrVar>()
+    if (fk_dialog_get_result(dlg.reinterpret(), ppsi.ptr.reinterpret()) != S_OK) return null
+    val item = ppsi.value ?: return null
+    try {
+        return shellItemToFile(item, sigdn)
+    } finally {
+        fk_shell_item_release(item.reinterpret())
+    }
+}
+
+private fun MemScope.getMultipleResults(dlg: ComPtr): List<PlatformFile> {
+    val ppArr = alloc<ComPtrVar>()
+    if (fk_open_dialog_get_results(dlg.reinterpret(), ppArr.ptr.reinterpret()) != S_OK) return emptyList()
+    val arr = ppArr.value ?: return emptyList()
+    try {
+        val cntVar = alloc<DWORDVar>()
+        fk_shell_item_array_get_count(arr.reinterpret(), cntVar.ptr)
+        return (0 until cntVar.value.toInt()).mapNotNull { i ->
+            val ppsi = alloc<ComPtrVar>()
+            if (fk_shell_item_array_get_item_at(arr.reinterpret(), i.toUInt(), ppsi.ptr.reinterpret()) != S_OK) return@mapNotNull null
+            val item = ppsi.value ?: return@mapNotNull null
+            try {
+                shellItemToFile(item, FK_SIGDN_FILESYSPATH.toInt())
+            } finally {
+                fk_shell_item_release(item.reinterpret())
+            }
+        }
+    } finally {
+        fk_shell_item_array_release(arr.reinterpret())
+    }
+}
+
+private fun MemScope.shellItemToFile(item: ComPtr, sigdn: Int): PlatformFile? {
+    val ppName = alloc<CPointerVar<UShortVar>>()
+    if (fk_shell_item_get_display_name(item.reinterpret(), sigdn, ppName.ptr.reinterpret()) != S_OK) return null
+    val namePtr = ppName.value ?: return null
+    try {
+        return PlatformFile(namePtr.toKStringFromUtf16())
+    } finally {
+        CoTaskMemFree(namePtr)
+    }
+}
+
+// endregion

--- a/filekit-dialogs/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.mingw.kt
+++ b/filekit-dialogs/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.mingw.kt
@@ -61,6 +61,10 @@ import platform.windows.ShellExecuteW
 // Opaque pointer type for COM objects (cinterop doesn't export C++ interfaces)
 private typealias ComPtr = CPointer<ByteVar>
 private typealias ComPtrVar = CPointerVar<ByteVar>
+private const val S_FALSE_HRESULT = 1
+private val ERROR_CANCELLED_HRESULT = 0x800704C7u.toInt()
+private val ERROR_FILE_NOT_FOUND_HRESULT = 0x80070002u.toInt()
+private val ERROR_INVALID_DRIVE_HRESULT = 0x8007000Fu.toInt()
 
 internal actual suspend fun FileKit.platformOpenFilePicker(
     type: FileKitType,
@@ -109,26 +113,46 @@ private fun showOpenDialog(
     pickFolders: Boolean,
     allowMultiple: Boolean,
 ): List<PlatformFile>? = memScoped {
-    CoInitializeEx(null, (COINIT_APARTMENTTHREADED or COINIT_DISABLE_OLE1DDE).toUInt())
+    val comInitialized = initializeComForDialogs()
     val ppDlg = alloc<ComPtrVar>()
     try {
-        if (fk_create_open_dialog(ppDlg.ptr.reinterpret()) != S_OK) return@memScoped null
-        val dlg = ppDlg.value ?: return@memScoped null
+        val createHr = fk_create_open_dialog(ppDlg.ptr.reinterpret())
+        if (createHr != S_OK) {
+            throw IllegalStateException("CoCreateInstance(IFileOpenDialog) failed with HRESULT 0x${createHr.toUInt().toString(16)}")
+        }
+        val dlg = ppDlg.value
+            ?: throw IllegalStateException("CoCreateInstance(IFileOpenDialog) returned a null dialog pointer")
 
         // Options
         val optsVar = alloc<DWORDVar>()
-        fk_dialog_get_options(dlg.reinterpret(), optsVar.ptr)
+        val getOptionsHr = fk_dialog_get_options(dlg.reinterpret(), optsVar.ptr)
+        if (getOptionsHr != S_OK) {
+            throw IllegalStateException("IFileDialog::GetOptions failed with HRESULT 0x${getOptionsHr.toUInt().toString(16)}")
+        }
         var opts = optsVar.value.toInt() or FK_FOS_FORCEFILESYSTEM or FK_FOS_PATHMUSTEXIST
         if (pickFolders) opts = opts or FK_FOS_PICKFOLDERS else opts = opts or FK_FOS_FILEMUSTEXIST
         if (allowMultiple) opts = opts or FK_FOS_ALLOWMULTISELECT
-        fk_dialog_set_options(dlg.reinterpret(), opts.toUInt())
+        val setOptionsHr = fk_dialog_set_options(dlg.reinterpret(), opts.toUInt())
+        if (setOptionsHr != S_OK) {
+            throw IllegalStateException("IFileDialog::SetOptions failed with HRESULT 0x${setOptionsHr.toUInt().toString(16)}")
+        }
 
-        title?.let { fk_dialog_set_title(dlg.reinterpret(), it) }
+        title?.let {
+            val setTitleHr = fk_dialog_set_title(dlg.reinterpret(), it)
+            if (setTitleHr != S_OK) {
+                throw IllegalStateException("IFileDialog::SetTitle failed with HRESULT 0x${setTitleHr.toUInt().toString(16)}")
+            }
+        }
         directory?.let { setFolder(dlg, it) }
         if (!extensions.isNullOrEmpty() && !pickFolders) setFileTypes(dlg, extensions)
 
         val hr = fk_dialog_show(dlg.reinterpret(), null)
-        if (hr != S_OK) return@memScoped null
+        if (hr != S_OK) {
+            if (hr == ERROR_CANCELLED_HRESULT) {
+                return@memScoped null
+            }
+            throw IllegalStateException("IFileOpenDialog::Show failed with HRESULT 0x${hr.toUInt().toString(16)}")
+        }
 
         if (allowMultiple) {
             getMultipleResults(dlg)
@@ -138,7 +162,9 @@ private fun showOpenDialog(
         }
     } finally {
         ppDlg.value?.let { fk_open_dialog_release(it.reinterpret()) }
-        CoUninitialize()
+        if (comInitialized) {
+            CoUninitialize()
+        }
     }
 }
 
@@ -148,39 +174,86 @@ private fun showSaveDialog(
     directory: PlatformFile?,
     title: String?,
 ): PlatformFile? = memScoped {
-    CoInitializeEx(null, (COINIT_APARTMENTTHREADED or COINIT_DISABLE_OLE1DDE).toUInt())
+    val comInitialized = initializeComForDialogs()
     val ppDlg = alloc<ComPtrVar>()
     try {
-        if (fk_create_save_dialog(ppDlg.ptr.reinterpret()) != S_OK) return@memScoped null
-        val dlg = ppDlg.value ?: return@memScoped null
+        val createHr = fk_create_save_dialog(ppDlg.ptr.reinterpret())
+        if (createHr != S_OK) {
+            throw IllegalStateException("CoCreateInstance(IFileSaveDialog) failed with HRESULT 0x${createHr.toUInt().toString(16)}")
+        }
+        val dlg = ppDlg.value
+            ?: throw IllegalStateException("CoCreateInstance(IFileSaveDialog) returned a null dialog pointer")
 
         val optsVar = alloc<DWORDVar>()
-        fk_dialog_get_options(dlg.reinterpret(), optsVar.ptr)
+        val getOptionsHr = fk_dialog_get_options(dlg.reinterpret(), optsVar.ptr)
+        if (getOptionsHr != S_OK) {
+            throw IllegalStateException("IFileDialog::GetOptions failed with HRESULT 0x${getOptionsHr.toUInt().toString(16)}")
+        }
         val opts = optsVar.value.toInt() or FK_FOS_FORCEFILESYSTEM or FK_FOS_PATHMUSTEXIST or FK_FOS_OVERWRITEPROMPT
-        fk_dialog_set_options(dlg.reinterpret(), opts.toUInt())
+        val setOptionsHr = fk_dialog_set_options(dlg.reinterpret(), opts.toUInt())
+        if (setOptionsHr != S_OK) {
+            throw IllegalStateException("IFileDialog::SetOptions failed with HRESULT 0x${setOptionsHr.toUInt().toString(16)}")
+        }
 
-        title?.let { fk_dialog_set_title(dlg.reinterpret(), it) }
-        fk_dialog_set_filename(dlg.reinterpret(), suggestedName)
+        title?.let {
+            val setTitleHr = fk_dialog_set_title(dlg.reinterpret(), it)
+            if (setTitleHr != S_OK) {
+                throw IllegalStateException("IFileDialog::SetTitle failed with HRESULT 0x${setTitleHr.toUInt().toString(16)}")
+            }
+        }
+        val setFilenameHr = fk_dialog_set_filename(dlg.reinterpret(), suggestedName)
+        if (setFilenameHr != S_OK) {
+            throw IllegalStateException("IFileDialog::SetFileName failed with HRESULT 0x${setFilenameHr.toUInt().toString(16)}")
+        }
         extension?.let {
-            fk_dialog_set_default_extension(dlg.reinterpret(), it)
+            val setDefaultExtensionHr = fk_dialog_set_default_extension(dlg.reinterpret(), it)
+            if (setDefaultExtensionHr != S_OK) {
+                throw IllegalStateException("IFileDialog::SetDefaultExtension failed with HRESULT 0x${setDefaultExtensionHr.toUInt().toString(16)}")
+            }
             setFileTypes(dlg, setOf(it))
         }
         directory?.let { setFolder(dlg, it) }
 
         val hr = fk_dialog_show(dlg.reinterpret(), null)
-        if (hr != S_OK) return@memScoped null
+        if (hr != S_OK) {
+            if (hr == ERROR_CANCELLED_HRESULT) {
+                return@memScoped null
+            }
+            throw IllegalStateException("IFileSaveDialog::Show failed with HRESULT 0x${hr.toUInt().toString(16)}")
+        }
         getSingleResult(dlg, FK_SIGDN_FILESYSPATH.toInt())
     } finally {
         ppDlg.value?.let { fk_save_dialog_release(it.reinterpret()) }
-        CoUninitialize()
+        if (comInitialized) {
+            CoUninitialize()
+        }
     }
 }
 
 // region Helpers
 
+private fun initializeComForDialogs(): Boolean {
+    val result = CoInitializeEx(
+        null,
+        COINIT_APARTMENTTHREADED or COINIT_DISABLE_OLE1DDE,
+    )
+
+    if (result == S_OK || result == S_FALSE_HRESULT) {
+        return true
+    }
+
+    throw IllegalStateException("CoInitializeEx failed with HRESULT 0x${result.toUInt().toString(16)}")
+}
+
 private fun MemScope.setFolder(dlg: ComPtr, dir: PlatformFile) {
     val ppsi = alloc<ComPtrVar>()
-    if (fk_create_shell_item_from_path(dir.path, ppsi.ptr.reinterpret()) != S_OK) return
+    val hr = fk_create_shell_item_from_path(dir.path, ppsi.ptr.reinterpret())
+    if (hr != S_OK) {
+        if (hr == ERROR_FILE_NOT_FOUND_HRESULT || hr == ERROR_INVALID_DRIVE_HRESULT) {
+            return
+        }
+        throw IllegalStateException("SHCreateItemFromParsingName failed with HRESULT 0x${hr.toUInt().toString(16)}")
+    }
     val folder = ppsi.value ?: return
     try {
         fk_dialog_set_folder(dlg.reinterpret(), folder.reinterpret())
@@ -196,13 +269,20 @@ private fun MemScope.setFileTypes(dlg: ComPtr, exts: Set<String>) {
     val spec = allocArray<CPointerVar<UShortVar>>(2)
     spec[0] = display.wcstr.ptr
     spec[1] = pattern.wcstr.ptr
-    fk_dialog_set_file_types(dlg.reinterpret(), 1u, spec.reinterpret())
+    val hr = fk_dialog_set_file_types(dlg.reinterpret(), 1u, spec.reinterpret())
+    if (hr != S_OK) {
+        throw IllegalStateException("IFileDialog::SetFileTypes failed with HRESULT 0x${hr.toUInt().toString(16)}")
+    }
 }
 
 private fun MemScope.getSingleResult(dlg: ComPtr, sigdn: Int): PlatformFile? {
     val ppsi = alloc<ComPtrVar>()
-    if (fk_dialog_get_result(dlg.reinterpret(), ppsi.ptr.reinterpret()) != S_OK) return null
-    val item = ppsi.value ?: return null
+    val hr = fk_dialog_get_result(dlg.reinterpret(), ppsi.ptr.reinterpret())
+    if (hr != S_OK) {
+        throw IllegalStateException("IFileDialog::GetResult failed with HRESULT 0x${hr.toUInt().toString(16)}")
+    }
+    val item = ppsi.value
+        ?: throw IllegalStateException("IFileDialog::GetResult returned a null result item")
     try {
         return shellItemToFile(item, sigdn)
     } finally {
@@ -212,15 +292,26 @@ private fun MemScope.getSingleResult(dlg: ComPtr, sigdn: Int): PlatformFile? {
 
 private fun MemScope.getMultipleResults(dlg: ComPtr): List<PlatformFile> {
     val ppArr = alloc<ComPtrVar>()
-    if (fk_open_dialog_get_results(dlg.reinterpret(), ppArr.ptr.reinterpret()) != S_OK) return emptyList()
-    val arr = ppArr.value ?: return emptyList()
+    val resultsHr = fk_open_dialog_get_results(dlg.reinterpret(), ppArr.ptr.reinterpret())
+    if (resultsHr != S_OK) {
+        throw IllegalStateException("IFileOpenDialog::GetResults failed with HRESULT 0x${resultsHr.toUInt().toString(16)}")
+    }
+    val arr = ppArr.value
+        ?: throw IllegalStateException("IFileOpenDialog::GetResults returned a null result array")
     try {
         val cntVar = alloc<DWORDVar>()
-        fk_shell_item_array_get_count(arr.reinterpret(), cntVar.ptr)
+        val countHr = fk_shell_item_array_get_count(arr.reinterpret(), cntVar.ptr)
+        if (countHr != S_OK) {
+            throw IllegalStateException("IShellItemArray::GetCount failed with HRESULT 0x${countHr.toUInt().toString(16)}")
+        }
         return (0 until cntVar.value.toInt()).mapNotNull { i ->
             val ppsi = alloc<ComPtrVar>()
-            if (fk_shell_item_array_get_item_at(arr.reinterpret(), i.toUInt(), ppsi.ptr.reinterpret()) != S_OK) return@mapNotNull null
-            val item = ppsi.value ?: return@mapNotNull null
+            val itemHr = fk_shell_item_array_get_item_at(arr.reinterpret(), i.toUInt(), ppsi.ptr.reinterpret())
+            if (itemHr != S_OK) {
+                throw IllegalStateException("IShellItemArray::GetItemAt failed with HRESULT 0x${itemHr.toUInt().toString(16)}")
+            }
+            val item = ppsi.value
+                ?: throw IllegalStateException("IShellItemArray::GetItemAt returned a null shell item")
             try {
                 shellItemToFile(item, FK_SIGDN_FILESYSPATH.toInt())
             } finally {
@@ -234,8 +325,12 @@ private fun MemScope.getMultipleResults(dlg: ComPtr): List<PlatformFile> {
 
 private fun MemScope.shellItemToFile(item: ComPtr, sigdn: Int): PlatformFile? {
     val ppName = alloc<CPointerVar<UShortVar>>()
-    if (fk_shell_item_get_display_name(item.reinterpret(), sigdn, ppName.ptr.reinterpret()) != S_OK) return null
-    val namePtr = ppName.value ?: return null
+    val hr = fk_shell_item_get_display_name(item.reinterpret(), sigdn, ppName.ptr.reinterpret())
+    if (hr != S_OK) {
+        throw IllegalStateException("IShellItem::GetDisplayName failed with HRESULT 0x${hr.toUInt().toString(16)}")
+    }
+    val namePtr = ppName.value
+        ?: throw IllegalStateException("IShellItem::GetDisplayName returned a null display name")
     try {
         return PlatformFile(namePtr.toKStringFromUtf16())
     } finally {

--- a/filekit-dialogs/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/dialogs/FileKitDialogSettings.mingw.kt
+++ b/filekit-dialogs/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/dialogs/FileKitDialogSettings.mingw.kt
@@ -1,0 +1,14 @@
+package io.github.vinceglb.filekit.dialogs
+
+/**
+ * Windows native implementation of [FileKitDialogSettings].
+ *
+ * @property title The title of the dialog.
+ */
+public actual class FileKitDialogSettings(
+    public val title: String? = null,
+) {
+    public actual companion object {
+        public actual fun createDefault(): FileKitDialogSettings = FileKitDialogSettings()
+    }
+}

--- a/filekit-dialogs/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/dialogs/FileKitOpenFileSettings.mingw.kt
+++ b/filekit-dialogs/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/dialogs/FileKitOpenFileSettings.mingw.kt
@@ -1,0 +1,11 @@
+package io.github.vinceglb.filekit.dialogs
+
+/**
+ * Windows native implementation of [FileKitOpenFileSettings].
+ * Currently, there are no specific settings for opening files on Windows native.
+ */
+public actual class FileKitOpenFileSettings {
+    public actual companion object {
+        public actual fun createDefault(): FileKitOpenFileSettings = FileKitOpenFileSettings()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.0.0-alpha06"
+agp = "9.1.0"
 android-compileSdk = "36"
 android-minSdk = "23"
 android-targetSdk = "36"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "9.1.0"
+agp = "9.0.0-alpha06"
 android-compileSdk = "36"
 android-minSdk = "23"
 android-targetSdk = "36"

--- a/sample/windowsNativeApp/build.gradle.kts
+++ b/sample/windowsNativeApp/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+}
+
+kotlin {
+    mingwX64 {
+        binaries {
+            executable {
+                entryPoint = "io.github.vinceglb.filekit.sample.main"
+                linkerOpts("-lcomdlg32", "-lole32", "-lshell32", "-ladvapi32")
+            }
+        }
+    }
+
+    sourceSets {
+        val mingwX64Main by getting {
+            dependencies {
+                implementation(projects.filekitCore)
+                implementation(projects.filekitDialogs)
+                implementation(libs.kotlinx.coroutines.core)
+            }
+        }
+    }
+}

--- a/sample/windowsNativeApp/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/sample/Main.kt
+++ b/sample/windowsNativeApp/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/sample/Main.kt
@@ -1,0 +1,420 @@
+@file:OptIn(ExperimentalForeignApi::class)
+
+package io.github.vinceglb.filekit.sample
+
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.cacheDir
+import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+import io.github.vinceglb.filekit.dialogs.FileKitType
+import io.github.vinceglb.filekit.dialogs.openDirectoryPicker
+import io.github.vinceglb.filekit.dialogs.openFilePicker
+import io.github.vinceglb.filekit.dialogs.openFileSaver
+import io.github.vinceglb.filekit.dialogs.openFileWithDefaultApplication
+import io.github.vinceglb.filekit.documentsDir
+import io.github.vinceglb.filekit.downloadsDir
+import io.github.vinceglb.filekit.exists
+import io.github.vinceglb.filekit.extension
+import io.github.vinceglb.filekit.filesDir
+import io.github.vinceglb.filekit.isDirectory
+import io.github.vinceglb.filekit.lastModified
+import io.github.vinceglb.filekit.list
+import io.github.vinceglb.filekit.mimeType
+import io.github.vinceglb.filekit.name
+import io.github.vinceglb.filekit.path
+import io.github.vinceglb.filekit.picturesDir
+import io.github.vinceglb.filekit.readString
+import io.github.vinceglb.filekit.resolve
+import io.github.vinceglb.filekit.size
+import io.github.vinceglb.filekit.writeString
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.alloc
+import kotlinx.cinterop.memScoped
+import kotlinx.cinterop.pointed
+import kotlinx.cinterop.ptr
+import kotlinx.cinterop.reinterpret
+import kotlinx.cinterop.staticCFunction
+import kotlinx.cinterop.toCPointer
+import kotlinx.cinterop.toLong
+import kotlinx.cinterop.wcstr
+import kotlinx.coroutines.runBlocking
+import platform.windows.BS_PUSHBUTTON
+import platform.windows.COLOR_WINDOW
+import platform.windows.CS_HREDRAW
+import platform.windows.CS_VREDRAW
+import platform.windows.CW_USEDEFAULT
+import platform.windows.CreateWindowExW
+import platform.windows.DefWindowProcW
+import platform.windows.DispatchMessageW
+import platform.windows.ES_AUTOVSCROLL
+import platform.windows.ES_MULTILINE
+import platform.windows.ES_READONLY
+import platform.windows.GetMessageW
+import platform.windows.GetModuleHandleW
+import platform.windows.HWND
+import platform.windows.IDC_ARROW
+import platform.windows.LPARAM
+import platform.windows.LRESULT
+import platform.windows.LoadCursorW
+import platform.windows.MSG
+import platform.windows.PostQuitMessage
+import platform.windows.RegisterClassExW
+import platform.windows.SW_SHOWDEFAULT
+import platform.windows.SendMessageW
+import platform.windows.ShowWindow
+import platform.windows.TranslateMessage
+import platform.windows.UINT
+import platform.windows.UpdateWindow
+import platform.windows.WM_CLOSE
+import platform.windows.WM_COMMAND
+import platform.windows.WM_CREATE
+import platform.windows.WM_DESTROY
+import platform.windows.WM_SETFONT
+import platform.windows.WNDCLASSEXW
+import platform.windows.WPARAM
+import platform.windows.WS_CHILD
+import platform.windows.WS_EX_CLIENTEDGE
+import platform.windows.WS_OVERLAPPEDWINDOW
+import platform.windows.WS_TABSTOP
+import platform.windows.WS_VISIBLE
+import platform.windows.WS_VSCROLL
+
+// Button IDs
+private const val ID_BTN_PICK_FILE = 101
+private const val ID_BTN_PICK_IMAGE = 102
+private const val ID_BTN_PICK_DIR = 103
+private const val ID_BTN_SAVE_FILE = 104
+private const val ID_BTN_WRITE_READ = 105
+private const val ID_BTN_LIST_DIR = 106
+private const val ID_BTN_OPEN_DEFAULT = 107
+private const val ID_BTN_SHOW_DIRS = 108
+private const val ID_EDIT_LOG = 201
+
+private var hLog: HWND? = null
+private var hDefaultFont: platform.windows.HFONT? = null
+
+fun main() {
+    FileKit.init("io.github.vinceglb.filekit.sample")
+
+    memScoped {
+        val hInstance = GetModuleHandleW(null)
+        val className = "FileKitSampleWindow"
+
+        // Register window class
+        val wc = alloc<WNDCLASSEXW>()
+        wc.cbSize = kotlinx.cinterop.sizeOf<WNDCLASSEXW>().toUInt()
+        wc.style = (CS_HREDRAW or CS_VREDRAW).toUInt()
+        wc.lpfnWndProc = staticCFunction(::wndProc)
+        wc.hInstance = hInstance
+        wc.hCursor = LoadCursorW(null, IDC_ARROW?.reinterpret())
+        wc.hbrBackground = (COLOR_WINDOW + 1).toLong().toCPointer()
+        wc.lpszClassName = className.wcstr.ptr
+
+        RegisterClassExW(wc.ptr)
+
+        // Create main window
+        val hwnd = CreateWindowExW(
+            dwExStyle = 0u,
+            lpClassName = className,
+            lpWindowName = "FileKit - Windows Native Sample",
+            dwStyle = WS_OVERLAPPEDWINDOW.toUInt(),
+            X = CW_USEDEFAULT,
+            Y = CW_USEDEFAULT,
+            nWidth = 720,
+            nHeight = 620,
+            hWndParent = null,
+            hMenu = null,
+            hInstance = hInstance,
+            lpParam = null,
+        )
+
+        ShowWindow(hwnd, SW_SHOWDEFAULT)
+        UpdateWindow(hwnd)
+
+        // Message loop
+        val msg = alloc<MSG>()
+        while (GetMessageW(msg.ptr, null, 0u, 0u) != 0) {
+            TranslateMessage(msg.ptr)
+            DispatchMessageW(msg.ptr)
+        }
+    }
+}
+
+@Suppress("UNUSED_PARAMETER")
+private fun wndProc(hwnd: HWND?, uMsg: UINT, wParam: WPARAM, lParam: LPARAM): LRESULT {
+    when (uMsg.toInt()) {
+        WM_CREATE -> {
+            createUI(hwnd!!)
+            return 0
+        }
+
+        WM_COMMAND -> {
+            val id = wParam.toInt() and 0xFFFF
+            when (id) {
+                ID_BTN_PICK_FILE -> onPickFile()
+                ID_BTN_PICK_IMAGE -> onPickImage()
+                ID_BTN_PICK_DIR -> onPickDirectory()
+                ID_BTN_SAVE_FILE -> onSaveFile()
+                ID_BTN_WRITE_READ -> onWriteRead()
+                ID_BTN_LIST_DIR -> onListDir()
+                ID_BTN_OPEN_DEFAULT -> onOpenDefault()
+                ID_BTN_SHOW_DIRS -> onShowDirs()
+            }
+            return 0
+        }
+
+        WM_CLOSE -> {
+            platform.windows.DestroyWindow(hwnd)
+            return 0
+        }
+
+        WM_DESTROY -> {
+            PostQuitMessage(0)
+            return 0
+        }
+    }
+    return DefWindowProcW(hwnd, uMsg, wParam, lParam)
+}
+
+private fun createUI(parent: HWND) {
+    val hInstance = GetModuleHandleW(null)
+
+    // Create a default font
+    hDefaultFont = platform.windows.CreateFontW(
+        -14,
+        0,
+        0,
+        0,
+        400, // FW_NORMAL
+        0u,
+        0u,
+        0u,
+        0u,
+        0u,
+        0u,
+        0u,
+        0u,
+        "Segoe UI",
+    )
+
+    var y = 10
+    val btnWidth = 200
+    val btnHeight = 32
+    val spacing = 38
+
+    // Left column: buttons
+    createButton(parent, hInstance, "Pick a File", ID_BTN_PICK_FILE, 15, y, btnWidth, btnHeight)
+    y += spacing
+    createButton(parent, hInstance, "Pick an Image", ID_BTN_PICK_IMAGE, 15, y, btnWidth, btnHeight)
+    y += spacing
+    createButton(parent, hInstance, "Pick a Directory", ID_BTN_PICK_DIR, 15, y, btnWidth, btnHeight)
+    y += spacing
+    createButton(parent, hInstance, "Save a File", ID_BTN_SAVE_FILE, 15, y, btnWidth, btnHeight)
+    y += spacing
+    createButton(parent, hInstance, "Write & Read File", ID_BTN_WRITE_READ, 15, y, btnWidth, btnHeight)
+    y += spacing
+    createButton(parent, hInstance, "List Directory", ID_BTN_LIST_DIR, 15, y, btnWidth, btnHeight)
+    y += spacing
+    createButton(parent, hInstance, "Open with Default App", ID_BTN_OPEN_DEFAULT, 15, y, btnWidth, btnHeight)
+    y += spacing
+    createButton(parent, hInstance, "Show Platform Dirs", ID_BTN_SHOW_DIRS, 15, y, btnWidth, btnHeight)
+
+    // Right side: log area
+    hLog = CreateWindowExW(
+        dwExStyle = WS_EX_CLIENTEDGE.toUInt(),
+        lpClassName = "EDIT",
+        lpWindowName = "",
+        dwStyle = (WS_CHILD or WS_VISIBLE or WS_VSCROLL or ES_MULTILINE or ES_AUTOVSCROLL or ES_READONLY).toUInt(),
+        X = 230,
+        Y = 10,
+        nWidth = 460,
+        nHeight = 555,
+        hWndParent = parent,
+        hMenu = ID_EDIT_LOG.toLong().toCPointer(),
+        hInstance = hInstance,
+        lpParam = null,
+    )
+    setFont(hLog!!)
+
+    log("=== FileKit Windows Native Sample ===\r\nClick a button to try the API.\r\n")
+}
+
+private fun createButton(
+    parent: HWND,
+    hInstance: platform.windows.HINSTANCE?,
+    text: String,
+    id: Int,
+    x: Int,
+    y: Int,
+    w: Int,
+    h: Int,
+) {
+    val btn = CreateWindowExW(
+        dwExStyle = 0u,
+        lpClassName = "BUTTON",
+        lpWindowName = text,
+        dwStyle = (WS_TABSTOP or WS_VISIBLE or WS_CHILD or BS_PUSHBUTTON.toInt()).toUInt(),
+        X = x,
+        Y = y,
+        nWidth = w,
+        nHeight = h,
+        hWndParent = parent,
+        hMenu = id.toLong().toCPointer(),
+        hInstance = hInstance,
+        lpParam = null,
+    )
+    setFont(btn!!)
+}
+
+private fun setFont(hwnd: HWND) {
+    hDefaultFont?.let {
+        SendMessageW(hwnd, WM_SETFONT.toUInt(), it.toLong().toULong(), 1L)
+    }
+}
+
+private fun log(text: String) {
+    val h = hLog ?: return
+    // Append text to the edit control
+    val len = platform.windows.GetWindowTextLengthW(h).toLong()
+    SendMessageW(h, platform.windows.EM_SETSEL.toUInt(), len.toULong(), len)
+    memScoped {
+        SendMessageW(h, platform.windows.EM_REPLACESEL.toUInt(), 0u, text.wcstr.ptr.toLong())
+    }
+    // Scroll to bottom
+    SendMessageW(h, platform.windows.EM_SCROLLCARET.toUInt(), 0u, 0)
+}
+
+// --- Button handlers ---
+
+private fun onPickFile() = runBlocking {
+    log("--- Pick a File ---\r\n")
+    val file = FileKit.openFilePicker(
+        dialogSettings = FileKitDialogSettings(title = "Pick any file"),
+    )
+    if (file != null) {
+        logFileInfo(file)
+    } else {
+        log("Cancelled.\r\n")
+    }
+    log("\r\n")
+}
+
+private fun onPickImage() = runBlocking {
+    log("--- Pick an Image ---\r\n")
+    val file = FileKit.openFilePicker(
+        type = FileKitType.Image,
+        dialogSettings = FileKitDialogSettings(title = "Pick an image"),
+    )
+    if (file != null) {
+        logFileInfo(file)
+    } else {
+        log("Cancelled.\r\n")
+    }
+    log("\r\n")
+}
+
+private fun onPickDirectory() = runBlocking {
+    log("--- Pick a Directory ---\r\n")
+    val dir = FileKit.openDirectoryPicker(
+        dialogSettings = FileKitDialogSettings(title = "Pick a directory"),
+    )
+    if (dir != null) {
+        log("Path: ${dir.path}\r\n")
+        log("isDirectory: ${dir.isDirectory()}\r\n")
+    } else {
+        log("Cancelled.\r\n")
+    }
+    log("\r\n")
+}
+
+private fun onSaveFile() = runBlocking {
+    log("--- Save a File ---\r\n")
+    val file = FileKit.openFileSaver(
+        suggestedName = "filekit-sample",
+        extension = "txt",
+        dialogSettings = FileKitDialogSettings(title = "Save a file"),
+    )
+    if (file != null) {
+        file.writeString("Hello from FileKit Windows Native!")
+        log("Saved to: ${file.path}\r\n")
+        log("Content: \"Hello from FileKit Windows Native!\"\r\n")
+    } else {
+        log("Cancelled.\r\n")
+    }
+    log("\r\n")
+}
+
+private fun onWriteRead() = runBlocking {
+    log("--- Write & Read ---\r\n")
+    val testFile = FileKit.filesDir.resolve("test.txt")
+    val content = "Hello from FileKit!\r\nWindows Native target."
+
+    testFile.writeString(content)
+    log("Written to: ${testFile.path}\r\n")
+
+    val readBack = testFile.readString()
+    log("Read back: $readBack\r\n")
+    log("Size: ${testFile.size()} bytes\r\n")
+    log("Last modified: ${testFile.lastModified()}\r\n")
+    log("\r\n")
+}
+
+private fun onListDir() = runBlocking {
+    log("--- List Directory ---\r\n")
+    val dir = FileKit.openDirectoryPicker(
+        dialogSettings = FileKitDialogSettings(title = "Select directory to list"),
+    )
+    if (dir == null) {
+        log("Cancelled.\r\n\r\n")
+        return@runBlocking
+    }
+
+    log("${dir.path}:\r\n")
+    val files = dir.list()
+    if (files.isEmpty()) {
+        log("  (empty)\r\n")
+    } else {
+        files.take(15).forEach { file ->
+            val tag = if (file.isDirectory()) "DIR " else "FILE"
+            log("  [$tag] ${file.name}\r\n")
+        }
+        if (files.size > 15) {
+            log("  ... +${files.size - 15} more\r\n")
+        }
+    }
+    log("\r\n")
+}
+
+private fun onOpenDefault() = runBlocking {
+    log("--- Open with Default App ---\r\n")
+    val file = FileKit.openFilePicker(
+        dialogSettings = FileKitDialogSettings(title = "Pick a file to open"),
+    )
+    if (file != null) {
+        log("Opening: ${file.path}\r\n")
+        FileKit.openFileWithDefaultApplication(file)
+    } else {
+        log("Cancelled.\r\n")
+    }
+    log("\r\n")
+}
+
+private fun onShowDirs() {
+    log("--- Platform Directories ---\r\n")
+    log("filesDir:     ${FileKit.filesDir.path}\r\n")
+    log("cacheDir:     ${FileKit.cacheDir.path}\r\n")
+    log("downloadsDir: ${FileKit.downloadsDir.path}\r\n")
+    log("documentsDir: ${FileKit.documentsDir.path}\r\n")
+    log("picturesDir:  ${FileKit.picturesDir.path}\r\n")
+    log("\r\n")
+}
+
+private fun logFileInfo(file: PlatformFile) {
+    log("Name:         ${file.name}\r\n")
+    log("Extension:    ${file.extension}\r\n")
+    log("Path:         ${file.path}\r\n")
+    log("Size:         ${file.size()} bytes\r\n")
+    log("Exists:       ${file.exists()}\r\n")
+    log("MIME type:    ${file.mimeType()}\r\n")
+    log("Last modified: ${file.lastModified()}\r\n")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -44,6 +44,7 @@ include(":sample:androidApp")
 include(":sample:desktopApp")
 include(":sample:shared")
 include(":sample:webApp")
+include(":sample:windowsNativeApp")
 
 // include(":samples-old:sample-core:shared")
 // include(":samples-old:sample-core:composeApp")


### PR DESCRIPTION
## Summary

- Add `mingwX64` target to `filekit-core` and `filekit-dialogs` modules
- `filekit-core`: PlatformFile implementation using kotlinx.io Path, Win32 APIs for file metadata (GetFileAttributesExW), MIME type via Windows Registry, directory resolution via SHGetKnownFolderPath with USERPROFILE fallback, Unicode-safe path resolution via GetFullPathNameW
- `filekit-dialogs`: Modern COM file dialogs (IFileOpenDialog/IFileSaveDialog) via cinterop C wrappers — same approach as the JNA implementation, with FOS_PICKFOLDERS for directory selection, multi-select support, file type filters, and ShellExecuteW for default app opening
- Win32 GUI sample app (`sample/windowsNativeApp`) demonstrating all FileKit APIs

## Test plan

- [x] `filekit-core:compileKotlinMingwX64` compiles
- [x] `filekit-dialogs:compileKotlinMingwX64` compiles
- [x] `sample:windowsNativeApp:linkReleaseExecutableMingwX64` links successfully
- [x] JVM tests still pass (`filekit-core:jvmTest`)
- [x] JVM compilation unaffected (`filekit-core:compileKotlinJvm`, `filekit-dialogs:compileKotlinJvm`)
- [x] Manual test: file picker dialog opens and returns selected file
- [x] Manual test: directory picker shows folder selection (FOS_PICKFOLDERS)
- [x] Manual test: save dialog creates file correctly
- [x] Manual test: files with Unicode paths (Hebrew, CJK) work