### PR TITLE
🐛 Run JVM file picker off the main thread

### DIFF
--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.jvm.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.jvm.kt
@@ -13,7 +13,7 @@ internal actual suspend fun FileKit.platformOpenFilePicker(
     mode: PickerMode,
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
-): Flow<FileKitPickerState<List<PlatformFile>>> {
+): Flow<FileKitPickerState<List<PlatformFile>>> = withContext(Dispatchers.IO) {
     // Filter by extension
     val extensions = when (type) {
         FileKitType.Image -> imageExtensions
@@ -42,7 +42,7 @@ internal actual suspend fun FileKit.platformOpenFilePicker(
         }
     }
 
-    return files.toPickerStateFlow()
+    files.toPickerStateFlow()
 }
 
 /**


### PR DESCRIPTION
## Problem

On JVM, `platformOpenFilePicker` calls `PlatformFilePicker.current.openFilePicker(...)` / `openFilesPicker(...)` **directly on the caller's dispatcher**, unlike `openDirectoryPicker` and `openFileSaver`, which already wrap their blocking work in `withContext(Dispatchers.IO)`.

`rememberFilePickerLauncher` launches its coroutine on the composition scope, whose dispatcher is `Dispatchers.Main`. On Compose Multiplatform desktop, `Dispatchers.Main` is the UI/event-loop thread, so the picker's blocking native work runs on it before the first suspension point.

On **Linux**, the picker path (`LinuxFilePicker` → `XdgFilePickerPortal`) performs **synchronous D-Bus work** — building the session-bus connection, the `isAvailable()` probe, and the `OpenFile` round-trip — all before it suspends on the response. Running this on the UI thread freezes it.

- **AWT-based backends** (the default `application { Window { } }`) tolerate this because the xdg-desktop-portal handshake is driven by a separate AWT/X11 toolkit thread.
- **No-AWT backends** (e.g. a Tao/winit window whose `Dispatchers.Main` is the single GTK event-loop thread) **freeze — and can deadlock**: the portal needs the app's event loop to complete the dialog parenting/focus handshake, but that loop is blocked waiting on the synchronous `OpenFile` call.

The directory picker and file saver are unaffected precisely because they already hop to `Dispatchers.IO`.

## Fix

Wrap the `platformOpenFilePicker` body in `withContext(Dispatchers.IO)`, matching `openDirectoryPicker` and `openFileSaver`. This keeps the blocking native/D-Bus work off the UI thread; the result is delivered back through the normal suspension, so callers that observe the picker state on the main thread are unchanged.

```diff
-): Flow<FileKitPickerState<List<PlatformFile>>> {
+): Flow<FileKitPickerState<List<PlatformFile>>> = withContext(Dispatchers.IO) {
     // Filter by extension
     ...
-    return files.toPickerStateFlow()
+    files.toPickerStateFlow()
 }
```

No API change. One file touched: `filekit-dialogs/src/jvmMain/.../FileKit.jvm.kt`.