### PR TITLE
Bug Fix on `PlatformFile.delete()` API in iOS target

### DIFF
--- a/filekit-core/src/jvmAndNativeMain/kotlin/io/github/vinceglb/filekit/PlatformFile.jvmAndNative.kt
+++ b/filekit-core/src/jvmAndNativeMain/kotlin/io/github/vinceglb/filekit/PlatformFile.jvmAndNative.kt
@@ -58,8 +58,10 @@ public actual fun PlatformFile.createDirectories(mustCreate: Boolean): Unit =
     SystemFileSystem.createDirectories(toKotlinxIoPath(), mustCreate)
 
 public actual suspend fun PlatformFile.delete(mustExist: Boolean): Unit =
-    withContext(Dispatchers.IO) {
-        SystemFileSystem.delete(path = toKotlinxIoPath(), mustExist = mustExist)
+    withScopedAccess {
+        withContext(Dispatchers.IO) {
+            SystemFileSystem.delete(path = toKotlinxIoPath(), mustExist = mustExist)
+        }
     }
 
 public actual suspend fun PlatformFile.atomicMove(destination: PlatformFile): Unit =


### PR DESCRIPTION
The `public expect suspend fun PlatformFile.delete(mustExist: Boolean = true): Unit` API definision in `jvmAndNative` target, which is the API definision used by the `ios` target, is defined the delete logic without the `securityScopedAccess`. Because of this, the delete API fails on files which are picked using system file pickers, causing a crash. I wrapped the logic in `withScopedAccess` block, assuming this is an implementation mistake while every other APIs are implemented in that scope. Validate the commit and merge if applicable