### PR TITLE
🍎 Capture stable iOS presenters for FileKit dialogs

### DIFF
--- a/docs/dialogs/dialog-settings.mdx
+++ b/docs/dialogs/dialog-settings.mdx
@@ -47,7 +47,11 @@ On iOS and macOS, you can configure:
 
 - `title`: Set a custom title for the dialog
 - `canCreateDirectories`: Allow or prevent directory creation in dialogs (default: true)
-- `assetRepresentationMode`: Choose the iOS Photos picker asset representation mode (default: `Automatic`)
+
+On iOS, you can also configure:
+
+- `assetRepresentationMode`: Choose the Photos picker asset representation mode (default: `Automatic`)
+- `presenter`: Set the iOS `UIViewController` used to present native dialogs
 
 ```kotlin
 val settings = FileKitDialogSettings(

--- a/docs/dialogs/dialog-settings.mdx
+++ b/docs/dialogs/dialog-settings.mdx
@@ -51,7 +51,7 @@ On iOS and macOS, you can configure:
 On iOS, you can also configure:
 
 - `assetRepresentationMode`: Choose the Photos picker asset representation mode (default: `Automatic`)
-- `presenter`: Set the iOS `UIViewController` used to present native dialogs
+- `presenter`: Set the `UIViewController` used to present native dialogs. If null, FileKit uses the current top-most controller.
 
 ```kotlin
 val settings = FileKitDialogSettings(

--- a/docs/dialogs/file-picker.mdx
+++ b/docs/dialogs/file-picker.mdx
@@ -27,54 +27,10 @@ Button(onClick = { launcher.launch() }) {
 </CodeGroup>
 
 <Warning>
-On iOS with Compose Multiplatform 1.10+, launching a picker while a Compose modal surface
-such as `ModalBottomSheet`, dialog, or dropdown is closing can cause the native picker to
-open and immediately disappear. Dismiss the Compose surface first, then launch FileKit
-after the modal state is closed.
+On iOS, remember FileKit Compose launchers from a stable/root Compose scope, not
+inside transient surfaces such as `ModalBottomSheet`, dialogs, popups, or
+dropdowns. [Learn more in GitHub issue #547](https://github.com/vinceglb/FileKit/issues/547).
 </Warning>
-
-<Accordion title="Show workaround template">
-
-This workaround is related to [GitHub issue #547](https://github.com/vinceglb/FileKit/issues/547).
-
-```kotlin filekit-dialogs-compose
-var showSheet by remember { mutableStateOf(false) }
-var launchPickerAfterSheetDismiss by remember { mutableStateOf(false) }
-
-val sheetState = rememberModalBottomSheetState()
-val coroutineScope = rememberCoroutineScope()
-val launcher = rememberFilePickerLauncher { file ->
-    // Handle the file
-}
-
-LaunchedEffect(showSheet, launchPickerAfterSheetDismiss) {
-    if (!showSheet && launchPickerAfterSheetDismiss) {
-        launchPickerAfterSheetDismiss = false
-        launcher.launch()
-    }
-}
-
-if (showSheet) {
-    ModalBottomSheet(
-        sheetState = sheetState,
-        onDismissRequest = { showSheet = false },
-    ) {
-        Button(
-            onClick = {
-                launchPickerAfterSheetDismiss = true
-                coroutineScope.launch {
-                    sheetState.hide()
-                    showSheet = false
-                }
-            },
-        ) {
-            Text("Pick a file")
-        }
-    }
-}
-```
-
-</Accordion>
 
 ## Selection mode
 

--- a/docs/dialogs/gallery-picker.mdx
+++ b/docs/dialogs/gallery-picker.mdx
@@ -39,9 +39,9 @@ val launcher = rememberFilePickerLauncher(
 </CodeGroup>
 
 <Warning>
-On iOS with Compose Multiplatform 1.10+, avoid launching the gallery picker while a Compose
-modal surface is closing. Dismiss the modal first, then launch FileKit after the modal state
-is closed. [Read more in the file picker documentation.](/dialogs/file-picker)
+On iOS, remember FileKit Compose launchers from a stable/root Compose scope, not
+inside transient surfaces such as `ModalBottomSheet`, dialogs, popups, or
+dropdowns. [Learn more in GitHub issue #547](https://github.com/vinceglb/FileKit/issues/547).
 </Warning>
 
 ### Maximum number of items

--- a/filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposePresenter.android.kt
+++ b/filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposePresenter.android.kt
@@ -1,0 +1,21 @@
+package io.github.vinceglb.filekit.dialogs.compose
+
+import androidx.compose.runtime.Composable
+import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+import io.github.vinceglb.filekit.dialogs.FileKitOpenCameraSettings
+import io.github.vinceglb.filekit.dialogs.FileKitShareSettings
+
+@Composable
+internal actual fun rememberStableDialogSettings(
+    dialogSettings: FileKitDialogSettings,
+): FileKitDialogSettings = dialogSettings
+
+@Composable
+internal actual fun rememberStableOpenCameraSettings(
+    openCameraSettings: FileKitOpenCameraSettings,
+): FileKitOpenCameraSettings = openCameraSettings
+
+@Composable
+internal actual fun rememberStableShareSettings(
+    shareSettings: FileKitShareSettings,
+): FileKitShareSettings = shareSettings

--- a/filekit-dialogs-compose/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.kt
+++ b/filekit-dialogs-compose/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.kt
@@ -28,11 +28,12 @@ public fun <PickerResult, ConsumedResult> rememberFilePickerLauncher(
 ): PickerResultLauncher {
     // Init FileKit
     InitFileKit()
+    val stableDialogSettings = rememberStableDialogSettings(dialogSettings)
     return rememberPlatformFilePickerLauncher(
         type = type,
         mode = mode,
         directory = directory,
-        dialogSettings = dialogSettings,
+        dialogSettings = stableDialogSettings,
         onResult = onResult,
     )
 }

--- a/filekit-dialogs-compose/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposePresenter.kt
+++ b/filekit-dialogs-compose/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposePresenter.kt
@@ -1,0 +1,9 @@
+package io.github.vinceglb.filekit.dialogs.compose
+
+import androidx.compose.runtime.Composable
+import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+
+@Composable
+internal expect fun rememberStableDialogSettings(
+    dialogSettings: FileKitDialogSettings,
+): FileKitDialogSettings

--- a/filekit-dialogs-compose/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.ios.kt
+++ b/filekit-dialogs-compose/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.ios.kt
@@ -31,8 +31,10 @@ public actual fun rememberCameraPickerLauncher(
 
     // Coroutine
     val coroutineScope = rememberCoroutineScope()
+    val stableOpenCameraSettings = rememberStableOpenCameraSettings(openCameraSettings)
 
     // Updated state
+    val currentOpenCameraSettings by rememberUpdatedState(stableOpenCameraSettings)
     val currentOnResult by rememberUpdatedState(onResult)
 
     // FileKit
@@ -46,7 +48,7 @@ public actual fun rememberCameraPickerLauncher(
                     type = type,
                     cameraFacing = cameraFacing,
                     destinationFile = destinationFile,
-                    openCameraSettings = openCameraSettings,
+                    openCameraSettings = currentOpenCameraSettings,
                 )
                 currentOnResult(result)
             }

--- a/filekit-dialogs-compose/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposePresenter.ios.kt
+++ b/filekit-dialogs-compose/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposePresenter.ios.kt
@@ -1,0 +1,50 @@
+package io.github.vinceglb.filekit.dialogs.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.uikit.LocalUIViewController
+import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+import io.github.vinceglb.filekit.dialogs.FileKitOpenCameraSettings
+import io.github.vinceglb.filekit.dialogs.FileKitShareSettings
+
+@Composable
+internal actual fun rememberStableDialogSettings(
+    dialogSettings: FileKitDialogSettings,
+): FileKitDialogSettings {
+    // Capture the presenter where the launcher is remembered, not where launch() is called.
+    val presenter = dialogSettings.presenter ?: LocalUIViewController.current
+    return remember(dialogSettings, presenter) {
+        FileKitDialogSettings(
+            title = dialogSettings.title,
+            canCreateDirectories = dialogSettings.canCreateDirectories,
+            assetRepresentationMode = dialogSettings.assetRepresentationMode,
+            presenter = presenter,
+        )
+    }
+}
+
+@Composable
+internal actual fun rememberStableOpenCameraSettings(
+    openCameraSettings: FileKitOpenCameraSettings,
+): FileKitOpenCameraSettings {
+    // Capture the presenter where the launcher is remembered, not where launch() is called.
+    val presenter = openCameraSettings.presenter ?: LocalUIViewController.current
+    return remember(openCameraSettings, presenter) {
+        FileKitOpenCameraSettings(presenter = presenter)
+    }
+}
+
+@Composable
+internal actual fun rememberStableShareSettings(
+    shareSettings: FileKitShareSettings,
+): FileKitShareSettings {
+    // Capture the presenter where the launcher is remembered, not where launch() is called.
+    val presenter = shareSettings.presenter ?: LocalUIViewController.current
+    return remember(shareSettings, presenter) {
+        FileKitShareSettings(
+            metaTitle = shareSettings.metaTitle,
+            addOptionUIActivityViewController = shareSettings.addOptionUIActivityViewController,
+            presenter = presenter,
+        )
+    }
+}

--- a/filekit-dialogs-compose/src/jvmAndNativeMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nativeAndJvm.kt
+++ b/filekit-dialogs-compose/src/jvmAndNativeMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nativeAndJvm.kt
@@ -31,9 +31,11 @@ public actual fun rememberDirectoryPickerLauncher(
 
     // Coroutine
     val coroutineScope = rememberCoroutineScope()
+    val stableDialogSettings = rememberStableDialogSettings(dialogSettings)
 
     // Updated state
     val currentDirectory by rememberUpdatedState(directory)
+    val currentDialogSettings by rememberUpdatedState(stableDialogSettings)
     val currentOnResult by rememberUpdatedState(onResult)
 
     // FileKit launcher
@@ -42,7 +44,7 @@ public actual fun rememberDirectoryPickerLauncher(
             coroutineScope.launch {
                 val result = FileKit.openDirectoryPicker(
                     directory = currentDirectory,
-                    dialogSettings = dialogSettings,
+                    dialogSettings = currentDialogSettings,
                 )
                 currentOnResult(result)
             }
@@ -58,6 +60,8 @@ internal actual fun rememberPlatformFileSaverLauncher(
     onResult: (PlatformFile?) -> Unit,
 ): SaverResultLauncher {
     val coroutineScope = rememberCoroutineScope()
+    val stableDialogSettings = rememberStableDialogSettings(dialogSettings)
+    val currentDialogSettings by rememberUpdatedState(stableDialogSettings)
     val currentOnResult by rememberUpdatedState(onResult)
 
     return remember {
@@ -67,7 +71,7 @@ internal actual fun rememberPlatformFileSaverLauncher(
                     suggestedName = suggestedName,
                     extension = extension,
                     directory = directory,
-                    dialogSettings = dialogSettings,
+                    dialogSettings = currentDialogSettings,
                 )
                 currentOnResult(result)
             }

--- a/filekit-dialogs-compose/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposePresenter.jvm.kt
+++ b/filekit-dialogs-compose/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposePresenter.jvm.kt
@@ -1,0 +1,9 @@
+package io.github.vinceglb.filekit.dialogs.compose
+
+import androidx.compose.runtime.Composable
+import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+
+@Composable
+internal actual fun rememberStableDialogSettings(
+    dialogSettings: FileKitDialogSettings,
+): FileKitDialogSettings = dialogSettings

--- a/filekit-dialogs-compose/src/macosMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposePresenter.macos.kt
+++ b/filekit-dialogs-compose/src/macosMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposePresenter.macos.kt
@@ -1,0 +1,9 @@
+package io.github.vinceglb.filekit.dialogs.compose
+
+import androidx.compose.runtime.Composable
+import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+
+@Composable
+internal actual fun rememberStableDialogSettings(
+    dialogSettings: FileKitDialogSettings,
+): FileKitDialogSettings = dialogSettings

--- a/filekit-dialogs-compose/src/mobileMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.mobile.kt
+++ b/filekit-dialogs-compose/src/mobileMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.mobile.kt
@@ -1,8 +1,10 @@
 package io.github.vinceglb.filekit.dialogs.compose
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitOpenCameraSettings
@@ -25,6 +27,8 @@ public fun rememberShareFileLauncher(
 
     // Coroutine
     val coroutineScope = rememberCoroutineScope()
+    val stableShareSettings = rememberStableShareSettings(shareSettings)
+    val currentShareSettings by rememberUpdatedState(stableShareSettings)
 
     // FileKit
     val fileKit = remember { FileKit }
@@ -33,7 +37,7 @@ public fun rememberShareFileLauncher(
     val returnedLauncher = remember {
         ShareResultLauncher { files ->
             coroutineScope.launch {
-                fileKit.shareFile(files, shareSettings)
+                fileKit.shareFile(files, currentShareSettings)
             }
         }
     }

--- a/filekit-dialogs-compose/src/mobileMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposeMobilePresenter.kt
+++ b/filekit-dialogs-compose/src/mobileMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposeMobilePresenter.kt
@@ -1,0 +1,15 @@
+package io.github.vinceglb.filekit.dialogs.compose
+
+import androidx.compose.runtime.Composable
+import io.github.vinceglb.filekit.dialogs.FileKitOpenCameraSettings
+import io.github.vinceglb.filekit.dialogs.FileKitShareSettings
+
+@Composable
+internal expect fun rememberStableOpenCameraSettings(
+    openCameraSettings: FileKitOpenCameraSettings,
+): FileKitOpenCameraSettings
+
+@Composable
+internal expect fun rememberStableShareSettings(
+    shareSettings: FileKitShareSettings,
+): FileKitShareSettings

--- a/filekit-dialogs-compose/src/nonAndroidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nonAndroid.kt
+++ b/filekit-dialogs-compose/src/nonAndroidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nonAndroid.kt
@@ -26,6 +26,7 @@ internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
     val currentType by rememberUpdatedState(type)
     val currentMode by rememberUpdatedState(mode)
     val currentDirectory by rememberUpdatedState(directory)
+    val currentDialogSettings by rememberUpdatedState(dialogSettings)
     val currentOnConsumed by rememberUpdatedState(onResult)
 
     return remember {
@@ -35,7 +36,7 @@ internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
                     type = currentType,
                     mode = currentMode,
                     directory = currentDirectory,
-                    dialogSettings = dialogSettings,
+                    dialogSettings = currentDialogSettings,
                 )
                 currentMode.consumeResult(result, currentOnConsumed)
             }

--- a/filekit-dialogs-compose/src/webMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposePresenter.web.kt
+++ b/filekit-dialogs-compose/src/webMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposePresenter.web.kt
@@ -1,0 +1,9 @@
+package io.github.vinceglb.filekit.dialogs.compose
+
+import androidx.compose.runtime.Composable
+import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+
+@Composable
+internal actual fun rememberStableDialogSettings(
+    dialogSettings: FileKitDialogSettings,
+): FileKitDialogSettings = dialogSettings

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -98,6 +98,7 @@ internal actual suspend fun FileKit.platformOpenFilePicker(
             },
             contentTypes = type.contentTypes,
             directory = directory,
+            dialogSettings = dialogSettings,
         )?.map { PlatformFile(it) }
 
         if (picked.isNullOrEmpty()) {
@@ -122,6 +123,7 @@ public actual suspend fun FileKit.openDirectoryPicker(
     mode = Mode.Directory,
     contentTypes = listOf(UTTypeFolder),
     directory = directory,
+    dialogSettings = dialogSettings,
 )?.firstOrNull()?.let { PlatformFile(it) }
 
 /**
@@ -198,7 +200,7 @@ public actual suspend fun FileKit.openFileSaver(
         pickerController.delegate = documentPickerDelegate
 
         // Present the picker controller
-        UIApplication.sharedApplication.topMostViewController()?.presentViewController(
+        dialogSettings.presenterViewController()?.presentViewController(
             pickerController,
             animated = true,
             completion = null,
@@ -264,7 +266,7 @@ public actual suspend fun FileKit.openCameraPicker(
             FileKitCameraFacing.System -> {}
         }
 
-        UIApplication.sharedApplication.topMostViewController()?.presentViewController(
+        openCameraSettings.presenterViewController()?.presentViewController(
             pickerController,
             animated = true,
             completion = null,
@@ -302,7 +304,7 @@ public actual suspend fun FileKit.shareFile(
 ) {
     if (files.isEmpty()) return
 
-    val viewController = UIApplication.sharedApplication.topMostViewController() ?: return
+    val viewController = shareSettings.presenterViewController() ?: return
 
     files.forEach { it.startAccessingSecurityScopedResource() }
     // Ensure we always pass a file URL to the activity items; otherwise iOS may treat the
@@ -371,10 +373,20 @@ private fun isIpad(): Boolean {
     return device.userInterfaceIdiom == UIUserInterfaceIdiomPad
 }
 
+private fun FileKitDialogSettings.presenterViewController(): UIViewController? =
+    presenter ?: UIApplication.sharedApplication.topMostViewController()
+
+private fun FileKitOpenCameraSettings.presenterViewController(): UIViewController? =
+    presenter ?: UIApplication.sharedApplication.topMostViewController()
+
+private fun FileKitShareSettings.presenterViewController(): UIViewController? =
+    presenter ?: UIApplication.sharedApplication.topMostViewController()
+
 private suspend fun callPicker(
     mode: Mode,
     contentTypes: List<UTType>,
     directory: PlatformFile?,
+    dialogSettings: FileKitDialogSettings,
 ): List<NSURL>? = withContext(Dispatchers.Main) {
     suspendCancellableCoroutine { continuation ->
         // Create a picker delegate
@@ -396,7 +408,7 @@ private suspend fun callPicker(
         pickerController.delegate = documentPickerDelegate
 
         // Present the picker controller
-        UIApplication.sharedApplication.topMostViewController()?.presentViewController(
+        dialogSettings.presenterViewController()?.presentViewController(
             pickerController,
             animated = true,
             completion = null,
@@ -450,7 +462,7 @@ private suspend fun getPhPickerResults(
     controller.presentationController?.delegate = phPickerDismissDelegate
 
     // Present the picker controller
-    UIApplication.sharedApplication.topMostViewController()?.presentViewController(
+    dialogSettings.presenterViewController()?.presentViewController(
         controller,
         animated = true,
         completion = null,

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitDialogSettings.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitDialogSettings.ios.kt
@@ -1,16 +1,20 @@
 package io.github.vinceglb.filekit.dialogs
 
+import platform.UIKit.UIViewController
+
 /**
- * Apple (iOS/macOS) implementation of [FileKitDialogSettings].
+ * iOS implementation of [FileKitDialogSettings].
  *
  * @property title The title of the dialog.
  * @property canCreateDirectories Whether the user can create directories in the save panel. Defaults to true.
  * @property assetRepresentationMode The preferred iOS photo/video picker asset representation mode.
+ * @property presenter The view controller used to present native dialogs.
  */
 public actual class FileKitDialogSettings(
     public val title: String? = null,
     public val canCreateDirectories: Boolean = true,
     public val assetRepresentationMode: FileKitAssetRepresentationMode = FileKitAssetRepresentationMode.Automatic,
+    public val presenter: UIViewController? = null,
 ) {
     public actual companion object {
         /**

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitOpenCameraSettings.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitOpenCameraSettings.ios.kt
@@ -1,10 +1,15 @@
 package io.github.vinceglb.filekit.dialogs
 
+import platform.UIKit.UIViewController
+
 /**
  * iOS implementation of [FileKitOpenCameraSettings].
- * Currently, there are no specific settings for opening the camera on iOS.
+ *
+ * @property presenter The view controller used to present the camera picker.
  */
-public actual class FileKitOpenCameraSettings {
+public actual class FileKitOpenCameraSettings(
+    public val presenter: UIViewController? = null,
+) {
     public actual companion object {
         /**
          * Creates a default instance of [FileKitOpenCameraSettings].

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitShareSettings.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitShareSettings.ios.kt
@@ -1,16 +1,19 @@
 package io.github.vinceglb.filekit.dialogs
 
 import platform.UIKit.UIActivityViewController
+import platform.UIKit.UIViewController
 
 /**
  * iOS implementation of [FileKitShareSettings].
  *
  * @property metaTitle The title of the share sheet. Defaults to "Share File".
  * @property addOptionUIActivityViewController Callback to customize the [UIActivityViewController].
+ * @property presenter The view controller used to present the share sheet.
  */
-public actual open class FileKitShareSettings(
+public actual class FileKitShareSettings(
     public val metaTitle: String = "Share File",
     public val addOptionUIActivityViewController: (UIActivityViewController) -> Unit = {},
+    public val presenter: UIViewController? = null,
 ) {
     public actual companion object {
         /**

--- a/filekit-dialogs/src/macosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitDialogSettings.macos.kt
+++ b/filekit-dialogs/src/macosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitDialogSettings.macos.kt
@@ -1,0 +1,19 @@
+package io.github.vinceglb.filekit.dialogs
+
+/**
+ * macOS implementation of [FileKitDialogSettings].
+ *
+ * @property title The title of the dialog.
+ * @property canCreateDirectories Whether the user can create directories in the save panel. Defaults to true.
+ */
+public actual class FileKitDialogSettings(
+    public val title: String? = null,
+    public val canCreateDirectories: Boolean = true,
+) {
+    public actual companion object {
+        /**
+         * Creates a default instance of [FileKitDialogSettings].
+         */
+        public actual fun createDefault(): FileKitDialogSettings = FileKitDialogSettings()
+    }
+}


### PR DESCRIPTION
## Summary
- Capture `LocalUIViewController.current` when FileKit Compose launchers are remembered on iOS, so native dialogs can be presented from a stable controller.
- Thread the captured presenter through file picker, directory picker, file saver, camera, and share flows.
- Update the iOS caveat docs to point users toward stable/root Compose scopes and the related issue.

## Testing
- Verified the changed Kotlin source sets compile for iOS simulator, JVM, Android, macOS, JS, and Wasm targets.
- Ran formatting/check validation to confirm the patch is clean.