### PR TITLE
🐛 Handle Compose picker failures without crashing

### DIFF
--- a/filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.android.kt
+++ b/filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.android.kt
@@ -34,6 +34,7 @@ import io.github.vinceglb.filekit.dialogs.FileKitCameraFacing
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitMode
 import io.github.vinceglb.filekit.dialogs.FileKitOpenCameraSettings
+import io.github.vinceglb.filekit.dialogs.FileKitPickerException
 import io.github.vinceglb.filekit.dialogs.FileKitPickerState
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.TakePictureWithCameraFacing
@@ -68,11 +69,13 @@ private fun InitializeAndroidFileKit() {
 }
 
 @Composable
+@Suppress("UNUSED_PARAMETER")
 internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLauncher(
     type: FileKitType,
     mode: FileKitMode<PickerResult, ConsumedResult>,
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
+    onError: (FileKitPickerException) -> Unit,
     onResult: (ConsumedResult) -> Unit,
 ): PickerResultLauncher {
     InitializeAndroidFileKit()

--- a/filekit-dialogs-compose/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.kt
+++ b/filekit-dialogs-compose/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitMode
+import io.github.vinceglb.filekit.dialogs.FileKitPickerException
 import io.github.vinceglb.filekit.dialogs.FileKitType
 
 /**
@@ -17,6 +18,8 @@ import io.github.vinceglb.filekit.dialogs.FileKitType
  * @param dialogSettings Platform-specific settings for the dialog.
  * @param onResult Callback invoked with the result.
  * @return A [PickerResultLauncher] that can be used to launch the picker.
+ *
+ * Picker failures are ignored by this overload. Use the overload with `onError` to handle them.
  */
 @Composable
 public fun <PickerResult, ConsumedResult> rememberFilePickerLauncher(
@@ -25,6 +28,34 @@ public fun <PickerResult, ConsumedResult> rememberFilePickerLauncher(
     directory: PlatformFile? = null,
     dialogSettings: FileKitDialogSettings = FileKitDialogSettings.createDefault(),
     onResult: (ConsumedResult) -> Unit,
+): PickerResultLauncher = rememberFilePickerLauncher(
+    type = type,
+    mode = mode,
+    directory = directory,
+    dialogSettings = dialogSettings,
+    onError = {},
+    onResult = onResult,
+)
+
+/**
+ * Creates and remembers a [PickerResultLauncher] for picking files.
+ *
+ * @param type The type of files to pick. Defaults to [FileKitType.File].
+ * @param mode The picking mode (e.g. Single, Multiple).
+ * @param directory The initial directory. Supported on desktop platforms.
+ * @param dialogSettings Platform-specific settings for the dialog.
+ * @param onError Callback invoked when FileKit cannot resolve the selected files.
+ * @param onResult Callback invoked with the result.
+ * @return A [PickerResultLauncher] that can be used to launch the picker.
+ */
+@Composable
+public fun <PickerResult, ConsumedResult> rememberFilePickerLauncher(
+    type: FileKitType = FileKitType.File(),
+    mode: FileKitMode<PickerResult, ConsumedResult>,
+    directory: PlatformFile? = null,
+    dialogSettings: FileKitDialogSettings = FileKitDialogSettings.createDefault(),
+    onError: (FileKitPickerException) -> Unit,
+    onResult: (ConsumedResult) -> Unit,
 ): PickerResultLauncher {
     val stableDialogSettings = rememberStableDialogSettings(dialogSettings)
     return rememberPlatformFilePickerLauncher(
@@ -32,6 +63,7 @@ public fun <PickerResult, ConsumedResult> rememberFilePickerLauncher(
         mode = mode,
         directory = directory,
         dialogSettings = stableDialogSettings,
+        onError = onError,
         onResult = onResult,
     )
 }
@@ -44,6 +76,8 @@ public fun <PickerResult, ConsumedResult> rememberFilePickerLauncher(
  * @param dialogSettings Platform-specific settings for the dialog.
  * @param onResult Callback invoked with the picked file, or null if cancelled.
  * @return A [PickerResultLauncher] that can be used to launch the picker.
+ *
+ * Picker failures are ignored by this overload. Use the overload with `onError` to handle them.
  */
 @Composable
 public fun rememberFilePickerLauncher(
@@ -53,9 +87,35 @@ public fun rememberFilePickerLauncher(
     onResult: (PlatformFile?) -> Unit,
 ): PickerResultLauncher = rememberFilePickerLauncher(
     type = type,
+    directory = directory,
+    dialogSettings = dialogSettings,
+    onError = {},
+    onResult = onResult,
+)
+
+/**
+ * Creates and remembers a [PickerResultLauncher] for picking a single file.
+ *
+ * @param type The type of files to pick. Defaults to [FileKitType.File].
+ * @param directory The initial directory. Supported on desktop platforms.
+ * @param dialogSettings Platform-specific settings for the dialog.
+ * @param onError Callback invoked when FileKit cannot resolve the selected file.
+ * @param onResult Callback invoked with the picked file, or null if cancelled.
+ * @return A [PickerResultLauncher] that can be used to launch the picker.
+ */
+@Composable
+public fun rememberFilePickerLauncher(
+    type: FileKitType = FileKitType.File(),
+    directory: PlatformFile? = null,
+    dialogSettings: FileKitDialogSettings = FileKitDialogSettings.createDefault(),
+    onError: (FileKitPickerException) -> Unit,
+    onResult: (PlatformFile?) -> Unit,
+): PickerResultLauncher = rememberFilePickerLauncher(
+    type = type,
     mode = FileKitMode.Single,
     directory = directory,
     dialogSettings = dialogSettings,
+    onError = onError,
     onResult = onResult,
 )
 
@@ -65,8 +125,24 @@ internal expect fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
     mode: FileKitMode<PickerResult, ConsumedResult>,
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
+    onError: (FileKitPickerException) -> Unit,
     onResult: (ConsumedResult) -> Unit,
 ): PickerResultLauncher
+
+internal suspend fun <PickerResult, ConsumedResult> runFilePickerLauncher(
+    mode: FileKitMode<PickerResult, ConsumedResult>,
+    openPicker: suspend () -> PickerResult,
+    onError: (FileKitPickerException) -> Unit,
+    onResult: (ConsumedResult) -> Unit,
+) {
+    val result = try {
+        openPicker()
+    } catch (failure: FileKitPickerException) {
+        onError(failure)
+        return
+    }
+    mode.consumeResult(result, onResult)
+}
 
 /**
  * Creates and remembers a [PickerResultLauncher] for picking a directory.

--- a/filekit-dialogs-compose/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposeFailureTest.kt
+++ b/filekit-dialogs-compose/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposeFailureTest.kt
@@ -1,0 +1,46 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+
+package io.github.vinceglb.filekit.dialogs.compose
+
+import io.github.vinceglb.filekit.dialogs.FileKitMode
+import io.github.vinceglb.filekit.dialogs.FileKitPickerException
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FileKitComposeFailureTest {
+    @Test
+    fun runFilePickerLauncher_reportsPickerException_withoutInvokingResult() = runTest {
+        val failure = FileKitPickerException("Failed to load the selected file.")
+        var reportedFailure: FileKitPickerException? = null
+        var resultInvoked = false
+
+        runFilePickerLauncher(
+            mode = FileKitMode.Single,
+            openPicker = { throw failure },
+            onError = { reportedFailure = it },
+            onResult = { resultInvoked = true },
+        )
+
+        assertEquals(expected = failure, actual = reportedFailure)
+        assertFalse(resultInvoked)
+    }
+
+    @Test
+    fun runFilePickerLauncher_invokesResult_withoutInvokingError() = runTest {
+        var errorInvoked = false
+        var resultInvoked = false
+
+        runFilePickerLauncher(
+            mode = FileKitMode.Single,
+            openPicker = { null },
+            onError = { errorInvoked = true },
+            onResult = { resultInvoked = true },
+        )
+
+        assertFalse(errorInvoked)
+        assertTrue(resultInvoked)
+    }
+}

--- a/filekit-dialogs-compose/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.jvm.kt
+++ b/filekit-dialogs-compose/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.jvm.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.window.WindowScope
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitMode
+import io.github.vinceglb.filekit.dialogs.FileKitPickerException
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import java.awt.Window
 
@@ -26,6 +27,23 @@ public fun <PickerResult, ConsumedResult> WindowScope.rememberFilePickerLauncher
 )
 
 @Composable
+public fun <PickerResult, ConsumedResult> WindowScope.rememberFilePickerLauncher(
+    type: FileKitType = FileKitType.File(),
+    mode: FileKitMode<PickerResult, ConsumedResult>,
+    directory: PlatformFile? = null,
+    dialogSettings: FileKitDialogSettings? = null,
+    onError: (FileKitPickerException) -> Unit,
+    onResult: (ConsumedResult?) -> Unit,
+): PickerResultLauncher = io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher(
+    type = type,
+    mode = mode,
+    directory = directory,
+    dialogSettings = injectDialogSettings(dialogSettings, this.window),
+    onError = onError,
+    onResult = onResult,
+)
+
+@Composable
 public fun WindowScope.rememberFilePickerLauncher(
     type: FileKitType = FileKitType.File(),
     directory: PlatformFile? = null,
@@ -35,6 +53,21 @@ public fun WindowScope.rememberFilePickerLauncher(
     type = type,
     directory = directory,
     dialogSettings = injectDialogSettings(dialogSettings, this.window),
+    onResult = onResult,
+)
+
+@Composable
+public fun WindowScope.rememberFilePickerLauncher(
+    type: FileKitType = FileKitType.File(),
+    directory: PlatformFile? = null,
+    dialogSettings: FileKitDialogSettings? = null,
+    onError: (FileKitPickerException) -> Unit,
+    onResult: (PlatformFile?) -> Unit,
+): PickerResultLauncher = io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher(
+    type = type,
+    directory = directory,
+    dialogSettings = injectDialogSettings(dialogSettings, this.window),
+    onError = onError,
     onResult = onResult,
 )
 

--- a/filekit-dialogs-compose/src/nonAndroidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nonAndroid.kt
+++ b/filekit-dialogs-compose/src/nonAndroidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nonAndroid.kt
@@ -9,6 +9,7 @@ import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitMode
+import io.github.vinceglb.filekit.dialogs.FileKitPickerException
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openDirectoryPicker
 import io.github.vinceglb.filekit.dialogs.openFilePicker
@@ -54,6 +55,7 @@ internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
     mode: FileKitMode<PickerResult, ConsumedResult>,
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
+    onError: (FileKitPickerException) -> Unit,
     onResult: (ConsumedResult) -> Unit,
 ): PickerResultLauncher {
     val coroutineScope = rememberCoroutineScope()
@@ -63,18 +65,25 @@ internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
     val currentMode by rememberUpdatedState(mode)
     val currentDirectory by rememberUpdatedState(directory)
     val currentDialogSettings by rememberUpdatedState(stableDialogSettings)
+    val currentOnError by rememberUpdatedState(onError)
     val currentOnConsumed by rememberUpdatedState(onResult)
 
     return remember {
         PickerResultLauncher {
             coroutineScope.launch {
-                val result = FileKit.openFilePicker(
-                    type = currentType,
+                runFilePickerLauncher(
                     mode = currentMode,
-                    directory = currentDirectory,
-                    dialogSettings = currentDialogSettings,
+                    openPicker = {
+                        FileKit.openFilePicker(
+                            type = currentType,
+                            mode = currentMode,
+                            directory = currentDirectory,
+                            dialogSettings = currentDialogSettings,
+                        )
+                    },
+                    onError = currentOnError,
+                    onResult = currentOnConsumed,
                 )
-                currentMode.consumeResult(result, currentOnConsumed)
             }
         }
     }

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/gallerypicker/GalleryPickerScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/gallerypicker/GalleryPickerScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitMode
+import io.github.vinceglb.filekit.dialogs.FileKitPickerException
 import io.github.vinceglb.filekit.dialogs.FileKitPickerState
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
@@ -76,23 +77,34 @@ private fun GalleryPickerScreen(
     var pickerDirectory: PlatformFile? by remember { mutableStateOf(null) }
 
     var files: List<PlatformFile> by remember { mutableStateOf(emptyList()) }
+    var pickerError: String? by remember { mutableStateOf(null) }
+
+    val onPickerError: (FileKitPickerException) -> Unit = { failure ->
+        buttonState = AppScreenHeaderButtonState.Enabled
+        files = emptyList()
+        pickerError = failure.message
+    }
 
     val gallerySinglePicker = rememberFilePickerLauncher(
         type = pickerType,
         mode = FileKitMode.Single,
         directory = pickerDirectory,
+        onError = onPickerError,
     ) { selectedFile ->
         buttonState = AppScreenHeaderButtonState.Enabled
         files = selectedFile?.let(::listOf) ?: emptyList()
+        pickerError = null
     }
 
     val galleryMultiplePicker = rememberFilePickerLauncher(
         type = pickerType,
         mode = FileKitMode.Multiple(maxItems = pickerMaxItems),
         directory = pickerDirectory,
+        onError = onPickerError,
     ) { selectedFiles ->
         buttonState = AppScreenHeaderButtonState.Enabled
         files = selectedFiles ?: emptyList()
+        pickerError = null
     }
 
     val gallerySingleWithStatePicker = rememberFilePickerLauncher(
@@ -101,6 +113,7 @@ private fun GalleryPickerScreen(
         directory = pickerDirectory,
     ) { state ->
         buttonState = AppScreenHeaderButtonState.Enabled
+        pickerError = (state as? FileKitPickerState.Failed)?.cause?.message
         files = when (state) {
             FileKitPickerState.Cancelled -> emptyList()
             is FileKitPickerState.Failed -> emptyList()
@@ -116,6 +129,7 @@ private fun GalleryPickerScreen(
         directory = pickerDirectory,
     ) { state ->
         buttonState = AppScreenHeaderButtonState.Enabled
+        pickerError = (state as? FileKitPickerState.Failed)?.cause?.message
         files = when (state) {
             FileKitPickerState.Cancelled -> emptyList()
             is FileKitPickerState.Failed -> emptyList()
@@ -231,7 +245,7 @@ private fun GalleryPickerScreen(
             item {
                 AppPickerResultsCard(
                     files = files,
-                    emptyText = "No files selected",
+                    emptyText = pickerError ?: "No files selected",
                     emptyIcon = LucideIcons.Camera,
                     onFileClick = onDisplayFileDetails,
                     modifier = Modifier.sizeIn(maxWidth = AppMaxWidth),


### PR DESCRIPTION
## Summary

- catch FileKitPickerException inside non-Android Compose file-picker launchers instead of letting it escape the composition coroutine
- preserve existing launcher signatures while adding onError overloads for explicit failure handling
- add common regression coverage for failure and success paths
- update the gallery sample to surface picker failures and restore its UI state

## Root cause

FileKit 0.14.2 correctly converted iOS PhotosUI file-representation failures into FileKitPickerException. The callback-style Compose launcher then invoked the throwing suspend API from an unguarded coroutine, so a recoverable provider failure became an unhandled application crash.

The suspend FileKit.openFilePicker API remains unchanged and continues to throw FileKitPickerException as documented.

## Affected platforms

The behavioral fix applies to non-Android Compose launchers, including iOS, macOS, and JVM. Android keeps the mirrored API overload; its Activity Result path already delivers picker states without this coroutine failure mode.

## Verification

- regression test observed failing before the fix and passing after it
- ./gradlew :filekit-dialogs-compose:check
- sample shared compilation on iOS simulator, JVM, and Android
- exact CI ktlint command with Compose rules 0.6.0
- ./gradlew assemble
- two-pass standards and crash-spec subagent review, with the sample finding resolved and no remaining material findings