### PR TITLE
✨ Add allowed extensions to file saver dialogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,11 @@ val directory = FileKit.openDirectoryPicker()
 
 // Save a file
 val contentToSave = "Hello FileKit!"
-val file = FileKit.openFileSaver(suggestedName = "document", extension = "txt")
+val file = FileKit.openFileSaver(
+    suggestedName = "document",
+    defaultExtension = "txt",
+    allowedExtensions = setOf("txt", "md"),
+)
 file?.writeString(contentToSave)
 
 // Work with files

--- a/docs/dialogs/file-saver.mdx
+++ b/docs/dialogs/file-saver.mdx
@@ -19,7 +19,7 @@ Here's a basic example:
 // Open file saver dialog
 val file = FileKit.openFileSaver(
     suggestedName = "document",
-    extension = "pdf"
+    defaultExtension = "pdf",
 )
 
 // Write your data to the file
@@ -39,7 +39,12 @@ val launcher = rememberFileSaverLauncher { file ->
     }
 }
 
-Button(onClick = { launcher.launch("document", "pdf") }) {
+Button(onClick = {
+    launcher.launch(
+        suggestedName = "document",
+        defaultExtension = "pdf",
+    )
+}) {
     Text("Save file")
 }
 ```
@@ -50,7 +55,8 @@ Button(onClick = { launcher.launch("document", "pdf") }) {
 The file saver can be customized with several parameters:
 
 - `suggestedName`: The default name for the file without extension
-- `extension`: The file extension without the dot (e.g., "pdf", "txt")
+- `defaultExtension`: The default file extension without the dot (e.g., "pdf", "txt")
+- `allowedExtensions`: The allowed save extensions without dots (e.g., `setOf("txt", "md")`). This is a native dialog hint, not a validation guarantee.
 - `directory`: The starting directory for the save dialog
 - `dialogSettings`: Platform-specific settings for customizing the dialog behavior
 
@@ -58,7 +64,8 @@ The file saver can be customized with several parameters:
 ```kotlin filekit-dialogs
 val file = FileKit.openFileSaver(
     suggestedName = "my-document",
-    extension = "pdf",
+    defaultExtension = "pdf",
+    allowedExtensions = setOf("pdf", "txt"),
     directory = PlatformFile("/custom/initial/path"),
     dialogSettings = FileKitDialogSettings.createDefault()
 )
@@ -66,15 +73,21 @@ val file = FileKit.openFileSaver(
 
 ```kotlin filekit-dialogs-compose
 val launcher = rememberFileSaverLauncher(
-    directory = PlatformFile("/custom/initial/path"),
     dialogSettings = FileKitDialogSettings.createDefault()
 ) { file ->
     // Handle the selected save location
 }
 
-launcher.launch("my-document", "pdf")
+launcher.launch(
+    suggestedName = "my-document",
+    defaultExtension = "pdf",
+    directory = PlatformFile("/custom/initial/path"),
+    allowedExtensions = setOf("pdf", "txt"),
+)
 ```
 </CodeGroup>
+
+Use `defaultExtension` for the default file name and default extension. Use `allowedExtensions` when the native save dialog should offer specific save types. Filtering is applied where the platform supports it; apps that require a specific output format should still validate the returned file extension.
 
 Read more about [dialog settings](/dialogs/dialog-settings) to customize the dialog for each platform.
 
@@ -83,7 +96,7 @@ Read more about [dialog settings](/dialogs/dialog-settings) to customize the dia
 The file saver returns a `PlatformFile` object representing the selected save location. You can write data to this file using the `write()` extension function:
 
 ```kotlin
-val file = FileKit.openFileSaver(suggestedName = "document", extension = "pdf")
+val file = FileKit.openFileSaver(suggestedName = "document", defaultExtension = "pdf")
 
 if (file != null) {
     // Write bytes to the file

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -101,7 +101,11 @@ FileKit makes it easy to save a file. Read more about [file saver](/dialogs/file
 val contentToSave = "Hello FileKit!"
 
 // Open save dialog to let user choose location
-val file = FileKit.openFileSaver(suggestedName = "document", extension = "txt")
+val file = FileKit.openFileSaver(
+    suggestedName = "document",
+    defaultExtension = "txt",
+    allowedExtensions = setOf("txt", "md"),
+)
 
 // Write content to the file
 file?.writeString(contentToSave)
@@ -115,7 +119,13 @@ val launcher = rememberFileSaverLauncher { file ->
 }
 
 // Display a button to open the file saver dialog
-Button(onClick = { launcher.launch("document", "txt") }) {
+Button(onClick = {
+    launcher.launch(
+        suggestedName = "document",
+        defaultExtension = "txt",
+        allowedExtensions = setOf("txt", "md"),
+    )
+}) {
     Text("Save a file")
 }
 

--- a/filekit-core/src/androidHostTest/kotlin/io/github/vinceglb/filekit/PlatformFileAndroidTest.kt
+++ b/filekit-core/src/androidHostTest/kotlin/io/github/vinceglb/filekit/PlatformFileAndroidTest.kt
@@ -438,6 +438,23 @@ class PlatformFileAndroidTest {
     }
 
     @Test
+    fun PlatformFile_createDocumentUri_isRegularFileWithoutTreeUriCrash() {
+        val savedUri = Uri.parse(
+            "content://com.android.externalstorage.documents/document/primary%3ADownload%2Fbonjour%2Fdocument.pdf",
+        )
+        ShadowContentResolver.registerProviderInternal(
+            "com.android.externalstorage.documents",
+            createNestedTreeContentProvider(),
+        )
+
+        val file = PlatformFile(savedUri)
+
+        assertTrue(file.exists())
+        assertFalse(file.isDirectory())
+        assertTrue(file.isRegularFile())
+    }
+
+    @Test
     @Config(sdk = [23])
     fun PlatformFile_fromBookmarkData_bookmarkedTreeUriOnApi23_restoresAccessibleFile() {
         val treeUri = Uri.parse("content://com.android.externalstorage.documents/tree/primary%3ADocuments")
@@ -487,6 +504,11 @@ private class NestedTreeContentProvider : ContentProvider() {
             false,
         ),
         "primary:Documents/Notes/note.txt" to TestDocument("primary:Documents/Notes/note.txt", "note.txt", false),
+        "primary:Download/bonjour/document.pdf" to TestDocument(
+            "primary:Download/bonjour/document.pdf",
+            "document.pdf",
+            false,
+        ),
     )
 
     override fun onCreate(): Boolean = true

--- a/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
+++ b/filekit-core/src/androidMain/kotlin/io/github/vinceglb/filekit/PlatformFile.android.kt
@@ -923,6 +923,10 @@ internal fun Uri.listDocuments(): List<PlatformFile> {
 }
 
 private fun Uri.findChildDocumentInfo(): AndroidDocumentInfo? {
+    if (!isTreeUriCompat()) {
+        return null
+    }
+
     val (parentDocumentId, childName) = parentDocumentIdAndNameOrNull() ?: return null
 
     return findChildDocumentInfo(
@@ -935,7 +939,11 @@ private fun Uri.findChildDocumentInfo(
     parentDocumentId: String,
     childName: String,
 ): AndroidDocumentInfo? {
-    val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(this, parentDocumentId)
+    val childrenUri = try {
+        DocumentsContract.buildChildDocumentsUriUsingTree(this, parentDocumentId)
+    } catch (_: IllegalArgumentException) {
+        return null
+    }
 
     return queryDocumentInfos(childrenUri).firstOrNull { it.name == childName }
 }

--- a/filekit-dialogs-compose/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/AndroidComposePickerReliabilityTest.kt
+++ b/filekit-dialogs-compose/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/AndroidComposePickerReliabilityTest.kt
@@ -343,6 +343,10 @@ class AndroidComposePickerReliabilityTest {
     fun FileSaverName_normalizesAndBuildsSuggestedName() {
         assertEquals("pdf", FileKitAndroidDialogsInternal.normalizeFileSaverExtension(" .pdf "))
         assertEquals(
+            setOf("txt", "md"),
+            FileKitAndroidDialogsInternal.normalizeFileSaverExtensions(setOf(" .txt ", ".md")),
+        )
+        assertEquals(
             expected = "report.pdf",
             actual = FileKitAndroidDialogsInternal.buildFileSaverSuggestedName(
                 suggestedName = "report",

--- a/filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.android.kt
+++ b/filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.android.kt
@@ -324,19 +324,27 @@ internal actual fun rememberPlatformFileSaverLauncher(
     }
 
     return remember(launcher) {
-        SaverResultLauncher { suggestedName, extension, directory ->
-            val normalizedExtension = FileKitAndroidDialogsInternal.normalizeFileSaverExtension(extension)
+        SaverResultLauncher { suggestedName, defaultExtension, allowedExtensions, directory ->
+            val normalizedDefaultExtension = FileKitAndroidDialogsInternal.normalizeFileSaverExtension(defaultExtension)
+            val normalizedAllowedExtensions = FileKitAndroidDialogsInternal
+                .normalizeFileSaverExtensions(allowedExtensions)
+            val allowedMimeTypes = normalizedAllowedExtensions?.let(FileKitAndroidDialogsInternal::getMimeTypes)
             val fileName = FileKitAndroidDialogsInternal.buildFileSaverSuggestedName(
                 suggestedName = suggestedName,
-                extension = normalizedExtension,
+                extension = normalizedDefaultExtension,
             )
-            val mimeType = FileKitAndroidDialogsInternal.getMimeType(normalizedExtension)
+            val mimeType = when {
+                allowedMimeTypes != null && allowedMimeTypes.size > 1 -> "*/*"
+                allowedMimeTypes != null -> allowedMimeTypes.first()
+                else -> FileKitAndroidDialogsInternal.getMimeType(normalizedDefaultExtension)
+            }
 
             hasPendingLaunch = true
             launcher.launch(
                 CreateDocumentInput(
                     mimeType = mimeType,
                     fileName = fileName,
+                    allowedMimeTypes = allowedMimeTypes,
                 ),
             )
         }
@@ -730,13 +738,18 @@ private class DynamicPickMultipleVisualMediaContract : ActivityResultContract<Dy
 private data class CreateDocumentInput(
     val mimeType: String,
     val fileName: String,
+    val allowedMimeTypes: Array<String>?,
 )
 
 private class CreateDocumentDynamicContract : ActivityResultContract<CreateDocumentInput, Uri?>() {
     override fun createIntent(
         context: Context,
         input: CreateDocumentInput,
-    ): Intent = ActivityResultContracts.CreateDocument(input.mimeType).createIntent(context, input.fileName)
+    ): Intent = ActivityResultContracts.CreateDocument(input.mimeType)
+        .createIntent(context, input.fileName)
+        .apply {
+            input.allowedMimeTypes?.let { putExtra(Intent.EXTRA_MIME_TYPES, it) }
+        }
 
     override fun parseResult(resultCode: Int, intent: Intent?): Uri? = ActivityResultContracts
         .CreateDocument(

--- a/filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.android.kt
+++ b/filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.android.kt
@@ -745,7 +745,8 @@ private class CreateDocumentDynamicContract : ActivityResultContract<CreateDocum
     override fun createIntent(
         context: Context,
         input: CreateDocumentInput,
-    ): Intent = ActivityResultContracts.CreateDocument(input.mimeType)
+    ): Intent = ActivityResultContracts
+        .CreateDocument(input.mimeType)
         .createIntent(context, input.fileName)
         .apply {
             input.allowedMimeTypes?.let { putExtra(Intent.EXTRA_MIME_TYPES, it) }

--- a/filekit-dialogs-compose/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitResultLauncher.kt
+++ b/filekit-dialogs-compose/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitResultLauncher.kt
@@ -22,22 +22,59 @@ public class PickerResultLauncher(
 public class SaverResultLauncher(
     private val onLaunch: (
         suggestedName: String,
-        extension: String?,
+        defaultExtension: String?,
+        allowedExtensions: Set<String>?,
         directory: PlatformFile?,
     ) -> Unit,
 ) {
     /**
      * Launches the file saver dialog.
      *
+     * [defaultExtension] controls the suggested/default extension for the
+     * generated file name. [allowedExtensions] controls native save dialog
+     * filters where the platform supports them; apps that require a specific
+     * output format should still validate the returned file extension.
+     *
      * @param suggestedName The suggested name for the file.
-     * @param extension The file extension (optional).
+     * @param defaultExtension The default file extension without the dot.
+     * @param allowedExtensions Allowed file extensions for the native save dialog.
      * @param directory The initial directory (optional, supported on desktop).
      */
+    public fun launch(
+        suggestedName: String,
+        defaultExtension: String? = null,
+        allowedExtensions: Set<String>? = null,
+        directory: PlatformFile? = null,
+    ) {
+        onLaunch(suggestedName, defaultExtension, allowedExtensions, directory)
+    }
+
+    /**
+     * Launches the file saver dialog.
+     *
+     * @param suggestedName The suggested name for the file.
+     * @param extension The default file extension without the dot.
+     * @param directory The initial directory (optional, supported on desktop).
+     */
+    @Deprecated(
+        message = "Use defaultExtension. The extension parameter is a default extension hint, not a filter.",
+        replaceWith = ReplaceWith(
+            "launch(" +
+                "suggestedName = suggestedName, " +
+                "defaultExtension = extension, " +
+                "directory = directory" +
+                ")",
+        ),
+    )
     public fun launch(
         suggestedName: String,
         extension: String? = null,
         directory: PlatformFile? = null,
     ) {
-        onLaunch(suggestedName, extension, directory)
+        launch(
+            suggestedName = suggestedName,
+            defaultExtension = extension,
+            directory = directory,
+        )
     }
 }

--- a/filekit-dialogs-compose/src/jvmAndNativeMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nativeAndJvm.kt
+++ b/filekit-dialogs-compose/src/jvmAndNativeMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nativeAndJvm.kt
@@ -22,11 +22,12 @@ internal actual fun rememberPlatformFileSaverLauncher(
     val currentOnResult by rememberUpdatedState(onResult)
 
     return remember {
-        SaverResultLauncher { suggestedName, extension, directory ->
+        SaverResultLauncher { suggestedName, defaultExtension, allowedExtensions, directory ->
             coroutineScope.launch {
                 val result = FileKit.openFileSaver(
                     suggestedName = suggestedName,
-                    extension = extension,
+                    defaultExtension = defaultExtension,
+                    allowedExtensions = allowedExtensions,
                     directory = directory,
                     dialogSettings = currentDialogSettings,
                 )

--- a/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.android.kt
+++ b/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.android.kt
@@ -60,24 +60,35 @@ internal actual suspend fun FileKit.platformOpenFilePicker(
  * @param dialogSettings Platform-specific settings for the dialog.
  * @return The path where the file should be saved as a [PlatformFile], or null if cancelled.
  */
-public actual suspend fun FileKit.openFileSaver(
+internal actual suspend fun FileKit.platformOpenFileSaver(
     suggestedName: String,
-    extension: String?,
+    defaultExtension: String?,
+    allowedExtensions: Set<String>?,
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
 ): PlatformFile? {
     val registry = FileKit.registry
-    val normalizedExtension = FileKitAndroidDialogsInternal.normalizeFileSaverExtension(extension)
-    val mimeType = FileKitAndroidDialogsInternal.getMimeType(normalizedExtension)
-    val contract = ActivityResultContracts.CreateDocument(mimeType)
+    val normalizedDefaultExtension = FileKitAndroidDialogsInternal.normalizeFileSaverExtension(defaultExtension)
+    val normalizedAllowedExtensions = FileKitAndroidDialogsInternal.normalizeFileSaverExtensions(allowedExtensions)
+    val allowedMimeTypes = normalizedAllowedExtensions?.let(FileKitAndroidDialogsInternal::getMimeTypes)
+    val mimeType = when {
+        allowedMimeTypes != null && allowedMimeTypes.size > 1 -> "*/*"
+        allowedMimeTypes != null -> allowedMimeTypes.first()
+        else -> FileKitAndroidDialogsInternal.getMimeType(normalizedDefaultExtension)
+    }
+    val contract = CreateDocumentDynamicContract()
     val fileName = FileKitAndroidDialogsInternal.buildFileSaverSuggestedName(
         suggestedName = suggestedName,
-        extension = normalizedExtension,
+        extension = normalizedDefaultExtension,
     )
     val uri = awaitActivityResult(
         registry = registry,
         contract = contract,
-        input = fileName,
+        input = CreateDocumentInput(
+            mimeType = mimeType,
+            fileName = fileName,
+            allowedMimeTypes = allowedMimeTypes,
+        ),
     )
     return uri?.let(::PlatformFile)
 }
@@ -486,6 +497,29 @@ private suspend fun <I, O> awaitActivityResult(
             }
         }
     }
+}
+
+private class CreateDocumentInput(
+    val mimeType: String,
+    val fileName: String,
+    val allowedMimeTypes: Array<String>?,
+)
+
+private class CreateDocumentDynamicContract : ActivityResultContract<CreateDocumentInput, Uri?>() {
+    override fun createIntent(
+        context: Context,
+        input: CreateDocumentInput,
+    ): Intent = ActivityResultContracts
+        .CreateDocument(input.mimeType)
+        .createIntent(context, input.fileName)
+        .apply {
+            input.allowedMimeTypes?.let { putExtra(Intent.EXTRA_MIME_TYPES, it) }
+        }
+
+    override fun parseResult(resultCode: Int, intent: Intent?): Uri? = ActivityResultContracts
+        .CreateDocument(
+            "*/*",
+        ).parseResult(resultCode, intent)
 }
 
 internal object FileKitDialog {

--- a/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitAndroidDialogsInternal.kt
+++ b/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitAndroidDialogsInternal.kt
@@ -37,6 +37,10 @@ public object FileKitAndroidDialogsInternal {
         io.github.vinceglb.filekit.dialogs
             .normalizeFileSaverExtension(extension)
 
+    public fun normalizeFileSaverExtensions(extensions: Set<String>?): Set<String>? =
+        io.github.vinceglb.filekit.dialogs
+            .normalizeFileSaverExtensions(extensions)
+
     public fun buildFileSaverSuggestedName(
         suggestedName: String,
         extension: String?,

--- a/filekit-dialogs/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/FileSaverName.kt
+++ b/filekit-dialogs/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/FileSaverName.kt
@@ -5,6 +5,11 @@ internal fun normalizeFileSaverExtension(extension: String?): String? = extensio
     ?.trimStart('.')
     ?.takeIf { it.isNotBlank() }
 
+internal fun normalizeFileSaverExtensions(extensions: Set<String>?): Set<String>? = extensions
+    ?.mapNotNull(::normalizeFileSaverExtension)
+    ?.toSet()
+    ?.takeIf { it.isNotEmpty() }
+
 internal fun buildFileSaverSuggestedName(
     suggestedName: String,
     extension: String?,

--- a/filekit-dialogs/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/FileSaverNameTest.kt
+++ b/filekit-dialogs/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/FileSaverNameTest.kt
@@ -28,6 +28,20 @@ class FileSaverNameTest {
     }
 
     @Test
+    fun normalizeFileSaverExtensions_whenValuesContainDotsAndBlankEntries_returnsCleanSet() {
+        assertEquals(
+            setOf("pdf", "md"),
+            normalizeFileSaverExtensions(setOf(" .pdf ", ".", "", "md")),
+        )
+    }
+
+    @Test
+    fun normalizeFileSaverExtensions_whenNoUsableValues_returnsNull() {
+        assertNull(normalizeFileSaverExtensions(null))
+        assertNull(normalizeFileSaverExtensions(setOf("", ".", "   ")))
+    }
+
+    @Test
     fun buildFileSaverSuggestedName_whenExtensionNullOrBlank_returnsSuggestedName() {
         assertEquals("document", buildFileSaverSuggestedName("document", null))
         assertEquals("document", buildFileSaverSuggestedName("document", ""))

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -130,15 +130,17 @@ public actual suspend fun FileKit.openDirectoryPicker(
  * Opens a file saver dialog.
  *
  * @param suggestedName The suggested name for the file.
- * @param extension The file extension (optional).
+ * @param defaultExtension The default file extension without the dot.
+ * @param allowedExtensions Allowed file extensions for the native save dialog. Ignored on iOS.
  * @param directory The initial directory. Supported on desktop platforms.
  * @param dialogSettings Platform-specific settings for the dialog.
  * @return The path where the file should be saved as a [PlatformFile], or null if canceled.
  */
 @OptIn(ExperimentalForeignApi::class)
-public actual suspend fun FileKit.openFileSaver(
+internal actual suspend fun FileKit.platformOpenFileSaver(
     suggestedName: String,
-    extension: String?,
+    defaultExtension: String?,
+    allowedExtensions: Set<String>?,
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
 ): PlatformFile? = withContext(Dispatchers.Main) {
@@ -166,9 +168,10 @@ public actual suspend fun FileKit.openFileSaver(
         // the suggestedName cannot include "/" because the OS interprets it as a directory separator.
         // However, "Files" renders ":" as "/", so we can just use ":" and the user will see "/".
         val sanitizedSuggestedName = suggestedName.replace("/", ":")
+        val normalizedDefaultExtension = normalizeFileSaverExtension(defaultExtension)
         val fileName = buildFileSaverSuggestedName(
             suggestedName = sanitizedSuggestedName,
-            extension = extension,
+            extension = normalizedDefaultExtension,
         )
 
         // Get the fileManager

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.jvm.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.jvm.kt
@@ -75,16 +75,19 @@ public actual suspend fun FileKit.openDirectoryPicker(
  * @param dialogSettings Platform-specific settings for the dialog.
  * @return The path where the file should be saved as a [PlatformFile], or null if cancelled.
  */
-public actual suspend fun FileKit.openFileSaver(
+internal actual suspend fun FileKit.platformOpenFileSaver(
     suggestedName: String,
-    extension: String?,
+    defaultExtension: String?,
+    allowedExtensions: Set<String>?,
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
 ): PlatformFile? = withContext(Dispatchers.IO) {
-    val normalizedExtension = normalizeFileSaverExtension(extension)
+    val normalizedDefaultExtension = normalizeFileSaverExtension(defaultExtension)
+    val normalizedAllowedExtensions = normalizeFileSaverExtensions(allowedExtensions)
     val result = PlatformFilePicker.current.openFileSaver(
         suggestedName = suggestedName,
-        extension = normalizedExtension,
+        defaultExtension = normalizedDefaultExtension,
+        allowedExtensions = normalizedAllowedExtensions,
         directory = directory,
         dialogSettings = dialogSettings,
     )

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/PlatformFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/PlatformFilePicker.kt
@@ -33,12 +33,14 @@ internal interface PlatformFilePicker {
 
     suspend fun openFileSaver(
         suggestedName: String,
-        extension: String?,
+        defaultExtension: String?,
+        allowedExtensions: Set<String>?,
         directory: PlatformFile?,
         dialogSettings: FileKitDialogSettings,
     ): File? = AwtFileSaver.saveFile(
         suggestedName = suggestedName,
-        extension = extension,
+        defaultExtension = defaultExtension,
+        allowedExtensions = allowedExtensions,
         directory = directory,
         dialogSettings = dialogSettings,
     )

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtFileSaver.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtFileSaver.kt
@@ -13,7 +13,8 @@ import kotlin.coroutines.resume
 internal object AwtFileSaver {
     suspend fun saveFile(
         suggestedName: String,
-        extension: String?,
+        defaultExtension: String?,
+        allowedExtensions: Set<String>?,
         directory: PlatformFile?,
         dialogSettings: FileKitDialogSettings?,
     ): File? = suspendCancellableCoroutine { continuation ->
@@ -44,9 +45,15 @@ internal object AwtFileSaver {
         // Set initial directory
         directory?.let { dialog.directory = directory.path }
 
+        allowedExtensions?.let { extensions ->
+            dialog.filenameFilter = java.io.FilenameFilter { _, name ->
+                extensions.any { extension -> name.endsWith(".$extension", ignoreCase = true) }
+            }
+        }
+
         // Set file name
         dialog.file = when {
-            extension != null -> "$suggestedName.$extension"
+            defaultExtension != null -> "$suggestedName.$defaultExtension"
             else -> suggestedName
         }
 

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtFileSaver.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtFileSaver.kt
@@ -45,7 +45,8 @@ internal object AwtFileSaver {
         // Set initial directory
         directory?.let { dialog.directory = directory.path }
 
-        allowedExtensions?.let { extensions ->
+        val filterExtensions = allowedExtensions ?: defaultExtension?.let { setOf(it) }
+        filterExtensions?.let { extensions ->
             dialog.filenameFilter = java.io.FilenameFilter { _, name ->
                 extensions.any { extension -> name.endsWith(".$extension", ignoreCase = true) }
             }

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/linux/LinuxFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/linux/LinuxFilePicker.kt
@@ -64,17 +64,19 @@ internal class LinuxFilePicker(
 
     override suspend fun openFileSaver(
         suggestedName: String,
-        extension: String?,
+        defaultExtension: String?,
+        allowedExtensions: Set<String>?,
         directory: PlatformFile?,
         dialogSettings: FileKitDialogSettings,
     ): File? = if (xdgFilePickerPortalAvailable) {
         xdgFilePickerPortal.openFileSaver(
             suggestedName,
-            extension,
+            defaultExtension,
+            allowedExtensions,
             directory,
             dialogSettings,
         )
     } else {
-        awtFilePicker.openFileSaver(suggestedName, extension, directory, dialogSettings)
+        awtFilePicker.openFileSaver(suggestedName, defaultExtension, allowedExtensions, directory, dialogSettings)
     }
 }

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/mac/MacOSFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/mac/MacOSFilePicker.kt
@@ -3,6 +3,7 @@ package io.github.vinceglb.filekit.dialogs.platform.mac
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitMacOSSettings
+import io.github.vinceglb.filekit.dialogs.buildFileSaverSuggestedName
 import io.github.vinceglb.filekit.dialogs.platform.PlatformFilePicker
 import io.github.vinceglb.filekit.dialogs.platform.mac.foundation.Foundation
 import io.github.vinceglb.filekit.dialogs.platform.mac.foundation.ID
@@ -47,6 +48,63 @@ internal class MacOSFilePicker : PlatformFilePicker {
         macOSSettings = dialogSettings.macOS,
     )
 
+    override suspend fun openFileSaver(
+        suggestedName: String,
+        defaultExtension: String?,
+        allowedExtensions: Set<String>?,
+        directory: PlatformFile?,
+        dialogSettings: FileKitDialogSettings,
+    ): File? = withContext(Dispatchers.IO) {
+        val pool = Foundation.NSAutoreleasePool()
+        try {
+            var response: File? = null
+
+            Foundation.executeOnMainThread(
+                withAutoreleasePool = false,
+                waitUntilDone = true,
+            ) {
+                val savePanel = Foundation.invoke("NSSavePanel", "new")
+
+                dialogSettings.title?.let {
+                    Foundation.invoke(savePanel, "setMessage:", Foundation.nsString(it))
+                }
+
+                directory?.let {
+                    Foundation.invoke(savePanel, "setDirectoryURL:", Foundation.nsURL(it.path))
+                }
+
+                Foundation.invoke(
+                    savePanel,
+                    "setNameFieldStringValue:",
+                    Foundation.nsString(
+                        buildFileSaverSuggestedName(
+                            suggestedName = suggestedName,
+                            extension = defaultExtension,
+                        ),
+                    ),
+                )
+
+                val fileTypes = allowedExtensions ?: defaultExtension?.let { setOf(it) }
+                savePanel.setAllowedFileTypes(fileTypes)
+
+                Foundation.invoke(
+                    savePanel,
+                    "setCanCreateDirectories:",
+                    dialogSettings.macOS.canCreateDirectories,
+                )
+
+                val result = Foundation.invoke(savePanel, "runModal")
+                if (result.toInt() == NS_MODAL_RESPONSE_OK) {
+                    response = singlePath(savePanel)
+                }
+            }
+
+            response
+        } finally {
+            pool.drain()
+        }
+    }
+
     private suspend fun <T> callNativeMacOSPicker(
         mode: MacOSFilePickerMode<T>,
         directory: PlatformFile?,
@@ -79,15 +137,7 @@ internal class MacOSFilePicker : PlatformFilePicker {
                 }
 
                 // Set file extensions
-                fileExtensions?.let { extensions ->
-                    val items = extensions.map { Foundation.nsString(it) }
-                    val nsData = Foundation.invokeVarArg(
-                        "NSArray",
-                        "arrayWithObjects:",
-                        *items.toTypedArray(),
-                    )
-                    Foundation.invoke(openPanel, "setAllowedFileTypes:", nsData)
-                }
+                openPanel.setAllowedFileTypes(fileExtensions)
 
                 // Set resolvesAliases
                 macOSSettings.resolvesAliases?.let { resolvesAliases ->
@@ -110,9 +160,37 @@ internal class MacOSFilePicker : PlatformFilePicker {
     }
 
     private companion object {
+        const val NS_MODAL_RESPONSE_OK = 1
+
+        fun Collection<String>.toNsStringArray(): ID? {
+            if (isEmpty()) {
+                return null
+            }
+
+            val items = map { Foundation.nsString(it) }
+            return Foundation.invokeVarArg(
+                "NSArray",
+                "arrayWithObjects:",
+                *items.toTypedArray(),
+            )
+        }
+
+        fun ID.setAllowedFileTypes(extensions: Collection<String>?) {
+            val fileTypes = extensions?.toNsStringArray() ?: return
+            Foundation.invoke(this, "setAllowedFileTypes:", fileTypes)
+        }
+
         fun singlePath(openPanel: ID): File? {
             val url = Foundation.invoke(openPanel, "URL")
+            if (Foundation.isNil(url)) {
+                return null
+            }
+
             val nsPath = Foundation.invoke(url, "path")
+            if (Foundation.isNil(nsPath)) {
+                return null
+            }
+
             val path = Foundation.toStringViaUTF8(nsPath)
             return path?.let { File(it) }
         }

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsFilePicker.kt
@@ -119,7 +119,8 @@ internal class WindowsFilePicker : PlatformFilePicker {
 
     override suspend fun openFileSaver(
         suggestedName: String,
-        extension: String?,
+        defaultExtension: String?,
+        allowedExtensions: Set<String>?,
         directory: PlatformFile?,
         dialogSettings: FileKitDialogSettings,
     ): File? = useFileDialog(FileDialogType.Save) { fileSaveDialog ->
@@ -132,14 +133,15 @@ internal class WindowsFilePicker : PlatformFilePicker {
             .verify("SetFileName failed")
 
         // Set the default extension
-        extension?.let {
+        defaultExtension?.let {
             fileSaveDialog
-                .SetDefaultExtension(WString(extension))
+                .SetDefaultExtension(WString(defaultExtension))
                 .verify("SetDefaultExtension failed")
         }
 
         // Set filters
-        extension?.let { fileSaveDialog.addFiltersToDialog(setOf(extension)) }
+        val filterExtensions = allowedExtensions ?: defaultExtension?.let { setOf(it) }
+        filterExtensions?.let { fileSaveDialog.addFiltersToDialog(it) }
 
         // Show the dialog to the user
         fileSaveDialog.show(dialogSettings.parentWindow) {

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/xdg/XdgFilePickerPortal.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/xdg/XdgFilePickerPortal.kt
@@ -114,7 +114,8 @@ internal class XdgFilePickerPortal : PlatformFilePicker {
 
     override suspend fun openFileSaver(
         suggestedName: String,
-        extension: String?,
+        defaultExtension: String?,
+        allowedExtensions: Set<String>?,
         directory: PlatformFile?,
         dialogSettings: FileKitDialogSettings,
     ): File? {
@@ -124,10 +125,11 @@ internal class XdgFilePickerPortal : PlatformFilePicker {
             options["handle_token"] = Variant(handleToken)
 
             options["current_name"] = when {
-                extension != null -> Variant("$suggestedName.$extension")
+                defaultExtension != null -> Variant("$suggestedName.$defaultExtension")
                 else -> Variant(suggestedName)
             }
 
+            allowedExtensions?.let { options["filters"] = createFilterOption(it) }
             directory?.let { options["current_folder"] = createCurrentFolderOption(it) }
 
             val deferredResult = registerResponseHandler(connection, handleToken)

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/xdg/XdgFilePickerPortal.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/xdg/XdgFilePickerPortal.kt
@@ -129,7 +129,8 @@ internal class XdgFilePickerPortal : PlatformFilePicker {
                 else -> Variant(suggestedName)
             }
 
-            allowedExtensions?.let { options["filters"] = createFilterOption(it) }
+            val filterExtensions = allowedExtensions ?: defaultExtension?.let { setOf(it) }
+            filterExtensions?.let { options["filters"] = createFilterOption(it) }
             directory?.let { options["current_folder"] = createCurrentFolderOption(it) }
 
             val deferredResult = registerResponseHandler(connection, handleToken)

--- a/filekit-dialogs/src/macosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.macos.kt
+++ b/filekit-dialogs/src/macosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.macos.kt
@@ -65,15 +65,17 @@ public actual suspend fun FileKit.openDirectoryPicker(
  * @param dialogSettings Platform-specific settings for the dialog.
  * @return The path where the file should be saved as a [PlatformFile], or null if canceled.
  */
-public actual suspend fun FileKit.openFileSaver(
+internal actual suspend fun FileKit.platformOpenFileSaver(
     suggestedName: String,
-    extension: String?,
+    defaultExtension: String?,
+    allowedExtensions: Set<String>?,
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
 ): PlatformFile? {
     // Create an NSSavePanel
     val nsSavePanel = NSSavePanel()
-    val normalizedExtension = normalizeFileSaverExtension(extension)
+    val normalizedDefaultExtension = normalizeFileSaverExtension(defaultExtension)
+    val normalizedAllowedExtensions = normalizeFileSaverExtensions(allowedExtensions)
 
     // Set the initial directory
     directory?.let { nsSavePanel.directoryURL = NSURL.fileURLWithPath(it.path) }
@@ -81,13 +83,12 @@ public actual suspend fun FileKit.openFileSaver(
     // Set the file name
     nsSavePanel.nameFieldStringValue = buildFileSaverSuggestedName(
         suggestedName = suggestedName,
-        extension = normalizedExtension,
+        extension = normalizedDefaultExtension,
     )
 
-    // Set the file extension
-    normalizedExtension?.let {
-        nsSavePanel.allowedFileTypes = listOf(it)
-    }
+    // Set the file extension filters
+    val fileTypes = normalizedAllowedExtensions ?: normalizedDefaultExtension?.let { setOf(it) }
+    fileTypes?.let { nsSavePanel.allowedFileTypes = it.toList() }
 
     // Accept the creation of directories
     nsSavePanel.canCreateDirectories = dialogSettings.canCreateDirectories

--- a/filekit-dialogs/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.mingw.kt
+++ b/filekit-dialogs/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.mingw.kt
@@ -90,14 +90,16 @@ public actual suspend fun FileKit.openDirectoryPicker(
     showOpenDialog(null, directory, dialogSettings.title, pickFolders = true, allowMultiple = false)
         ?.firstOrNull()
 
-public actual suspend fun FileKit.openFileSaver(
+internal actual suspend fun FileKit.platformOpenFileSaver(
     suggestedName: String,
-    extension: String?,
+    defaultExtension: String?,
+    allowedExtensions: Set<String>?,
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
 ): PlatformFile? {
-    val ext = normalizeFileSaverExtension(extension)
-    return showSaveDialog(buildFileSaverSuggestedName(suggestedName, ext), ext, directory, dialogSettings.title)
+    val ext = normalizeFileSaverExtension(defaultExtension)
+    val filters = normalizeFileSaverExtensions(allowedExtensions)
+    return showSaveDialog(buildFileSaverSuggestedName(suggestedName, ext), ext, filters, directory, dialogSettings.title)
 }
 
 public actual fun FileKit.openFileWithDefaultApplication(
@@ -171,7 +173,8 @@ private fun showOpenDialog(
 
 private fun showSaveDialog(
     suggestedName: String,
-    extension: String?,
+    defaultExtension: String?,
+    allowedExtensions: Set<String>?,
     directory: PlatformFile?,
     title: String?,
 ): PlatformFile? = memScoped {
@@ -206,15 +209,16 @@ private fun showSaveDialog(
         if (setFilenameHr != S_OK) {
             throw IllegalStateException("IFileDialog::SetFileName failed with HRESULT 0x${setFilenameHr.toUInt().toString(16)}")
         }
-        extension?.let {
+        defaultExtension?.let {
             val setDefaultExtensionHr = fk_dialog_set_default_extension(dlg.reinterpret(), it)
             if (setDefaultExtensionHr != S_OK) {
                 throw IllegalStateException(
                     "IFileDialog::SetDefaultExtension failed with HRESULT 0x${setDefaultExtensionHr.toUInt().toString(16)}",
                 )
             }
-            setFileTypes(dlg, setOf(it))
         }
+        val filterExtensions = allowedExtensions ?: defaultExtension?.let { setOf(it) }
+        filterExtensions?.let { setFileTypes(dlg, it) }
         directory?.let { setFolder(dlg, it) }
 
         val hr = fk_dialog_show(dlg.reinterpret(), null)

--- a/filekit-dialogs/src/nonWebMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.nonWeb.kt
+++ b/filekit-dialogs/src/nonWebMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.nonWeb.kt
@@ -6,17 +6,70 @@ import io.github.vinceglb.filekit.PlatformFile
 /**
  * Opens a file saver dialog.
  *
+ * [defaultExtension] controls the suggested/default extension for the generated
+ * file name. [allowedExtensions] controls native save dialog filters where the
+ * platform supports them; apps that require a specific output format should
+ * still validate the returned file extension.
+ *
  * @param suggestedName The suggested name for the file.
- * @param extension The file extension (optional).
+ * @param defaultExtension The default file extension without the dot.
+ * @param allowedExtensions The allowed file extensions without dots.
  * @param directory The initial directory. Supported on desktop platforms.
  * @param dialogSettings Platform-specific settings for the dialog.
  * @return The path where the file should be saved as a [PlatformFile], or null if cancelled.
  */
-public expect suspend fun FileKit.openFileSaver(
+public suspend fun FileKit.openFileSaver(
+    suggestedName: String,
+    defaultExtension: String? = null,
+    allowedExtensions: Set<String>? = null,
+    directory: PlatformFile? = null,
+    dialogSettings: FileKitDialogSettings = FileKitDialogSettings.createDefault(),
+): PlatformFile? = platformOpenFileSaver(
+    suggestedName = suggestedName,
+    defaultExtension = defaultExtension,
+    allowedExtensions = allowedExtensions,
+    directory = directory,
+    dialogSettings = dialogSettings,
+)
+
+/**
+ * Opens a file saver dialog.
+ *
+ * @param suggestedName The suggested name for the file.
+ * @param extension The default file extension without the dot.
+ * @param directory The initial directory. Supported on desktop platforms.
+ * @param dialogSettings Platform-specific settings for the dialog.
+ * @return The path where the file should be saved as a [PlatformFile], or null if cancelled.
+ */
+@Deprecated(
+    message = "Use defaultExtension. The extension parameter is a default extension hint, not a filter.",
+    replaceWith = ReplaceWith(
+        "openFileSaver(" +
+            "suggestedName = suggestedName, " +
+            "defaultExtension = extension, " +
+            "directory = directory, " +
+            "dialogSettings = dialogSettings" +
+            ")",
+    ),
+)
+public suspend fun FileKit.openFileSaver(
     suggestedName: String,
     extension: String? = null,
     directory: PlatformFile? = null,
     dialogSettings: FileKitDialogSettings = FileKitDialogSettings.createDefault(),
+): PlatformFile? = openFileSaver(
+    suggestedName = suggestedName,
+    defaultExtension = extension,
+    directory = directory,
+    dialogSettings = dialogSettings,
+)
+
+internal expect suspend fun FileKit.platformOpenFileSaver(
+    suggestedName: String,
+    defaultExtension: String?,
+    allowedExtensions: Set<String>?,
+    directory: PlatformFile?,
+    dialogSettings: FileKitDialogSettings,
 ): PlatformFile?
 
 /**

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.kt
@@ -8,7 +8,8 @@ internal interface FileSaverLauncher {
 
     fun launch(
         suggestedName: String,
-        extension: String?,
+        defaultExtension: String?,
+        allowedExtensions: Set<String>?,
         directory: PlatformFile?,
     )
 }

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverScreen.kt
@@ -64,6 +64,7 @@ private fun FileSaverScreen(
     var buttonState by remember { mutableStateOf(AppScreenHeaderButtonState.Enabled) }
     var suggestedName by remember { mutableStateOf("document") }
     var extension by remember { mutableStateOf("pdf") }
+    var allowedExtensions by remember { mutableStateOf("pdf, txt") }
     var saveDirectory by remember { mutableStateOf<PlatformFile?>(null) }
     var savedFiles by remember { mutableStateOf(emptyList<PlatformFile>()) }
 
@@ -89,10 +90,17 @@ private fun FileSaverScreen(
         }
         val resolvedName = suggestedName.trim().ifBlank { "document" }
         val resolvedExtension = extension.trim().removePrefix(".").ifBlank { null }
+        val resolvedAllowedExtensions = allowedExtensions
+            .split(",")
+            .mapNotNull { value ->
+                value.trim().removePrefix(".").ifBlank { null }
+            }.toSet()
+            .takeIf { it.isNotEmpty() }
         buttonState = AppScreenHeaderButtonState.Loading
         fileSaverLauncher.launch(
             suggestedName = resolvedName,
-            extension = resolvedExtension,
+            defaultExtension = resolvedExtension,
+            allowedExtensions = resolvedAllowedExtensions,
             directory = saveDirectory,
         )
     }
@@ -128,14 +136,16 @@ private fun FileSaverScreen(
             item {
                 FileSaverSettingsCard(
                     suggestedName = suggestedName,
-                    extension = extension,
+                    defaultExtension = extension,
+                    allowedExtensions = allowedExtensions,
                     saveDirectoryName = saveDirectory?.name,
                     isSupported = isSupported,
                     onSuggestedNameChange = { suggestedName = it },
-                    onExtensionChange = { newValue ->
+                    onDefaultExtensionChange = { newValue ->
                         val trimmed = newValue.trim()
                         extension = if (trimmed.startsWith(".")) trimmed.drop(1) else trimmed
                     },
+                    onAllowedExtensionsChange = { allowedExtensions = it },
                     onPickSaveDirectory = directoryPickerLauncher::launch,
                     onClearSaveDirectory = { saveDirectory = null },
                     modifier = Modifier.sizeIn(maxWidth = AppMaxWidth),
@@ -168,11 +178,13 @@ private fun FileSaverScreen(
 @Composable
 private fun FileSaverSettingsCard(
     suggestedName: String,
-    extension: String,
+    defaultExtension: String,
+    allowedExtensions: String,
     saveDirectoryName: String?,
     isSupported: Boolean,
     onSuggestedNameChange: (String) -> Unit,
-    onExtensionChange: (String) -> Unit,
+    onDefaultExtensionChange: (String) -> Unit,
+    onAllowedExtensionsChange: (String) -> Unit,
     onPickSaveDirectory: () -> Unit,
     onClearSaveDirectory: () -> Unit,
     modifier: Modifier = Modifier,
@@ -203,12 +215,12 @@ private fun FileSaverSettingsCard(
                 }
 
                 AppField(
-                    label = "Extension",
+                    label = "Default Extension",
                     modifier = Modifier.weight(1f),
                 ) {
                     AppOutlinedTextField(
-                        value = extension,
-                        onValueChange = onExtensionChange,
+                        value = defaultExtension,
+                        onValueChange = onDefaultExtensionChange,
                         placeholder = {
                             Text(
                                 text = "pdf",
@@ -219,6 +231,21 @@ private fun FileSaverSettingsCard(
                         fontFamily = monoFontFamily,
                     )
                 }
+            }
+
+            AppField(label = "Allowed Extensions") {
+                AppOutlinedTextField(
+                    value = allowedExtensions,
+                    onValueChange = onAllowedExtensionsChange,
+                    placeholder = {
+                        Text(
+                            text = "pdf, txt",
+                            color = MaterialTheme.colorScheme.outline,
+                        )
+                    },
+                    modifier = Modifier.fillMaxWidth(),
+                    fontFamily = monoFontFamily,
+                )
             }
 
             AppPickerSelectionButton(

--- a/sample/shared/src/jvmMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.jvm.kt
+++ b/sample/shared/src/jvmMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.jvm.kt
@@ -21,12 +21,14 @@ internal actual fun rememberFileSaverLauncher(
 
             override fun launch(
                 suggestedName: String,
-                extension: String?,
+                defaultExtension: String?,
+                allowedExtensions: Set<String>?,
                 directory: PlatformFile?,
             ) {
                 launcher.launch(
                     suggestedName = suggestedName,
-                    extension = extension,
+                    defaultExtension = defaultExtension,
+                    allowedExtensions = allowedExtensions,
                     directory = directory,
                 )
             }

--- a/sample/shared/src/macosMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.macos.kt
+++ b/sample/shared/src/macosMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.macos.kt
@@ -21,12 +21,14 @@ internal actual fun rememberFileSaverLauncher(
 
             override fun launch(
                 suggestedName: String,
-                extension: String?,
+                defaultExtension: String?,
+                allowedExtensions: Set<String>?,
                 directory: PlatformFile?,
             ) {
                 launcher.launch(
                     suggestedName = suggestedName,
-                    extension = extension,
+                    defaultExtension = defaultExtension,
+                    allowedExtensions = allowedExtensions,
                     directory = directory,
                 )
             }

--- a/sample/shared/src/mobileMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.mobile.kt
+++ b/sample/shared/src/mobileMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.mobile.kt
@@ -21,12 +21,14 @@ internal actual fun rememberFileSaverLauncher(
 
             override fun launch(
                 suggestedName: String,
-                extension: String?,
+                defaultExtension: String?,
+                allowedExtensions: Set<String>?,
                 directory: PlatformFile?,
             ) {
                 launcher.launch(
                     suggestedName = suggestedName,
-                    extension = extension,
+                    defaultExtension = defaultExtension,
+                    allowedExtensions = allowedExtensions,
                     directory = directory,
                 )
             }

--- a/sample/shared/src/nonWebMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filedetails/components/FileDetailsActions.nonWeb.kt
+++ b/sample/shared/src/nonWebMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filedetails/components/FileDetailsActions.nonWeb.kt
@@ -77,7 +77,7 @@ internal actual fun FileDetailsActions(
                     scope.launch {
                         val selectedFile = FileKit.openFileSaver(
                             suggestedName = "${file.nameWithoutExtension}/(copy)",
-                            extension = file.extension,
+                            defaultExtension = file.extension,
                             directory = file.parent(),
                         )
 

--- a/sample/shared/src/webMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.web.kt
+++ b/sample/shared/src/webMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.web.kt
@@ -13,7 +13,8 @@ internal actual fun rememberFileSaverLauncher(
 
         override fun launch(
             suggestedName: String,
-            extension: String?,
+            defaultExtension: String?,
+            allowedExtensions: Set<String>?,
             directory: PlatformFile?,
         ) {
             onResult(null)


### PR DESCRIPTION
## Summary
- Add `defaultExtension` and optional `allowedExtensions` to the file saver API.
- Wire the new contract through JVM, Android, iOS, macOS, Windows, Linux, and Compose launchers.
- Keep the deprecated `extension` overload for compatibility.
- Update docs and the sample file saver screen to reflect the new behavior.
- Improve Android save-result handling for document URIs and add regression coverage.

## Testing
- `:filekit-dialogs:check` and `:filekit-dialogs-compose:check` passed.
- Sample compile checks passed for JVM, Android, JS, and WASM targets.
- Added/updated unit and host tests for file saver name normalization and Android save-path behavior.