### PR TITLE
🐛 Fix empty path deletion on iOS

### DIFF
--- a/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/utils/NSURLExt.kt
+++ b/filekit-core/src/appleMain/kotlin/io/github/vinceglb/filekit/utils/NSURLExt.kt
@@ -6,4 +6,7 @@ import platform.Foundation.NSURL
 
 public fun NSURL.toKotlinxPath(): Path = this.path
     ?.let(::Path)
+    ?: absoluteString
+        ?.takeIf(String::isEmpty)
+        ?.let(::Path)
     ?: throw FileKitNSURLNullPathException()

--- a/filekit-core/src/nonWebTest/kotlin/io/github/vinceglb/filekit/PlatformFileNonWebTest.kt
+++ b/filekit-core/src/nonWebTest/kotlin/io/github/vinceglb/filekit/PlatformFileNonWebTest.kt
@@ -105,6 +105,11 @@ class PlatformFileNonWebTest {
     }
 
     @Test
+    fun PlatformFile_deleteEmptyPathWithMustExistFalse_doesNothing() = runTest {
+        PlatformFile("").delete(mustExist = false)
+    }
+
+    @Test
     fun testPlatformFileReadBytes() = runTest {
         val textFileContent = textFile.readString()
         assertEquals(expected = "Hello, World!", actual = textFileContent)


### PR DESCRIPTION
## Summary

- Treat an empty `NSURL` as an empty Kotlin path on Apple platforms.
- Preserve `FileKitNSURLNullPathException` for other pathless URLs.
- Add regression coverage for `PlatformFile("").delete(mustExist = false)`.

This makes empty-path deletion consistent with Android when `mustExist` is `false`.

Fixes #592

## Verification

- Targeted iOS simulator regression test
- `./gradlew :filekit-core:check`
- Kotlin lint
- `git diff --check`