### PR TITLE
Add exception details for bookmark failure

### DIFF
--- a/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/PlatformFile.apple.kt
+++ b/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/PlatformFile.apple.kt
@@ -214,7 +214,7 @@ public actual fun PlatformFile.startAccessingSecurityScopedResource(): Boolean =
 public actual fun PlatformFile.stopAccessingSecurityScopedResource(): Unit =
     nsUrl.stopAccessingSecurityScopedResource()
 
-@OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)
+@OptIn(ExperimentalForeignApi::class, UnsafeNumber::class, BetaInteropApi::class)
 public actual suspend fun PlatformFile.bookmarkData(): BookmarkData = withContext(Dispatchers.IO) {
     withScopedAccess {
         memScoped {

--- a/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/PlatformFile.apple.kt
+++ b/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/PlatformFile.apple.kt
@@ -223,7 +223,7 @@ public actual suspend fun PlatformFile.bookmarkData(): BookmarkData = withContex
                 options = 0u,
                 includingResourceValuesForKeys = null,
                 relativeToURL = null,
-                error = errorPtr.ptr
+                error = errorPtr.ptr,
             ) ?: throw FileKitException("Failed to create bookmark data: ${errorPtr.ptr.pointed.value}")
             BookmarkData(bookmarkData.toByteArray())
         }

--- a/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/PlatformFile.apple.kt
+++ b/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/PlatformFile.apple.kt
@@ -217,13 +217,16 @@ public actual fun PlatformFile.stopAccessingSecurityScopedResource(): Unit =
 @OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)
 public actual suspend fun PlatformFile.bookmarkData(): BookmarkData = withContext(Dispatchers.IO) {
     withScopedAccess {
-        val bookmarkData = nsUrl.bookmarkDataWithOptions(
-            options = 0u,
-            includingResourceValuesForKeys = null,
-            relativeToURL = null,
-            error = null,
-        ) ?: throw FileKitException("Failed to create bookmark data")
-        BookmarkData(bookmarkData.toByteArray())
+        memScoped {
+            val errorPtr = alloc<ObjCObjectVar<NSError?>>()
+            val bookmarkData = nsUrl.bookmarkDataWithOptions(
+                options = 0u,
+                includingResourceValuesForKeys = null,
+                relativeToURL = null,
+                error = errorPtr.ptr
+            ) ?: throw FileKitException("Failed to create bookmark data: ${errorPtr.ptr.pointed.value}")
+            BookmarkData(bookmarkData.toByteArray())
+        }
     }
 }
 


### PR DESCRIPTION
This pull request improves error handling in the `bookmarkData` function for Apple platforms. The main change is to capture and report detailed error information if bookmark data creation fails.

**Error handling improvement:**

* Updated `PlatformFile.bookmarkData()` in `PlatformFile.apple.kt` to use a scoped error pointer (`errorPtr`) when calling `nsUrl.bookmarkDataWithOptions`, and included the error details in the thrown `FileKitException` message for better debugging.