### PR TITLE
⬇️ Revert Android SDK pins to 36

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 agp = "9.2.0"
-android-compileSdk = "37"
+android-compileSdk = "36"
 android-minSdk = "23"
-android-targetSdk = "37"
+android-targetSdk = "36"
 androidx-activity = "1.13.0"
 androidx-annotation = "1.9.1"
 androidx-documentfile = "1.1.0"


### PR DESCRIPTION
## Summary
- Revert the shared Android `compileSdk` and `targetSdk` from 37 back to 36.
- Keep the rest of the dependency and tooling versions unchanged.

## Testing
- Ran `:filekit-core:check :filekit-dialogs:check` locally; the modules passed.