### PR TITLE
✨ Add iOS asset representation mode setting

### DIFF
--- a/docs/dialogs/dialog-settings.mdx
+++ b/docs/dialogs/dialog-settings.mdx
@@ -41,19 +41,29 @@ Window(onCloseRequest = ::exitApplication) {
 }
 ```
 
-### macOS Settings
+### iOS and macOS Settings
 
-On macOS, you can configure:
+On iOS and macOS, you can configure:
 
 - `title`: Set a custom title for the dialog
 - `canCreateDirectories`: Allow or prevent directory creation in dialogs (default: true)
+- `assetRepresentationMode`: Choose the iOS Photos picker asset representation mode (default: `Automatic`)
 
 ```kotlin
 val settings = FileKitDialogSettings(
     title = "Save document",
-    canCreateDirectories = true
+    canCreateDirectories = true,
+    assetRepresentationMode = FileKitAssetRepresentationMode.Automatic
 )
 ```
+
+The iOS Photos picker supports these asset representation modes:
+
+- `Automatic`: Let the system choose the best representation
+- `Current`: Prefer the original/current representation and avoid transcoding when possible
+- `Compatible`: Prefer a broadly compatible representation, even if transcoding is required
+
+Use `Compatible` when picked image bytes need to be decoded by libraries that may not support every Apple-native image format, such as HEIF/HEIC.
 
 ### Android, Web, and WASM
 
@@ -84,7 +94,14 @@ actual fun createDialogSettings(): FileKitDialogSettings {
     )
 }
 
-// androidMain, iosMain, jsMain
+// iosMain
+actual fun createDialogSettings(): FileKitDialogSettings {
+    return FileKitDialogSettings(
+        assetRepresentationMode = FileKitAssetRepresentationMode.Automatic
+    )
+}
+
+// androidMain, jsMain
 actual fun createDialogSettings(): FileKitDialogSettings {
     return FileKitDialogSettings.createDefault()
 }

--- a/filekit-dialogs/src/appleMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitAssetRepresentationMode.apple.kt
+++ b/filekit-dialogs/src/appleMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitAssetRepresentationMode.apple.kt
@@ -1,0 +1,21 @@
+package io.github.vinceglb.filekit.dialogs
+
+/**
+ * Preferred asset representation mode for iOS photo and video picker results.
+ */
+public enum class FileKitAssetRepresentationMode {
+    /**
+     * Lets the system choose the best representation.
+     */
+    Automatic,
+
+    /**
+     * Uses the current representation to avoid transcoding when possible.
+     */
+    Current,
+
+    /**
+     * Uses the most compatible representation when possible, even if transcoding is required.
+     */
+    Compatible,
+}

--- a/filekit-dialogs/src/appleMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitDialogSettings.apple.kt
+++ b/filekit-dialogs/src/appleMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitDialogSettings.apple.kt
@@ -5,10 +5,12 @@ package io.github.vinceglb.filekit.dialogs
  *
  * @property title The title of the dialog.
  * @property canCreateDirectories Whether the user can create directories in the save panel. Defaults to true.
+ * @property assetRepresentationMode The preferred iOS photo/video picker asset representation mode.
  */
 public actual class FileKitDialogSettings(
     public val title: String? = null,
     public val canCreateDirectories: Boolean = true,
+    public val assetRepresentationMode: FileKitAssetRepresentationMode = FileKitAssetRepresentationMode.Automatic,
 ) {
     public actual companion object {
         /**

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -35,6 +35,8 @@ import platform.Foundation.temporaryDirectory
 import platform.Foundation.writeToURL
 import platform.Photos.PHPhotoLibrary.Companion.sharedPhotoLibrary
 import platform.PhotosUI.PHPickerConfiguration
+import platform.PhotosUI.PHPickerConfigurationAssetRepresentationModeAutomatic
+import platform.PhotosUI.PHPickerConfigurationAssetRepresentationModeCompatible
 import platform.PhotosUI.PHPickerConfigurationAssetRepresentationModeCurrent
 import platform.PhotosUI.PHPickerFilter
 import platform.PhotosUI.PHPickerResult
@@ -84,6 +86,7 @@ internal actual suspend fun FileKit.platformOpenFilePicker(
     -> callPhPicker(
         mode = mode,
         type = type,
+        dialogSettings = dialogSettings,
     )
 
     // Use UIDocumentPickerViewController for other types
@@ -404,6 +407,7 @@ private suspend fun callPicker(
 private suspend fun getPhPickerResults(
     mode: PickerMode,
     type: FileKitType,
+    dialogSettings: FileKitDialogSettings,
 ): List<PHPickerResult> = suspendCancellableCoroutine { continuation ->
     // Create a picker delegate
     phPickerDelegate = PhPickerDelegate(onFilesPicked = continuation::resume)
@@ -418,8 +422,11 @@ private suspend fun getPhPickerResults(
         PickerMode.Single -> 1
     }
 
-    // Use current mode per Apple documentation for faster file provider
-    configuration.preferredAssetRepresentationMode = PHPickerConfigurationAssetRepresentationModeCurrent
+    configuration.preferredAssetRepresentationMode = when (dialogSettings.assetRepresentationMode) {
+        FileKitAssetRepresentationMode.Automatic -> PHPickerConfigurationAssetRepresentationModeAutomatic
+        FileKitAssetRepresentationMode.Current -> PHPickerConfigurationAssetRepresentationModeCurrent
+        FileKitAssetRepresentationMode.Compatible -> PHPickerConfigurationAssetRepresentationModeCompatible
+    }
 
     // Filter configuration
     configuration.filter = when (type) {
@@ -454,10 +461,11 @@ private suspend fun getPhPickerResults(
 private fun callPhPicker(
     mode: PickerMode,
     type: FileKitType,
+    dialogSettings: FileKitDialogSettings,
 ): Flow<FileKitPickerState<List<PlatformFile>>> = channelFlow {
     // Fetch picker results on Main
     val pickerResults = withContext(Dispatchers.Main) {
-        getPhPickerResults(mode, type)
+        getPhPickerResults(mode, type, dialogSettings)
     }
 
     if (pickerResults.isEmpty()) {

--- a/sample/shared/src/iosMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filepicker/FilePickerDialogSettings.ios.kt
+++ b/sample/shared/src/iosMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filepicker/FilePickerDialogSettings.ios.kt
@@ -15,7 +15,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import io.github.vinceglb.filekit.dialogs.FileKitAssetRepresentationMode
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+import io.github.vinceglb.filekit.sample.shared.ui.components.AppDropdown
+import io.github.vinceglb.filekit.sample.shared.ui.components.AppDropdownItem
 import io.github.vinceglb.filekit.sample.shared.ui.components.AppField
 import io.github.vinceglb.filekit.sample.shared.ui.components.AppOutlinedTextField
 import io.github.vinceglb.filekit.sample.shared.ui.theme.geistMonoFontFamily
@@ -26,10 +29,14 @@ import io.github.vinceglb.filekit.sample.shared.ui.theme.geistMonoFontFamily
 internal class AppleFilePickerDialogSettingsState : FilePickerDialogSettingsState {
     var title: String by mutableStateOf("")
     var canCreateDirectories: Boolean by mutableStateOf(true)
+    var assetRepresentationMode: FileKitAssetRepresentationMode by mutableStateOf(
+        FileKitAssetRepresentationMode.Automatic,
+    )
 
     override fun build(): FileKitDialogSettings = FileKitDialogSettings(
         title = title.ifBlank { null },
         canCreateDirectories = canCreateDirectories,
+        assetRepresentationMode = assetRepresentationMode,
     )
 }
 
@@ -73,5 +80,29 @@ internal actual fun FilePickerDialogSettingsContent(state: FilePickerDialogSetti
                 onCheckedChange = { appleState.canCreateDirectories = it },
             )
         }
+
+        AppField(label = "Asset Representation") {
+            AppDropdown(
+                value = appleState.assetRepresentationMode,
+                onValueChange = { appleState.assetRepresentationMode = it },
+                options = assetRepresentationModeOptions,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
     }
 }
+
+private val assetRepresentationModeOptions = listOf(
+    AppDropdownItem.SimpleItem(
+        label = "Automatic",
+        value = FileKitAssetRepresentationMode.Automatic,
+    ),
+    AppDropdownItem.SimpleItem(
+        label = "Current",
+        value = FileKitAssetRepresentationMode.Current,
+    ),
+    AppDropdownItem.SimpleItem(
+        label = "Compatible",
+        value = FileKitAssetRepresentationMode.Compatible,
+    ),
+)


### PR DESCRIPTION
## Summary
- Add `FileKitAssetRepresentationMode` for iOS photo/video picker results
- Wire `FileKitDialogSettings.assetRepresentationMode` into `PHPickerConfiguration.preferredAssetRepresentationMode`
- Keep the default at `Automatic`, while documenting `Compatible` for decoder-friendly image bytes
- Surface the setting in the iOS sample dialog settings UI

## Testing
- `./gradlew :filekit-dialogs:compileKotlinIosSimulatorArm64`
- `./gradlew :sample:shared:compileKotlinIosSimulatorArm64`
- `./gradlew :filekit-dialogs:check`