### PR TITLE
Clean up sample app debug screen

### DIFF
--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/debug/DebugScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/debug/DebugScreen.kt
@@ -64,14 +64,14 @@ private fun DebugScreen(
 
     val scope = rememberCoroutineScope()
     val pickerReproSheetState = rememberModalBottomSheetState()
-    val picker = rememberFilePickerLauncher { file ->
-        buttonState = AppScreenHeaderButtonState.Enabled
-        files = file?.let(::listOf) ?: emptyList()
-
-        scope.launch {
-            file?.let { debugPlatformTest(it) }
-        }
-    }
+//    val picker = rememberFilePickerLauncher { file ->
+//        buttonState = AppScreenHeaderButtonState.Enabled
+//        files = file?.let(::listOf) ?: emptyList()
+//
+//        scope.launch {
+//            file?.let { debugPlatformTest(it) }
+//        }
+//    }
     val imagePicker = rememberFilePickerLauncher(
         type = FileKitType.Image,
         mode = FileKitMode.Multiple(),

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/debug/DebugScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/debug/DebugScreen.kt
@@ -85,6 +85,8 @@ private fun DebugScreen(
                 debugPlatformTest(folder)
                 // bookmarkFolder(folder)
             }
+
+            buttonState = AppScreenHeaderButtonState.Enabled
         }
     }
 
@@ -121,7 +123,7 @@ private fun DebugScreen(
                     title = "Debug",
                     subtitle = "Debug page for testing FileKit features",
                     documentationUrl = "",
-                    primaryButtonText = "Pick File",
+                    primaryButtonText = "Pick Folder",
                     primaryButtonState = buttonState,
                     onPrimaryButtonClick = {
                         buttonState = AppScreenHeaderButtonState.Loading


### PR DESCRIPTION
Hi @vinceglb,

This PR correctly sets the name of the folder picker button on the DebugScreen to "Pick Folder" rather than "Pick File".

It also resets the folder picker's buttonState to AppScreenHeaderButtonState.Enabled in it's onResult block. However, I would like to point out that the nonWeb implementation of the debugPlatformTest function is such that calling it on the same folder twice will throw an exception if the previously created savedDir is still present in the folder.

Lastly, this PR comments out an unused file picker on the same screen as I am not fully certain what it is for.

I look forward to your feedback.