### PR TITLE
🐛 Handle missing Android camera activities

### DIFF
--- a/filekit-dialogs-compose/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/AndroidComposePickerReliabilityTest.kt
+++ b/filekit-dialogs-compose/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/AndroidComposePickerReliabilityTest.kt
@@ -96,6 +96,15 @@ class AndroidComposePickerReliabilityTest {
     }
 
     @Test
+    fun CameraLaunchSafely_whenActivityNotFound_returnsFalse() {
+        val launched = launchCameraSafely(Uri.parse("content://example.provider/camera/photo.jpg")) {
+            throw ActivityNotFoundException("No activity found")
+        }
+
+        assertFalse(launched)
+    }
+
+    @Test
     fun CameraLaunchSafely_whenNoError_returnsTrue() {
         val expectedUri = Uri.parse("content://example.provider/camera/photo.jpg")
         var launchedUri: Uri? = null

--- a/filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.android.kt
+++ b/filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.android.kt
@@ -480,6 +480,8 @@ internal fun launchCameraSafely(
 ): Boolean = try {
     launch(uri)
     true
+} catch (_: ActivityNotFoundException) {
+    false
 } catch (_: SecurityException) {
     false
 }


### PR DESCRIPTION
## Summary
- prevent the Android Compose camera launcher from crashing when no activity handles `ACTION_IMAGE_CAPTURE`
- route `ActivityNotFoundException` through the existing failed-launch/null-result path
- add a regression test reproducing the Crashlytics failure

## Platforms
- Android (`filekit-dialogs-compose`)

## Documentation
- No documentation changes: the public camera-picker API and expected null-result behavior are unchanged.

## Validation
- `./gradlew testAndroidHostTest --console=plain`
- `./gradlew check --no-daemon --console=plain`
- `ktlint filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.android.kt filekit-dialogs-compose/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/AndroidComposePickerReliabilityTest.kt -R ktlint-compose-0.4.28-all.jar`
- independent standards review: 0 findings
- independent spec/correctness review: 0 findings