### PR TITLE
🐛 Fix Android SAF child directory handling

### DIFF
--- a/filekit-core/src/androidHostTest/kotlin/io/github/vinceglb/filekit/PlatformFileAndroidTest.kt
+++ b/filekit-core/src/androidHostTest/kotlin/io/github/vinceglb/filekit/PlatformFileAndroidTest.kt
@@ -33,7 +33,6 @@ import java.io.FileNotFoundException
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
-import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertIsNot
@@ -579,7 +578,9 @@ private fun MatrixCursor.addDocumentRow(
         .map { column ->
             when (column) {
                 DocumentsContract.Document.COLUMN_DOCUMENT_ID -> document.id
+
                 DocumentsContract.Document.COLUMN_DISPLAY_NAME -> document.name
+
                 DocumentsContract.Document.COLUMN_MIME_TYPE -> if (document.isDirectory) {
                     DocumentsContract.Document.MIME_TYPE_DIR
                 } else {
@@ -587,6 +588,7 @@ private fun MatrixCursor.addDocumentRow(
                 }
 
                 OpenableColumns.SIZE -> null
+
                 else -> null
             }
         }.toTypedArray()

--- a/filekit-core/src/androidHostTest/kotlin/io/github/vinceglb/filekit/PlatformFileAndroidTest.kt
+++ b/filekit-core/src/androidHostTest/kotlin/io/github/vinceglb/filekit/PlatformFileAndroidTest.kt
@@ -7,9 +7,11 @@ import android.content.ContentResolver
 import android.content.ContentValues
 import android.content.Context
 import android.content.ContextWrapper
+import android.content.pm.ProviderInfo
 import android.database.Cursor
 import android.database.MatrixCursor
 import android.net.Uri
+import android.os.Bundle
 import android.os.ParcelFileDescriptor
 import android.provider.DocumentsContract
 import android.provider.MediaStore
@@ -113,9 +115,7 @@ class PlatformFileAndroidTest {
         assertEquals("/tmp/test/child.txt", child.path)
     }
 
-    // Issue #415: Test `/` operator on UriWrapper does NOT throw FileKitUriPathNotSupportedException
-    // Note: In Robolectric, DocumentFile.fromTreeUri() returns null (no real SAF support),
-    // so this test verifies that the ORIGINAL bug (FileKitUriPathNotSupportedException) is fixed.
+    // Issue #415: Test `/` operator on UriWrapper does NOT throw FileKitUriPathNotSupportedException.
     // Full integration testing requires a real Android device with SAF support.
     @Test
     fun testDivOperatorOnUriWrapper_noLongerThrowsPathNotSupportedException() {
@@ -123,21 +123,75 @@ class PlatformFileAndroidTest {
         val uri = Uri.parse("content://com.android.externalstorage.documents/tree/primary%3ADocuments")
         val base = PlatformFile(uri)
 
-        // Before the fix, this would throw FileKitUriPathNotSupportedException
-        // because PlatformFile(base, child) called base.toKotlinxIoPath() which throws for UriWrapper.
-        // After the fix, it uses DocumentFile API instead, which fails in Robolectric
-        // with a generic FileKitException (not FileKitUriPathNotSupportedException).
-        val exception = assertFailsWith<FileKitException> {
-            base / "backup.zip"
-        }
+        val child = base / "backup.zip"
 
-        // Verify it's NOT the old exception type (the bug we fixed)
-        assertIsNot<FileKitUriPathNotSupportedException>(exception)
-        // The error message should be about DocumentFile access, not Path conversion
-        assertTrue(
-            exception.message?.contains("Could not access Uri as directory") == true ||
-                exception.message?.contains("Could not create child file") == true,
+        assertIs<AndroidFile.UriWrapper>(child.androidFile)
+        assertEquals(
+            "content://com.android.externalstorage.documents/tree/primary%3ADocuments/document/primary%3ADocuments%2Fbackup.zip",
+            child.path,
         )
+    }
+
+    @Test
+    fun createDirectories_onUriChild_doesNotUsePathRepresentation() {
+        val uri = Uri.parse("content://com.android.externalstorage.documents/tree/primary%3ADocuments")
+        val base = PlatformFile(uri)
+
+        val directory = base / "Notes"
+        assertFalse(directory.exists())
+        assertFalse(directory.isDirectory())
+
+        val exception = runCatching {
+            directory.createDirectories()
+        }.exceptionOrNull()
+
+        assertIsNot<FileKitUriPathNotSupportedException>(exception)
+    }
+
+    @Test
+    fun div_onNestedUriChild_keepsUsingGrantedTreeUri() {
+        val uri = Uri.parse("content://com.android.externalstorage.documents/tree/primary%3ADocuments")
+        val base = PlatformFile(uri)
+
+        val nestedFile = base / "Notes" / "note.txt"
+
+        assertIs<AndroidFile.UriWrapper>(nestedFile.androidFile)
+        assertEquals(
+            "content://com.android.externalstorage.documents/tree/primary%3ADocuments/document/primary%3ADocuments%2FNotes%2Fnote.txt",
+            nestedFile.path,
+        )
+    }
+
+    @Test
+    fun list_onUriChildDirectory_returnsChildDirectoryContents() {
+        val treeUri = Uri.parse("content://com.android.externalstorage.documents/tree/primary%3ADocuments")
+        ShadowContentResolver.registerProviderInternal(
+            "com.android.externalstorage.documents",
+            createNestedTreeContentProvider(),
+        )
+        val base = PlatformFile(treeUri)
+
+        val notes = base / "Notes"
+
+        assertEquals(listOf("Notes", "parent-only.txt"), base.list().map { it.name })
+        assertEquals(listOf("note.txt"), notes.list().map { it.name })
+    }
+
+    @Test
+    fun createDirectories_onNestedUriChild_createsMissingParents() {
+        val treeUri = Uri.parse("content://com.android.externalstorage.documents/tree/primary%3ADocuments")
+        ShadowContentResolver.registerProviderInternal(
+            "com.android.externalstorage.documents",
+            createNestedTreeContentProvider(),
+        )
+        val base = PlatformFile(treeUri)
+
+        val target = base / "Created" / "Nested"
+        target.createDirectories()
+
+        assertTrue((base / "Created").isDirectory())
+        assertTrue(target.isDirectory())
+        assertEquals(listOf("Nested"), (base / "Created").list().map { it.name })
     }
 
     @Test
@@ -423,6 +477,136 @@ private class NullInsertContentProvider : ContentProvider() {
         selectionArgs: Array<out String>?,
     ): Int = 0
 }
+
+private class NestedTreeContentProvider : ContentProvider() {
+    private val documents = mutableMapOf(
+        "primary:Documents" to TestDocument("primary:Documents", "Documents", true),
+        "primary:Documents/Notes" to TestDocument("primary:Documents/Notes", "Notes", true),
+        "primary:Documents/parent-only.txt" to TestDocument(
+            "primary:Documents/parent-only.txt",
+            "parent-only.txt",
+            false,
+        ),
+        "primary:Documents/Notes/note.txt" to TestDocument("primary:Documents/Notes/note.txt", "note.txt", false),
+    )
+
+    override fun onCreate(): Boolean = true
+
+    override fun query(
+        uri: Uri,
+        projection: Array<out String>?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+        sortOrder: String?,
+    ): Cursor {
+        val columns = projection?.toList()?.toTypedArray()
+            ?: arrayOf(
+                DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+                DocumentsContract.Document.COLUMN_MIME_TYPE,
+                OpenableColumns.SIZE,
+            )
+
+        val cursor = MatrixCursor(columns)
+        val segments = uri.pathSegments
+        val documentId = segments
+            .indexOf("document")
+            .takeIf { it != -1 }
+            ?.let { segments.getOrNull(it + 1) }
+
+        if (segments.lastOrNull() == "children") {
+            documents
+                .values
+                .filter { it.parentId == documentId }
+                .forEach { cursor.addDocumentRow(columns, it) }
+        } else if (documentId != null) {
+            documents[documentId]?.let { cursor.addDocumentRow(columns, it) }
+        }
+
+        return cursor
+    }
+
+    override fun call(method: String, arg: String?, extras: Bundle?): Bundle? {
+        if (method != "android:createDocument") {
+            return super.call(method, arg, extras)
+        }
+
+        val parentUri = extras?.getParcelableCompat(DOCUMENTS_CONTRACT_EXTRA_URI)
+            ?: return null
+        val parentId = DocumentsContract.getDocumentId(parentUri)
+        val displayName = extras.getString(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+            ?: return null
+        val mimeType = extras.getString(DocumentsContract.Document.COLUMN_MIME_TYPE)
+        val documentId = "$parentId/$displayName"
+        val isDirectory = mimeType == DocumentsContract.Document.MIME_TYPE_DIR
+        documents[documentId] = TestDocument(documentId, displayName, isDirectory)
+        val uri = DocumentsContract.buildDocumentUriUsingTree(parentUri, documentId)
+
+        return Bundle().apply {
+            putParcelable(DOCUMENTS_CONTRACT_EXTRA_URI, uri)
+        }
+    }
+
+    override fun getType(uri: Uri): String? = null
+
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+
+    override fun update(
+        uri: Uri,
+        values: ContentValues?,
+        selection: String?,
+        selectionArgs: Array<out String>?,
+    ): Int = 0
+}
+
+private fun createNestedTreeContentProvider(): NestedTreeContentProvider =
+    NestedTreeContentProvider().apply {
+        attachInfo(
+            RuntimeEnvironment.getApplication(),
+            ProviderInfo().apply {
+                authority = "com.android.externalstorage.documents"
+            },
+        )
+    }
+
+private fun MatrixCursor.addDocumentRow(
+    columns: Array<out String>,
+    document: TestDocument,
+) {
+    val row = columns
+        .map { column ->
+            when (column) {
+                DocumentsContract.Document.COLUMN_DOCUMENT_ID -> document.id
+                DocumentsContract.Document.COLUMN_DISPLAY_NAME -> document.name
+                DocumentsContract.Document.COLUMN_MIME_TYPE -> if (document.isDirectory) {
+                    DocumentsContract.Document.MIME_TYPE_DIR
+                } else {
+                    "text/plain"
+                }
+
+                OpenableColumns.SIZE -> null
+                else -> null
+            }
+        }.toTypedArray()
+    addRow(row)
+}
+
+private data class TestDocument(
+    val id: String,
+    val name: String,
+    val isDirectory: Boolean,
+) {
+    val parentId: String?
+        get() = id.substringBeforeLast('/', missingDelimiterValue = "").takeIf(String::isNotEmpty)
+}
+
+@Suppress("DEPRECATION")
+private fun Bundle.getParcelableCompat(key: String): Uri? =
+    getParcelable(key)
+
+private const val DOCUMENTS_CONTRACT_EXTRA_URI = "uri"
 
 private class MissingSizeContentProvider(
     private val sourceUri: Uri,

--- a/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
+++ b/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
@@ -109,24 +109,12 @@ public actual fun PlatformFile(base: PlatformFile, child: String): PlatformFile 
         }
 
         is AndroidFile.UriWrapper -> {
-            // For Uri-based directories, use DocumentFile API
-            val context = FileKit.context
-            val directoryDocument = DocumentFile.fromTreeUri(context, baseFile.uri)
-                ?: throw FileKitException("Could not access Uri as directory: ${baseFile.uri}")
-
-            // Find existing child
-            directoryDocument.findFile(child)?.let { existing ->
+            val childUri = baseFile.uri.buildChildDocumentUri(child)
+            childUri.findChildDocumentInfo()?.let { existing ->
                 return PlatformFile(existing.uri)
             }
 
-            // Create the file since it doesn't exist
-            // Android SAF requires files to be created via DocumentFile.createFile()
-            val extension = child.substringAfterLast('.', "")
-            val mimeType = getMimeTypeValueFromExtension(extension) ?: DEFAULT_STREAM_MIME_TYPE
-            val created = directoryDocument.createFile(mimeType, child)
-                ?: throw FileKitException("Could not create child file: $child")
-
-            PlatformFile(created.uri)
+            PlatformFile(childUri)
         }
     }
 }
@@ -175,11 +163,7 @@ public actual fun PlatformFile.isRegularFile(): Boolean = when (androidFile) {
     }
 
     is AndroidFile.UriWrapper -> {
-        DocumentFile
-            .fromSingleUri(
-                FileKit.context,
-                androidFile.uri,
-            )?.isFile == true
+        androidFile.uri.isRegularDocument()
     }
 }
 
@@ -187,15 +171,7 @@ public actual fun PlatformFile.isDirectory(): Boolean = when (androidFile) {
     is AndroidFile.FileWrapper -> SystemFileSystem.metadataOrNull(toKotlinxIoPath())?.isDirectory
         ?: false
 
-    is AndroidFile.UriWrapper -> try {
-        DocumentFile
-            .fromTreeUri(
-                FileKit.context,
-                androidFile.uri,
-            )?.isDirectory == true
-    } catch (_: Exception) {
-        false
-    }
+    is AndroidFile.UriWrapper -> androidFile.uri.isDirectoryDocument()
 }
 
 public actual fun PlatformFile.isAbsolute(): Boolean = when (androidFile) {
@@ -205,7 +181,7 @@ public actual fun PlatformFile.isAbsolute(): Boolean = when (androidFile) {
 
 public actual fun PlatformFile.exists(): Boolean = when (androidFile) {
     is AndroidFile.FileWrapper -> SystemFileSystem.exists(toKotlinxIoPath())
-    is AndroidFile.UriWrapper -> getDocumentFile(androidFile.uri)?.exists() == true
+    is AndroidFile.UriWrapper -> androidFile.uri.existsAsDocument()
 }
 
 public actual fun PlatformFile.size(): Long = when (androidFile) {
@@ -379,11 +355,12 @@ public actual fun PlatformFile.sink(append: Boolean): RawSink = when (androidFil
     }
 
     is AndroidFile.UriWrapper -> {
+        val uri = androidFile.uri.ensureFileDocument()
         // Use "wt" (write+truncate) for overwrite, "wa" (write+append) for append
         // This ensures existing file content is properly truncated when overwriting
         val mode = if (append) "wa" else "wt"
         val fos = FileKit.context.contentResolver
-            .openFileDescriptor(androidFile.uri, mode)
+            .openFileDescriptor(uri, mode)
             ?.let { ParcelFileDescriptor.AutoCloseOutputStream(it) }
             ?: throw FileKitException("Could not open output stream for Uri")
 
@@ -402,6 +379,16 @@ public actual fun PlatformFile.sink(append: Boolean): RawSink = when (androidFil
     }
 }
 
+public actual fun PlatformFile.createDirectories(mustCreate: Boolean): Unit = when (val file = androidFile) {
+    is AndroidFile.FileWrapper -> {
+        SystemFileSystem.createDirectories(toKotlinxIoPath(), mustCreate)
+    }
+
+    is AndroidFile.UriWrapper -> {
+        file.uri.ensureDirectoryDocument(mustCreate)
+    }
+}
+
 public actual fun PlatformFile.startAccessingSecurityScopedResource(): Boolean = true
 
 public actual fun PlatformFile.stopAccessingSecurityScopedResource() {}
@@ -414,10 +401,7 @@ public actual inline fun PlatformFile.list(block: (List<PlatformFile>) -> Unit) 
         }
 
         is AndroidFile.UriWrapper -> {
-            val documentFile = DocumentFile.fromTreeUri(FileKit.context, androidFile.uri)
-                ?: throw FileKitException("Could not access Uri as DocumentFile")
-            val files = documentFile.listFiles().map { PlatformFile(it.uri) }
-            block(files)
+            block(androidFile.uri.listDocuments())
         }
     }
 }
@@ -428,9 +412,7 @@ public actual fun PlatformFile.list(): List<PlatformFile> = when (androidFile) {
     }
 
     is AndroidFile.UriWrapper -> {
-        val documentFile = DocumentFile.fromTreeUri(FileKit.context, androidFile.uri)
-            ?: throw FileKitException("Could not access Uri as DocumentFile")
-        documentFile.listFiles().map { PlatformFile(it.uri) }
+        androidFile.uri.listDocuments()
     }
 }
 
@@ -847,6 +829,254 @@ private fun Uri.toDocumentUriForMetadata(): Uri {
     return DocumentsContract.buildDocumentUriUsingTree(this, documentId)
 }
 
+private fun Uri.ensureDirectoryDocument(mustCreate: Boolean) {
+    findChildDocumentInfo()?.let { document ->
+        if (!document.isDirectory) {
+            throw FileKitException("Uri exists but is not a directory: $this")
+        }
+        if (mustCreate) {
+            throw FileKitException("Directory already exists: $this")
+        }
+        return
+    }
+
+    if (!isChildDocumentUri()) {
+        getDocumentFile(this)?.takeIf { it.exists() }?.let { documentFile ->
+            if (!documentFile.isDirectory) {
+                throw FileKitException("Uri exists but is not a directory: $this")
+            }
+            if (mustCreate) {
+                throw FileKitException("Directory already exists: $this")
+            }
+            return
+        }
+    }
+
+    ensureDirectoryPath(mustCreate)
+}
+
+private fun Uri.ensureFileDocument(): Uri {
+    findChildDocumentInfo()?.let { document ->
+        if (document.isDirectory) {
+            throw FileKitException("Uri exists but is a directory: $this")
+        }
+        return document.uri
+    }
+
+    if (!isChildDocumentUri()) {
+        getDocumentFile(this)?.takeIf { it.exists() }?.let { documentFile ->
+            if (documentFile.isDirectory) {
+                throw FileKitException("Uri exists but is a directory: $this")
+            }
+            return documentFile.uri
+        }
+    }
+
+    val (parentUri, childName) = parentDocumentUriAndName()
+    val extension = childName.substringAfterLast('.', "")
+    val mimeType = getMimeTypeValueFromExtension(extension) ?: DEFAULT_STREAM_MIME_TYPE
+
+    return DocumentsContract.createDocument(
+        FileKit.context.contentResolver,
+        parentUri,
+        mimeType,
+        childName,
+    )
+        ?: throw FileKitException("Could not create file: $childName")
+}
+
+private fun Uri.buildChildDocumentUri(child: String): Uri {
+    val parentDocumentId = documentId()
+    val childDocumentId = listOf(parentDocumentId, child)
+        .filter(String::isNotEmpty)
+        .joinToString("/")
+
+    return DocumentsContract.buildDocumentUriUsingTree(this, childDocumentId)
+}
+
+private fun Uri.existsAsDocument(): Boolean {
+    findChildDocumentInfo()?.let { return true }
+    if (isChildDocumentUri()) return false
+    return getDocumentFile(this)?.exists() == true
+}
+
+private fun Uri.isDirectoryDocument(): Boolean {
+    findChildDocumentInfo()?.let { return it.isDirectory }
+    if (isChildDocumentUri()) return false
+    return getDocumentFile(this)?.isDirectory == true
+}
+
+private fun Uri.isRegularDocument(): Boolean {
+    findChildDocumentInfo()?.let { return !it.isDirectory }
+    if (isChildDocumentUri()) return false
+    return getDocumentFile(this)?.isFile == true
+}
+
+@PublishedApi
+internal fun Uri.listDocuments(): List<PlatformFile> {
+    if (!isDirectoryDocument()) {
+        throw FileKitException("Uri is not a directory: $this")
+    }
+
+    val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(this, documentId())
+    return queryDocumentInfos(childrenUri).map { PlatformFile(it.uri) }
+}
+
+private fun Uri.findChildDocumentInfo(): AndroidDocumentInfo? {
+    val (parentDocumentId, childName) = parentDocumentIdAndNameOrNull() ?: return null
+
+    return findChildDocumentInfo(
+        parentDocumentId = parentDocumentId,
+        childName = childName,
+    )
+}
+
+private fun Uri.findChildDocumentInfo(
+    parentDocumentId: String,
+    childName: String,
+): AndroidDocumentInfo? {
+    val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(this, parentDocumentId)
+
+    return queryDocumentInfos(childrenUri).firstOrNull { it.name == childName }
+}
+
+private fun Uri.ensureDirectoryPath(mustCreate: Boolean) {
+    val treeDocumentId = treeDocumentId()
+    val targetDocumentId = documentId()
+
+    if (targetDocumentId == treeDocumentId) {
+        throw FileKitException("Directory is not accessible: $this")
+    }
+    if (!targetDocumentId.startsWith("$treeDocumentId/")) {
+        throw FileKitException("Uri is outside the granted tree: $this")
+    }
+
+    val relativeSegments = targetDocumentId
+        .removePrefix("$treeDocumentId/")
+        .split("/")
+        .filter(String::isNotEmpty)
+    var parentDocumentId = treeDocumentId
+    var parentUri = DocumentsContract.buildDocumentUriUsingTree(this, parentDocumentId)
+
+    relativeSegments.forEachIndexed { index, segment ->
+        val isTargetDirectory = index == relativeSegments.lastIndex
+        val existing = findChildDocumentInfo(
+            parentDocumentId = parentDocumentId,
+            childName = segment,
+        )
+
+        if (existing != null) {
+            if (!existing.isDirectory) {
+                throw FileKitException("Uri exists but is not a directory: ${existing.uri}")
+            }
+            if (isTargetDirectory && mustCreate) {
+                throw FileKitException("Directory already exists: ${existing.uri}")
+            }
+            parentDocumentId = existing.documentId
+            parentUri = existing.uri
+            return@forEachIndexed
+        }
+
+        val createdUri = DocumentsContract.createDocument(
+            FileKit.context.contentResolver,
+            parentUri,
+            DocumentsContract.Document.MIME_TYPE_DIR,
+            segment,
+        ) ?: throw FileKitException("Could not create directory: $segment")
+
+        parentDocumentId = createdUri.documentId()
+        parentUri = createdUri
+    }
+}
+
+private fun Uri.queryDocumentInfos(childrenUri: Uri): List<AndroidDocumentInfo> = try {
+    FileKit.context.contentResolver
+        .query(
+            childrenUri,
+            ANDROID_DOCUMENT_INFO_PROJECTION,
+            null,
+            null,
+            null,
+        )?.use { cursor ->
+            val documentIdIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
+            val nameIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+            val mimeTypeIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_MIME_TYPE)
+            val documents = mutableListOf<AndroidDocumentInfo>()
+
+            while (cursor.moveToNext()) {
+                val displayName = if (nameIndex == -1 || cursor.isNull(nameIndex)) {
+                    null
+                } else {
+                    cursor.getString(nameIndex)
+                }
+
+                val documentId = if (documentIdIndex == -1 || cursor.isNull(documentIdIndex)) {
+                    continue
+                } else {
+                    cursor.getString(documentIdIndex)
+                }
+                val mimeType = if (mimeTypeIndex == -1 || cursor.isNull(mimeTypeIndex)) {
+                    null
+                } else {
+                    cursor.getString(mimeTypeIndex)
+                }
+
+                documents += AndroidDocumentInfo(
+                    uri = DocumentsContract.buildDocumentUriUsingTree(
+                        this,
+                        documentId,
+                    ),
+                    documentId = documentId,
+                    name = displayName,
+                    mimeType = mimeType,
+                )
+            }
+
+            documents
+        } ?: emptyList()
+} catch (_: SecurityException) {
+    emptyList()
+} catch (_: IllegalArgumentException) {
+    emptyList()
+}
+
+private fun Uri.parentDocumentUriAndName(): Pair<Uri, String> {
+    val (parentDocumentId, childName) = parentDocumentIdAndNameOrNull()
+        ?: throw FileKitException("Uri does not describe a child document: $this")
+
+    return DocumentsContract.buildDocumentUriUsingTree(this, parentDocumentId) to childName
+}
+
+private fun Uri.parentDocumentIdAndNameOrNull(): Pair<String, String>? {
+    val documentId = try {
+        documentId()
+    } catch (_: IllegalArgumentException) {
+        return null
+    }
+    val parentDocumentId = documentId.substringBeforeLast('/', missingDelimiterValue = "")
+    val childName = documentId.substringAfterLast('/')
+
+    if (parentDocumentId.isEmpty() || childName.isEmpty() || childName == documentId) {
+        return null
+    }
+
+    return parentDocumentId to childName
+}
+
+private fun Uri.isChildDocumentUri(): Boolean {
+    val segments = pathSegments
+    return "tree" in segments && "document" in segments && parentDocumentIdAndNameOrNull() != null
+}
+
+private fun Uri.documentId(): String = try {
+    DocumentsContract.getDocumentId(this)
+} catch (_: IllegalArgumentException) {
+    DocumentsContract.getTreeDocumentId(this)
+}
+
+private fun Uri.treeDocumentId(): String =
+    DocumentsContract.getTreeDocumentId(this)
+
 private fun Uri.isTreeUriCompat(): Boolean {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
         return DocumentsContract.isTreeUri(this)
@@ -873,6 +1103,21 @@ private fun getDocumentFile(uri: Uri): DocumentFile? {
         }
     }
 }
+
+private data class AndroidDocumentInfo(
+    val uri: Uri,
+    val documentId: String,
+    val name: String?,
+    val mimeType: String?,
+) {
+    val isDirectory: Boolean = mimeType == DocumentsContract.Document.MIME_TYPE_DIR
+}
+
+private val ANDROID_DOCUMENT_INFO_PROJECTION = arrayOf(
+    DocumentsContract.Document.COLUMN_DOCUMENT_ID,
+    DocumentsContract.Document.COLUMN_DISPLAY_NAME,
+    DocumentsContract.Document.COLUMN_MIME_TYPE,
+)
 
 private fun Uri.toFileOrNull(): File? {
     if (!scheme.equals("file", ignoreCase = true)) {

--- a/filekit-core/src/jvmAndNativeMain/kotlin/io/github/vinceglb/filekit/PlatformFile.jvmAndNative.kt
+++ b/filekit-core/src/jvmAndNativeMain/kotlin/io/github/vinceglb/filekit/PlatformFile.jvmAndNative.kt
@@ -54,6 +54,9 @@ public actual fun PlatformFile.sink(append: Boolean): RawSink = withScopedAccess
     SystemFileSystem.sink(toKotlinxIoPath(), append)
 }
 
+public actual fun PlatformFile.createDirectories(mustCreate: Boolean): Unit =
+    SystemFileSystem.createDirectories(toKotlinxIoPath(), mustCreate)
+
 public actual suspend fun PlatformFile.delete(mustExist: Boolean): Unit =
     withContext(Dispatchers.IO) {
         SystemFileSystem.delete(path = toKotlinxIoPath(), mustExist = mustExist)

--- a/filekit-core/src/nonWebMain/kotlin/io/github/vinceglb/filekit/PlatformFile.nonWeb.kt
+++ b/filekit-core/src/nonWebMain/kotlin/io/github/vinceglb/filekit/PlatformFile.nonWeb.kt
@@ -9,7 +9,6 @@ import kotlinx.io.RawSink
 import kotlinx.io.RawSource
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
-import kotlinx.io.files.SystemFileSystem
 import kotlinx.io.readByteArray
 import kotlinx.io.readString
 import kotlinx.io.writeString
@@ -230,8 +229,7 @@ internal expect suspend fun PlatformFile.prepareDestinationForWrite(source: Plat
  *
  * @param mustCreate If `true`, fails if the directory already exists. Defaults to `false`.
  */
-public fun PlatformFile.createDirectories(mustCreate: Boolean = false): Unit =
-    SystemFileSystem.createDirectories(toKotlinxIoPath(), mustCreate)
+public expect fun PlatformFile.createDirectories(mustCreate: Boolean = false)
 
 /**
  * Lists the files in this directory and passes them to the given block.

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/debug/DebugScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/debug/DebugScreen.kt
@@ -64,8 +64,8 @@ private fun DebugScreen(
     val folderPicker = rememberDirectoryPickerLauncher(directory = null) { folder ->
         scope.launch {
             folder?.let {
-                // debugPlatformTest(folder)
-                bookmarkFolder(folder)
+                debugPlatformTest(folder)
+                // bookmarkFolder(folder)
             }
         }
     }
@@ -127,7 +127,7 @@ private fun DebugScreen(
     }
 }
 
-internal expect suspend fun debugPlatformTest(file: PlatformFile)
+internal expect suspend fun debugPlatformTest(folder: PlatformFile)
 
 internal expect suspend fun bookmarkFolder(folder: PlatformFile)
 

--- a/sample/shared/src/nonWebMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/debug/DebugScreen.nonWeb.kt
+++ b/sample/shared/src/nonWebMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/debug/DebugScreen.nonWeb.kt
@@ -5,10 +5,12 @@ import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.atomicMove
 import io.github.vinceglb.filekit.bookmarkData
 import io.github.vinceglb.filekit.cacheDir
+import io.github.vinceglb.filekit.createDirectories
 import io.github.vinceglb.filekit.div
 import io.github.vinceglb.filekit.exists
 import io.github.vinceglb.filekit.filesDir
 import io.github.vinceglb.filekit.fromBookmarkData
+import io.github.vinceglb.filekit.isDirectory
 import io.github.vinceglb.filekit.list
 import io.github.vinceglb.filekit.name
 import io.github.vinceglb.filekit.path
@@ -19,19 +21,48 @@ import io.github.vinceglb.filekit.write
 import io.github.vinceglb.filekit.writeString
 import kotlin.time.Clock
 
-internal actual suspend fun debugPlatformTest(file: PlatformFile) {
-    val folderBookmark = file.bookmarkData()
+internal actual suspend fun debugPlatformTest(folder: PlatformFile) {
+//    val folderBookmark = file.bookmarkData()
+//
+//    val niceFile = FileKit.cacheDir / "test${Clock.System.now().toEpochMilliseconds()}.txt"
+//    niceFile.writeString("Hey dude")
+//
+//    val folder = PlatformFile.fromBookmarkData(folderBookmark)
+//    // val destinationFile = folder / niceFile.name
+//    niceFile.atomicMove(folder)
+//
+//    // println("Content = ${destinationFile.readString()}")
+//
+//    println("Files of folder = ${folder.list().joinToString { it.name }}")
 
-    val niceFile = FileKit.cacheDir / "test${Clock.System.now().toEpochMilliseconds()}.txt"
-    niceFile.writeString("Hey dude")
+    val contentTest = "Hey dude folder".encodeToByteArray()
+    val fileTest = folder / "test.txt"
+    fileTest.write(contentTest)
 
-    val folder = PlatformFile.fromBookmarkData(folderBookmark)
-    // val destinationFile = folder / niceFile.name
-    niceFile.atomicMove(folder)
+    println("fileTest exists = ${fileTest.exists()}")
+    println("fileTest content = ${fileTest.readString()}")
 
-    // println("Content = ${destinationFile.readString()}")
+    val savedDir = folder / "vince-sub1" / "vince-sub2" / "vince-sub3"
 
-    println("Files of folder = ${folder.list().joinToString { it.name }}")
+    println("savedDir exists = ${savedDir.exists()}")
+    println("savedDir isDirectory = ${savedDir.isDirectory()}")
+
+    savedDir.createDirectories(mustCreate = true)
+
+    println("savedDir exists after create = ${savedDir.exists()}")
+    println("savedDir isDirectory() after create = ${savedDir.isDirectory()}")
+
+    val content = "Hey dude subfolder".encodeToByteArray()
+    val file = savedDir / "test.txt"
+
+    println("Files of savedDir before write = ${savedDir.list().joinToString { it.name }}")
+    println("file exists = ${file.exists()}")
+
+    file.write(content)
+
+    println("Files of savedDir after write = ${savedDir.list().joinToString { it.name }}")
+    println("file exists = ${file.exists()}")
+    println("file content = ${file.readString()}")
 }
 
 private val bookmarkFile = FileKit.filesDir / "bookmark.bin"

--- a/sample/shared/src/webMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/debug/DebugScreen.web.kt
+++ b/sample/shared/src/webMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/debug/DebugScreen.web.kt
@@ -2,7 +2,7 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.debug
 
 import io.github.vinceglb.filekit.PlatformFile
 
-internal actual suspend fun debugPlatformTest(file: PlatformFile) {
+internal actual suspend fun debugPlatformTest(folder: PlatformFile) {
     // Web does not support directory-based file operations in the same way
     // This is a no-op on web platforms
 }


### PR DESCRIPTION
## Summary
- Preserve Android SAF child directory URIs as lazy document URIs so nested `directory / child` paths work without falling back to `toKotlinxIoPath()`.
- Add Android-specific handling for `exists()`, `isDirectory()`, `list()`, `sink()`, and `createDirectories()` so picked directories, nested subdirectories, and files behave consistently.
- Cover the Android SAF flow with host tests for nested directory creation, child listing, and nested file creation.

## Testing
- `:filekit-core:testAndroidHostTest`
- `:filekit-core:check`