### PR TITLE
🐛 Force filesystem results for JVM Windows dialogs

### DIFF
--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsFilePicker.kt
@@ -27,6 +27,7 @@ import io.github.vinceglb.filekit.dialogs.platform.windows.jna.IFileSaveDialog
 import io.github.vinceglb.filekit.dialogs.platform.windows.jna.IShellItem
 import io.github.vinceglb.filekit.dialogs.platform.windows.jna.ShTypes.COMDLG_FILTERSPEC
 import io.github.vinceglb.filekit.dialogs.platform.windows.jna.ShTypes.FILEOPENDIALOGOPTIONS.Companion.FOS_ALLOWMULTISELECT
+import io.github.vinceglb.filekit.dialogs.platform.windows.jna.ShTypes.FILEOPENDIALOGOPTIONS.Companion.FOS_FORCEFILESYSTEM
 import io.github.vinceglb.filekit.dialogs.platform.windows.jna.ShTypes.FILEOPENDIALOGOPTIONS.Companion.FOS_PICKFOLDERS
 import io.github.vinceglb.filekit.dialogs.platform.windows.jna.ShTypes.SIGDN.Companion.SIGDN_DESKTOPABSOLUTEPARSING
 import io.github.vinceglb.filekit.dialogs.platform.windows.jna.ShTypes.SIGDN.Companion.SIGDN_FILESYSPATH
@@ -170,6 +171,8 @@ internal class WindowsFilePicker : PlatformFilePicker {
                 ).verify("CoCreateInstance failed")
                 .let { type.build(pbrFileDialog) }
 
+            fileDialog.updateOptions(::requiredFileDialogOptions)
+
             // Run the block
             block(fileDialog)
         } finally {
@@ -263,12 +266,16 @@ internal class WindowsFilePicker : PlatformFilePicker {
     }
 
     private fun FileDialog.setFlag(flag: Int) {
+        updateOptions { options -> options or flag }
+    }
+
+    private fun FileDialog.updateOptions(transform: (Int) -> Int) {
         // Get the dialog options
         val ref = IntByReference()
         this.GetOptions(ref).verify("GetOptions failed")
 
         // Set the dialog options
-        this.SetOptions(ref.value or flag).verify("SetOptions failed")
+        this.SetOptions(transform(ref.value)).verify("SetOptions failed")
     }
 
     private fun <FD : FileDialog, T> FD.show(
@@ -398,3 +405,5 @@ internal class WindowsFilePicker : PlatformFilePicker {
         }
     }
 }
+
+internal fun requiredFileDialogOptions(options: Int): Int = options or FOS_FORCEFILESYSTEM

--- a/filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsFilePickerOptionsTest.kt
+++ b/filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsFilePickerOptionsTest.kt
@@ -1,0 +1,18 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+
+package io.github.vinceglb.filekit.dialogs.platform.windows
+
+import io.github.vinceglb.filekit.dialogs.platform.windows.jna.ShTypes.FILEOPENDIALOGOPTIONS.Companion.FOS_ALLOWMULTISELECT
+import io.github.vinceglb.filekit.dialogs.platform.windows.jna.ShTypes.FILEOPENDIALOGOPTIONS.Companion.FOS_FORCEFILESYSTEM
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class WindowsFilePickerOptionsTest {
+    @Test
+    fun requiredFileDialogOptions_whenOptionsAlreadyExist_preservesOptionsAndForcesFilesystemResults() {
+        assertEquals(
+            expected = FOS_ALLOWMULTISELECT or FOS_FORCEFILESYSTEM,
+            actual = requiredFileDialogOptions(FOS_ALLOWMULTISELECT),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Force filesystem-backed results during the shared JVM Windows dialog setup.
- Preserve the dialog's existing options and picker-specific flags.
- Add regression coverage for the required Windows dialog options.

The Kotlin/Native Windows backend already applies `FOS_FORCEFILESYSTEM`, so this brings the JVM Windows backend in line with it.

Related to #608

## Affected platforms

- JVM on Windows

## Verification

- `./gradlew :filekit-dialogs:jvmTest --tests io.github.vinceglb.filekit.dialogs.platform.windows.WindowsFilePickerOptionsTest`
- `./gradlew :filekit-dialogs:check --no-daemon`
- `ktlint filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsFilePicker.kt filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsFilePickerOptionsTest.kt`
- `git diff --check`

Native Windows UI behavior was not manually tested because the development host is macOS.
