### PR TITLE
📝 Update file picker docs for title move

### DIFF
--- a/docs/dialogs/directory-picker.mdx
+++ b/docs/dialogs/directory-picker.mdx
@@ -28,21 +28,19 @@ Button(onClick = { launcher.launch() }) {
 
 ## Customizing the dialog
 
-You can customize the dialog by setting the title and the initial directory.
+You can customize the dialog by setting the initial directory and platform-specific `dialogSettings`, such as a title on supported platforms.
 
 <CodeGroup>
 ```kotlin filekit-dialogs
 val directory = FileKit.openDirectoryPicker(
-    title = "Directory picker",
     directory = PlatformFile("/custom/initial/path"),
-    dialogSettings = dialogSettings,
+    dialogSettings = FileKitDialogSettings.createDefault(),
 )
 ```
 ```kotlin filekit-dialogs-compose
 val launcher = rememberDirectoryPickerLauncher(
-    title = "Directory picker",
     directory = PlatformFile("/custom/initial/path"),
-    dialogSettings = dialogSettings,
+    dialogSettings = FileKitDialogSettings.createDefault(),
 ) { directory ->
     // Handle the directory
 }

--- a/docs/dialogs/file-picker.mdx
+++ b/docs/dialogs/file-picker.mdx
@@ -150,22 +150,20 @@ val launcher = rememberFilePickerLauncher(
 
 ## Customizing the dialog
 
-You can customize the dialog by setting the title, the initial directory and some settings relative to the platform.
+You can customize the dialog by setting the initial directory and platform-specific `dialogSettings`, such as a title on supported platforms.
 
 <CodeGroup>
 ```kotlin filekit-dialogs
 val file = FileKit.openFilePicker(
-    title = "Custom title",
     directory = PlatformFile("/custom/initial/path"),
-    dialogSettings = FileKitDialogSettings.createDefault()
+    dialogSettings = FileKitDialogSettings.createDefault(),
 )
 ```
 
 ```kotlin filekit-dialogs-compose
 val launcher = rememberFilePickerLauncher(
-    title = "Custom title",
     directory = PlatformFile("/custom/initial/path"),
-    dialogSettings = FileKitDialogSettings.createDefault()
+    dialogSettings = FileKitDialogSettings.createDefault(),
 ) { file ->
     // Handle the file
 }


### PR DESCRIPTION
## Summary
- Remove stale direct `title` arguments from the file picker and directory picker docs
- Point customization guidance at `dialogSettings` for platform-specific titles
- Keep the code samples self-contained with `FileKitDialogSettings.createDefault()`

## Testing
- Not run (not requested)