### PR TITLE
✨ Add iOS picker race workaround docs

### DIFF
--- a/docs/dialogs/file-picker.mdx
+++ b/docs/dialogs/file-picker.mdx
@@ -26,6 +26,55 @@ Button(onClick = { launcher.launch() }) {
 ```
 </CodeGroup>
 
+<Warning>
+On iOS with Compose Multiplatform 1.10+, launching a picker while a Compose modal surface
+such as `ModalBottomSheet`, dialog, or dropdown is closing can cause the native picker to
+open and immediately disappear. Dismiss the Compose surface first, then launch FileKit
+after the modal state is closed.
+</Warning>
+
+<details>
+<summary>Show workaround template</summary>
+
+```kotlin filekit-dialogs-compose
+var showSheet by remember { mutableStateOf(false) }
+var launchPickerAfterSheetDismiss by remember { mutableStateOf(false) }
+
+val sheetState = rememberModalBottomSheetState()
+val coroutineScope = rememberCoroutineScope()
+val launcher = rememberFilePickerLauncher { file ->
+    // Handle the file
+}
+
+LaunchedEffect(showSheet, launchPickerAfterSheetDismiss) {
+    if (!showSheet && launchPickerAfterSheetDismiss) {
+        launchPickerAfterSheetDismiss = false
+        launcher.launch()
+    }
+}
+
+if (showSheet) {
+    ModalBottomSheet(
+        sheetState = sheetState,
+        onDismissRequest = { showSheet = false },
+    ) {
+        Button(
+            onClick = {
+                launchPickerAfterSheetDismiss = true
+                coroutineScope.launch {
+                    sheetState.hide()
+                    showSheet = false
+                }
+            },
+        ) {
+            Text("Pick a file")
+        }
+    }
+}
+```
+
+</details>
+
 ## Selection mode
 
 Select one or multiple files using the `mode` parameter. FileKit provides four different selection modes:

--- a/docs/dialogs/gallery-picker.mdx
+++ b/docs/dialogs/gallery-picker.mdx
@@ -38,6 +38,12 @@ val launcher = rememberFilePickerLauncher(
 ```
 </CodeGroup>
 
+<Warning>
+On iOS with Compose Multiplatform 1.10+, avoid launching the gallery picker while a Compose
+modal surface is closing. Dismiss the modal first, then launch FileKit after the modal state
+is closed. [Read more in the file picker documentation.](/dialogs/file-picker)
+</Warning>
+
 ### Maximum number of items
 
 On both Android and iOS, you can set a limit on the number of items a user can select by passing the `maxItems` parameter to `FileKitMode.Multiple()`:

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/debug/DebugScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/debug/DebugScreen.kt
@@ -1,14 +1,20 @@
 package io.github.vinceglb.filekit.sample.shared.ui.screens.debug
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -19,6 +25,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitMode
+import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
 import io.github.vinceglb.filekit.sample.shared.ui.components.AppPickerResultsCard
 import io.github.vinceglb.filekit.sample.shared.ui.components.AppPickerTopBar
@@ -43,6 +51,7 @@ internal fun DebugRoute(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun DebugScreen(
     onNavigateBack: () -> Unit,
@@ -50,8 +59,11 @@ private fun DebugScreen(
 ) {
     var buttonState by remember { mutableStateOf(AppScreenHeaderButtonState.Enabled) }
     var files by remember { mutableStateOf(emptyList<PlatformFile>()) }
+    var showPickerReproSheet by remember { mutableStateOf(false) }
+    var launchImagePickerAfterSheetDismiss by remember { mutableStateOf(false) }
 
     val scope = rememberCoroutineScope()
+    val pickerReproSheetState = rememberModalBottomSheetState()
     val picker = rememberFilePickerLauncher { file ->
         buttonState = AppScreenHeaderButtonState.Enabled
         files = file?.let(::listOf) ?: emptyList()
@@ -59,6 +71,12 @@ private fun DebugScreen(
         scope.launch {
             file?.let { debugPlatformTest(it) }
         }
+    }
+    val imagePicker = rememberFilePickerLauncher(
+        type = FileKitType.Image,
+        mode = FileKitMode.Multiple(),
+    ) { pickedFiles ->
+        files = pickedFiles ?: emptyList()
     }
 
     val folderPicker = rememberDirectoryPickerLauncher(directory = null) { folder ->
@@ -73,6 +91,13 @@ private fun DebugScreen(
     fun test() {
         scope.launch {
             loadBookmarkedFolder()
+        }
+    }
+
+    LaunchedEffect(showPickerReproSheet, launchImagePickerAfterSheetDismiss) {
+        if (!showPickerReproSheet && launchImagePickerAfterSheetDismiss) {
+            launchImagePickerAfterSheetDismiss = false
+            imagePicker.launch()
         }
     }
 
@@ -108,6 +133,15 @@ private fun DebugScreen(
 
             item {
                 Button(
+                    modifier = Modifier.sizeIn(maxWidth = AppMaxWidth).fillMaxWidth(),
+                    onClick = { showPickerReproSheet = true },
+                ) {
+                    Text("Open iOS picker race repro")
+                }
+            }
+
+            item {
+                Button(
                     onClick = { test() },
                 ) {
                     Text("Load Bookmarked Folder")
@@ -122,6 +156,34 @@ private fun DebugScreen(
                     onFileClick = onDisplayFileDetails,
                     modifier = Modifier.sizeIn(maxWidth = AppMaxWidth),
                 )
+            }
+        }
+    }
+
+    if (showPickerReproSheet) {
+        ModalBottomSheet(
+            sheetState = pickerReproSheetState,
+            onDismissRequest = { showPickerReproSheet = false },
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 32.dp),
+            ) {
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {
+                        scope.launch {
+                            launchImagePickerAfterSheetDismiss = true
+                            pickerReproSheetState.hide()
+                            showPickerReproSheet = false
+                        }
+                    },
+                ) {
+                    Text("Launch picker")
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- Document the iOS Compose Multiplatform 1.10+ picker race in the file picker docs.
- Add a collapsed workaround template showing the recommended launch-after-dismiss pattern.
- Add a shorter cross-reference note in the gallery picker docs.

## Testing
- Not run (not requested)