### PR TITLE
🐛 [iOS] Deliver camera result after dismissal and encode JPEG off the main thread

### DIFF
--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -46,6 +46,7 @@ import platform.UIKit.UIApplication
 import platform.UIKit.UIDevice
 import platform.UIKit.UIDocumentInteractionController
 import platform.UIKit.UIDocumentPickerViewController
+import platform.UIKit.UIImage
 import platform.UIKit.UIImageJPEGRepresentation
 import platform.UIKit.UIImagePickerController
 import platform.UIKit.UIImagePickerControllerCameraDevice
@@ -225,55 +226,57 @@ public actual suspend fun FileKit.openCameraPicker(
     cameraFacing: FileKitCameraFacing,
     destinationFile: PlatformFile,
     openCameraSettings: FileKitOpenCameraSettings,
-): PlatformFile? = withContext(Dispatchers.Main) {
-    suspendCancellableCoroutine { continuation ->
-        cameraControllerDelegate = CameraControllerDelegate(
-            onImagePicked = { image ->
-                if (image != null) {
-                    // Convert UIImage to NSData (JPEG format with compression quality 1.0)
-                    val imageData = UIImageJPEGRepresentation(image, 1.0)
+): PlatformFile? {
+    val image = withContext(Dispatchers.Main) {
+        suspendCancellableCoroutine<UIImage?> { continuation ->
+            cameraControllerDelegate = CameraControllerDelegate(
+                onImagePicked = { image ->
+                    continuation.resume(image)
+                },
+            )
 
-                    // Create an NSURL for the file path
-                    val fileUrl = NSURL.fileURLWithPath(destinationFile.path)
+            val pickerController = UIImagePickerController()
+            pickerController.sourceType =
+                UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera
+            pickerController.delegate = cameraControllerDelegate
 
-                    // Write the NSData to the file
-                    if (imageData?.writeToURL(fileUrl, true) == true) {
-                        // Return the NSURL of the saved image file
-                        continuation.resume(destinationFile)
-                    } else {
-                        // If saving fails, return null
-                        continuation.resume(null)
-                    }
-                } else {
-                    continuation.resume(null)
+            when (cameraFacing) {
+                FileKitCameraFacing.Front -> {
+                    pickerController.cameraDevice =
+                        UIImagePickerControllerCameraDevice.UIImagePickerControllerCameraDeviceFront
                 }
-            },
-        )
 
-        val pickerController = UIImagePickerController()
-        pickerController.sourceType =
-            UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera
-        pickerController.delegate = cameraControllerDelegate
+                FileKitCameraFacing.Back -> {
+                    pickerController.cameraDevice =
+                        UIImagePickerControllerCameraDevice.UIImagePickerControllerCameraDeviceRear
+                }
 
-        when (cameraFacing) {
-            FileKitCameraFacing.Front -> {
-                pickerController.cameraDevice =
-                    UIImagePickerControllerCameraDevice.UIImagePickerControllerCameraDeviceFront
+                FileKitCameraFacing.System -> {}
             }
 
-            FileKitCameraFacing.Back -> {
-                pickerController.cameraDevice =
-                    UIImagePickerControllerCameraDevice.UIImagePickerControllerCameraDeviceRear
-            }
-
-            FileKitCameraFacing.System -> {}
+            openCameraSettings.presenterViewController()?.presentViewController(
+                pickerController,
+                animated = true,
+                completion = null,
+            )
         }
+    } ?: return null
 
-        openCameraSettings.presenterViewController()?.presentViewController(
-            pickerController,
-            animated = true,
-            completion = null,
-        )
+    // Encode and write off the main thread: JPEG encoding a full-resolution photo
+    // at quality 1.0 is expensive and used to freeze the UI right after the capture
+    return withContext(Dispatchers.IO) {
+        // Convert UIImage to NSData (JPEG format with compression quality 1.0)
+        val imageData = UIImageJPEGRepresentation(image, 1.0)
+
+        // Create an NSURL for the file path
+        val fileUrl = NSURL.fileURLWithPath(destinationFile.path)
+
+        // Write the NSData to the file, returning the saved file on success
+        if (imageData?.writeToURL(fileUrl, true) == true) {
+            destinationFile
+        } else {
+            null
+        }
     }
 }
 

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/util/CameraControllerDelegate.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/util/CameraControllerDelegate.kt
@@ -17,12 +17,16 @@ internal class CameraControllerDelegate(
         didFinishPickingMediaWithInfo: Map<Any?, *>,
     ) {
         val image = didFinishPickingMediaWithInfo[UIImagePickerControllerOriginalImage] as? UIImage
-        onImagePicked.invoke(image)
-        picker.dismissViewControllerAnimated(true, null)
+        // Deliver the result only once the picker is fully dismissed, so client reactions
+        // (navigation, closing dialogs, ...) can't race the UIKit dismissal transition
+        picker.dismissViewControllerAnimated(true) {
+            onImagePicked.invoke(image)
+        }
     }
 
     override fun imagePickerControllerDidCancel(picker: UIImagePickerController) {
-        picker.dismissViewControllerAnimated(true, null)
-        onImagePicked.invoke(null)
+        picker.dismissViewControllerAnimated(true) {
+            onImagePicked.invoke(null)
+        }
     }
 }


### PR DESCRIPTION
Fixes the two iOS camera picker problems reported in #618.

### 1. Result delivered before the picker dismissal (`CameraControllerDelegate`)

`imagePickerController(_:didFinishPickingMediaWithInfo:)` used to invoke `onImagePicked` *before* starting `dismissViewControllerAnimated`, so the continuation resumed (and client code reacted — navigation, closing Compose dialogs, ...) while the modal was still on screen, racing the UIKit dismissal transition. The gallery path doesn't have this issue in practice because the async `NSItemProvider` loading naturally delays results past the dismissal.

Now both the success and cancel callbacks are invoked from the dismissal completion handler, so `openCameraPicker` only returns once the picker is fully gone.

### 2. JPEG encode + file write on the main thread (`FileKit.ios.kt`)

`UIImageJPEGRepresentation(image, 1.0)` on a full-resolution photo plus the multi-MB `writeToURL` ran inside `withContext(Dispatchers.Main)`, freezing the UI right after the capture. The function is now split in two phases: the UIKit part (presentation + delegate) stays on `Dispatchers.Main`, and the encode/write moved to `Dispatchers.IO`. Public API unchanged.

`:filekit-dialogs:compileKotlinIosSimulatorArm64` passes. The underlying diagnosis (camera result racing the dismissal while the launcher lived inside a Compose Dialog) was confirmed on a physical iPhone 15 (iOS 17, Compose Multiplatform 1.11.1), where an equivalent deliver-after-dismissal + encode-off-main implementation resolves the freezes; this patch itself is compile-tested.
