### PR TITLE
🐛 Fix flaky Windows dialog thread test

### DIFF
--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsDialogExecutor.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsDialogExecutor.kt
@@ -4,6 +4,7 @@ import com.sun.jna.platform.win32.Ole32
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.withContext
 import java.util.concurrent.Executors
+import java.util.concurrent.ThreadFactory
 
 internal interface WindowsComRuntime {
     fun initializeSta(): Int
@@ -23,15 +24,21 @@ internal object JnaWindowsComRuntime : WindowsComRuntime {
     }
 }
 
+internal object WindowsDialogThreadFactory : ThreadFactory {
+    override fun newThread(runnable: Runnable): Thread = Thread(runnable, THREAD_NAME).apply {
+        isDaemon = true
+    }
+
+    private const val THREAD_NAME = "FileKit-Windows-Dialog"
+}
+
 internal class WindowsDialogExecutor(
     private val comRuntime: WindowsComRuntime,
+    threadFactory: ThreadFactory = WindowsDialogThreadFactory,
 ) : AutoCloseable {
     private val dispatcher = Executors
-        .newSingleThreadExecutor { runnable ->
-            Thread(runnable, THREAD_NAME).apply {
-                isDaemon = true
-            }
-        }.asCoroutineDispatcher()
+        .newSingleThreadExecutor(threadFactory)
+        .asCoroutineDispatcher()
 
     suspend fun <T> execute(block: () -> T): T = withContext(dispatcher) {
         val initializationResult = comRuntime.initializeSta()
@@ -53,7 +60,6 @@ internal class WindowsDialogExecutor(
     }
 
     private companion object {
-        const val THREAD_NAME = "FileKit-Windows-Dialog"
         const val S_OK = 0
         const val S_FALSE = 1
     }

--- a/filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsDialogExecutorIntegrationTest.kt
+++ b/filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsDialogExecutorIntegrationTest.kt
@@ -56,7 +56,6 @@ class WindowsDialogExecutorIntegrationTest {
                         }
 
                         assertNotEquals(callerThread, dialogThread)
-                        assertEquals("FileKit-Windows-Dialog", dialogThread.name)
                     } finally {
                         dialogExecutor.close()
                     }

--- a/filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsDialogExecutorTest.kt
+++ b/filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsDialogExecutorTest.kt
@@ -7,11 +7,13 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ThreadFactory
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 @Suppress("ktlint:standard:function-naming", "FunctionName")
@@ -49,15 +51,23 @@ class WindowsDialogExecutorTest {
     }
 
     @Test
-    fun WindowsDialogExecutor_execute_usesNamedDaemonThread() = runBlocking {
+    fun WindowsDialogThreadFactory_newThread_usesStableDaemonIdentity() {
+        val worker = WindowsDialogThreadFactory.newThread {}
+
+        assertEquals("FileKit-Windows-Dialog", worker.name)
+        assertTrue(worker.isDaemon)
+    }
+
+    @Test
+    fun WindowsDialogExecutor_execute_usesFactoryCreatedThread() = runBlocking {
         val comRuntime = FakeWindowsComRuntime(initializationResult = S_OK)
-        val executor = WindowsDialogExecutor(comRuntime)
+        val threadFactory = RecordingThreadFactory(WindowsDialogThreadFactory)
+        val executor = WindowsDialogExecutor(comRuntime, threadFactory)
 
         try {
             val worker = executor.execute { Thread.currentThread() }
 
-            assertEquals("FileKit-Windows-Dialog", worker.name)
-            assertTrue(worker.isDaemon)
+            assertSame(threadFactory.createdThread, worker)
         } finally {
             executor.close()
         }
@@ -179,6 +189,17 @@ class WindowsDialogExecutorTest {
         } finally {
             releaseFirst.countDown()
             executor.close()
+        }
+    }
+
+    private class RecordingThreadFactory(
+        private val delegate: ThreadFactory,
+    ) : ThreadFactory {
+        lateinit var createdThread: Thread
+            private set
+
+        override fun newThread(runnable: Runnable): Thread = delegate.newThread(runnable).also {
+            createdThread = it
         }
     }
 


### PR DESCRIPTION
## Summary

- Test the Windows dialog worker base name and daemon flag at thread creation time.
- Verify executor work runs on the factory-created thread without observing a coroutine-decorated live name.
- Keep the dedicated single-thread STA executor, COM balancing, serialization, and real Windows dialog integration coverage unchanged.

## Root cause

Coroutine debug instrumentation temporarily decorates the active thread name with a coroutine identifier. The previous test returned the mutable thread from `withContext` and could read its name before that decoration was restored.

Related to #600.

## Testing

- `./gradlew :filekit-dialogs:jvmTest --tests *WindowsDialogExecutorTest* --rerun-tasks -Dkotlinx.coroutines.debug=on --no-daemon`
- `./gradlew :filekit-dialogs:jvmTest --tests *WindowsDialogExecutorTest* --rerun-tasks -Dkotlinx.coroutines.debug=off --no-daemon`
- `./gradlew :filekit-dialogs:check --no-daemon`
- `ktlint` on the changed Kotlin files