### PR TITLE
🥅 Add explicit Compose dialog error handling

### DIFF
--- a/docs/dialogs/camera-picker.mdx
+++ b/docs/dialogs/camera-picker.mdx
@@ -28,6 +28,25 @@ Button(onClick = { launcher.launch() }) {
 ```
 </CodeGroup>
 
+## Handle failures
+
+```kotlin
+val launcher = rememberCameraPickerLauncher(
+    onError = { error: FileKitDialogException ->
+        logger.error(error)
+    },
+    onResult = { file ->
+        if (file == null) {
+            // The user cancelled or denied the runtime camera permission.
+        }
+    },
+)
+```
+
+The compatibility overload without `onError` reports an operational failure as `onResult(null)`. Suspend callers receive `FileKitDialogException` directly. Android FileProvider configuration errors remain programmer/configuration errors and are not routed to `onError`.
+
+Only one launch may be pending from a launcher at a time. Starting another before the first completes is unsupported.
+
 The captured media file is automatically saved to the specified location (or cache directory by default). If you need to keep the file permanently, make sure to copy it to a permanent storage location.
 
 ## Android camera permission behavior

--- a/docs/dialogs/directory-picker.mdx
+++ b/docs/dialogs/directory-picker.mdx
@@ -26,6 +26,27 @@ Button(onClick = { launcher.launch() }) {
 ```
 </CodeGroup>
 
+## Handle failures
+
+Use the error-aware Compose overload when your UI needs to distinguish cancellation from an operational failure:
+
+```kotlin
+val launcher = rememberDirectoryPickerLauncher(
+    onError = { error: FileKitDialogException ->
+        logger.error(error)
+    },
+    onResult = { directory ->
+        if (directory == null) {
+            // The user cancelled.
+        }
+    },
+)
+```
+
+The compatibility overload without `onError` reports an operational failure as `onResult(null)`. Suspend callers receive `FileKitDialogException` directly.
+
+Only one launch may be pending from a launcher at a time. Starting another before the first completes is unsupported.
+
 ## Customizing the dialog
 
 You can customize the dialog by setting the initial directory and platform-specific `dialogSettings`, such as a title on supported platforms.

--- a/docs/dialogs/file-picker.mdx
+++ b/docs/dialogs/file-picker.mdx
@@ -26,6 +26,31 @@ Button(onClick = { launcher.launch() }) {
 ```
 </CodeGroup>
 
+## Handle failures
+
+Compose launchers expose expected dialog failures through `onError`. `FileKitPickerException` extends `FileKitDialogException`, so one handler can be reused across file, directory, saver, camera, and share launchers:
+
+```kotlin
+val onDialogError: (FileKitDialogException) -> Unit = { error ->
+    logger.error(error)
+}
+
+val fileLauncher = rememberFilePickerLauncher(
+    type = FileKitType.Image,
+    onError = onDialogError,
+    onResult = ::handleResult,
+)
+
+val directoryLauncher = rememberDirectoryPickerLauncher(
+    onError = onDialogError,
+    onResult = ::handleDirectory,
+)
+```
+
+The compatibility file-picker overload without `onError` ignores launch failures. In state-tracking modes, failures after selection begins continue to arrive as `FileKitPickerState.Failed` rather than being reported twice.
+
+Only one launch may be pending from a launcher at a time. Starting another before the first completes is unsupported.
+
 <Warning>
 On iOS, remember FileKit Compose launchers from a stable/root Compose scope, not
 inside transient surfaces such as `ModalBottomSheet`, dialogs, popups, or

--- a/docs/dialogs/file-saver.mdx
+++ b/docs/dialogs/file-saver.mdx
@@ -50,6 +50,26 @@ Button(onClick = {
 ```
 </CodeGroup>
 
+## Handle failures
+
+```kotlin
+val launcher = rememberFileSaverLauncher(
+    dialogSettings = FileKitDialogSettings.createDefault(),
+    onError = { error: FileKitDialogException ->
+        logger.error(error)
+    },
+    onResult = { file ->
+        if (file == null) {
+            // The user cancelled.
+        }
+    },
+)
+```
+
+The compatibility overload without `onError` reports an operational failure as `onResult(null)`. Suspend callers receive `FileKitDialogException` directly.
+
+Only one launch may be pending from a launcher at a time. Starting another before the first completes is unsupported.
+
 ## Parameters
 
 The file saver can be customized with several parameters:

--- a/docs/dialogs/share-file.mdx
+++ b/docs/dialogs/share-file.mdx
@@ -40,6 +40,20 @@ Button(onClick = {
 ```
 </CodeGroup>
 
+## Handle failures
+
+```kotlin
+val launcher = rememberShareFileLauncher(
+    onError = { error: FileKitDialogException ->
+        logger.error(error)
+    },
+)
+```
+
+The compatibility overload without `onError` ignores operational failures because it has no result callback. Suspend callers receive `FileKitDialogException` directly.
+
+Only one launch may be pending from a launcher at a time. Starting another before the first completes is unsupported.
+
 <Info>
 Ensure the file you are sharing exists and is accessible. Sharing a non-existent file will result in an error.
 </Info>

--- a/filekit-dialogs-compose/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/AndroidComposePickerReliabilityTest.kt
+++ b/filekit-dialogs-compose/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/AndroidComposePickerReliabilityTest.kt
@@ -7,6 +7,7 @@ import android.content.ActivityNotFoundException
 import android.net.Uri
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitAndroidDialogsInternal
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitPickerState
 import io.github.vinceglb.filekit.path
 import org.junit.runner.RunWith
@@ -14,6 +15,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertNull
@@ -22,6 +24,49 @@ import kotlin.test.assertTrue
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [36])
 class AndroidComposePickerReliabilityTest {
+    @Test
+    fun DirectoryLaunchFailure_reportsDialogError() {
+        assertAndroidDialogLaunchFailure("Failed to launch the directory picker.")
+    }
+
+    @Test
+    fun FileSaverLaunchFailure_reportsDialogError() {
+        assertAndroidDialogLaunchFailure("Failed to launch the file saver.")
+    }
+
+    @Test
+    fun CameraLaunchFailure_clearsPendingStateBeforeErrorCallback() {
+        var pendingUri: String? = "content://example.provider/camera/photo.jpg"
+        val nativeFailure = SecurityException("Camera launch denied")
+
+        dispatchCameraLaunchResult(
+            launchResult = AndroidLaunchResult.Failed(nativeFailure),
+            clearPendingState = { pendingUri = null },
+            onError = { failure ->
+                assertNull(pendingUri)
+                assertEquals(nativeFailure, failure.cause)
+            },
+        )
+    }
+
+    @Test
+    fun LaunchFailure_clearsPendingStateBeforeErrorCallback() {
+        var hasPendingLaunch = true
+        val failure = FileKitDialogException("Failed to launch")
+        var reportedFailure: FileKitDialogException? = null
+
+        dispatchAndroidLaunchFailure(
+            failure = failure,
+            clearPendingState = { hasPendingLaunch = false },
+            onError = {
+                assertFalse(hasPendingLaunch)
+                reportedFailure = it
+            },
+        )
+
+        assertEquals(failure, reportedFailure)
+    }
+
     @Test
     fun CameraResult_successWithPendingUri_returnsPlatformFile() {
         val result = resolveCameraResult(
@@ -87,54 +132,80 @@ class AndroidComposePickerReliabilityTest {
     }
 
     @Test
-    fun CameraLaunchSafely_whenSecurityException_returnsFalse() {
-        val launched = launchCameraSafely(Uri.parse("content://example.provider/camera/photo.jpg")) {
-            throw SecurityException("camera permission denied")
+    fun CameraLaunchSafely_whenSecurityException_returnsFailure() {
+        val failure = SecurityException("camera permission denied")
+        val result = launchCameraSafely(Uri.parse("content://example.provider/camera/photo.jpg")) {
+            throw failure
         }
 
-        assertFalse(launched)
+        assertEquals(failure, assertIs<AndroidLaunchResult.Failed>(result).cause)
     }
 
     @Test
-    fun CameraLaunchSafely_whenActivityNotFound_returnsFalse() {
-        val launched = launchCameraSafely(Uri.parse("content://example.provider/camera/photo.jpg")) {
-            throw ActivityNotFoundException("No activity found")
+    fun CameraLaunchSafely_whenActivityNotFound_returnsFailure() {
+        val failure = ActivityNotFoundException("No activity found")
+        val result = launchCameraSafely(Uri.parse("content://example.provider/camera/photo.jpg")) {
+            throw failure
         }
 
-        assertFalse(launched)
+        assertEquals(failure, assertIs<AndroidLaunchResult.Failed>(result).cause)
     }
 
     @Test
-    fun CameraLaunchSafely_whenNoError_returnsTrue() {
+    fun CameraLaunchSafely_whenNoError_returnsLaunched() {
         val expectedUri = Uri.parse("content://example.provider/camera/photo.jpg")
         var launchedUri: Uri? = null
 
-        val launched = launchCameraSafely(expectedUri) { uri ->
+        val result = launchCameraSafely(expectedUri) { uri ->
             launchedUri = uri
         }
 
-        assertTrue(launched)
+        assertIs<AndroidLaunchResult.Launched>(result)
         assertEquals(expectedUri, launchedUri)
     }
 
     @Test
-    fun PickerLaunchSafely_whenActivityNotFound_returnsFalse() {
-        val launched = launchPickerSafely {
-            throw ActivityNotFoundException("No activity found")
+    fun CameraLaunchSafely_whenConfigurationFails_propagates() {
+        val configurationFailure = IllegalArgumentException("Invalid FileProvider authority")
+
+        val thrown = assertFailsWith<IllegalArgumentException> {
+            launchCameraSafely(Uri.parse("content://example.provider/camera/photo.jpg")) {
+                throw configurationFailure
+            }
         }
 
-        assertFalse(launched)
+        assertEquals(configurationFailure, thrown)
     }
 
     @Test
-    fun PickerLaunchSafely_whenNoError_returnsTrue() {
+    fun PickerLaunchSafely_whenActivityNotFound_returnsFailure() {
+        val failure = ActivityNotFoundException("No activity found")
+        val result = launchPickerSafely {
+            throw failure
+        }
+
+        assertEquals(failure, assertIs<AndroidLaunchResult.Failed>(result).cause)
+    }
+
+    @Test
+    fun PickerLaunchSafely_whenSecurityException_returnsFailure() {
+        val failure = SecurityException("Picker launch denied")
+        val result = launchPickerSafely {
+            throw failure
+        }
+
+        assertEquals(failure, assertIs<AndroidLaunchResult.Failed>(result).cause)
+    }
+
+    @Test
+    fun PickerLaunchSafely_whenNoError_returnsLaunched() {
         var launched = false
 
-        val wasLaunched = launchPickerSafely {
+        val result = launchPickerSafely {
             launched = true
         }
 
-        assertTrue(wasLaunched)
+        assertIs<AndroidLaunchResult.Launched>(result)
         assertTrue(launched)
     }
 
@@ -143,10 +214,10 @@ class AndroidComposePickerReliabilityTest {
         var fallbackCalls = 0
 
         val outcome = resolvePickerLaunchOutcome(
-            launchPrimary = { false },
+            launchPrimary = { AndroidLaunchResult.Failed(ActivityNotFoundException()) },
             launchFallback = {
                 fallbackCalls++
-                true
+                AndroidLaunchResult.Launched
             },
         )
 
@@ -155,13 +226,14 @@ class AndroidComposePickerReliabilityTest {
     }
 
     @Test
-    fun PickerLaunchOutcome_primaryAndFallbackFail_returnsCancelled() {
+    fun PickerLaunchOutcome_primaryAndFallbackFail_returnsLastFailure() {
+        val fallbackFailure = ActivityNotFoundException("No fallback activity found")
         val outcome = resolvePickerLaunchOutcome(
-            launchPrimary = { false },
-            launchFallback = { false },
+            launchPrimary = { AndroidLaunchResult.Failed(ActivityNotFoundException()) },
+            launchFallback = { AndroidLaunchResult.Failed(fallbackFailure) },
         )
 
-        assertEquals(PickerLaunchOutcome.Cancelled, outcome)
+        assertEquals(fallbackFailure, assertIs<PickerLaunchOutcome.Failed>(outcome).cause)
     }
 
     @Test
@@ -363,4 +435,21 @@ class AndroidComposePickerReliabilityTest {
             ),
         )
     }
+}
+
+private fun assertAndroidDialogLaunchFailure(message: String) {
+    val nativeFailure = ActivityNotFoundException(message)
+    var pending = true
+    var reportedFailure: FileKitDialogException? = null
+
+    dispatchAndroidDialogLaunchResult(
+        launchResult = AndroidLaunchResult.Failed(nativeFailure),
+        message = message,
+        clearPendingState = { pending = false },
+        onError = { reportedFailure = it },
+    )
+
+    assertFalse(pending)
+    assertEquals(message, reportedFailure?.message)
+    assertEquals(nativeFailure, reportedFailure?.cause)
 }

--- a/filekit-dialogs-compose/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/MobileLauncherCallShapeTest.kt
+++ b/filekit-dialogs-compose/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/MobileLauncherCallShapeTest.kt
@@ -1,0 +1,20 @@
+package io.github.vinceglb.filekit.dialogs.compose
+
+import androidx.compose.runtime.Composable
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
+
+@Composable
+private fun CompileMobileLauncherCallShapes() {
+    rememberCameraPickerLauncher(onResult = {})
+    rememberCameraPickerLauncher {}
+    rememberCameraPickerLauncher(
+        onError = ::handleMobileDialogError,
+        onResult = {},
+    )
+    rememberCameraPickerLauncher(onError = ::handleMobileDialogError) {}
+    rememberShareFileLauncher()
+    rememberShareFileLauncher(onError = ::handleMobileDialogError)
+    rememberShareFileLauncher { error -> handleMobileDialogError(error) }
+}
+
+private fun handleMobileDialogError(error: FileKitDialogException) = Unit

--- a/filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.android.kt
+++ b/filekit-dialogs-compose/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.android.kt
@@ -31,6 +31,7 @@ import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitAndroidCameraPermissionInternal
 import io.github.vinceglb.filekit.dialogs.FileKitAndroidDialogsInternal
 import io.github.vinceglb.filekit.dialogs.FileKitCameraFacing
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitMode
 import io.github.vinceglb.filekit.dialogs.FileKitOpenCameraSettings
@@ -82,6 +83,7 @@ internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
 
     val currentType by rememberUpdatedState(type)
     val currentMode by rememberUpdatedState(mode)
+    val currentOnError by rememberUpdatedState(onError)
     val currentOnConsumed by rememberUpdatedState(onResult)
 
     var pendingModeId by rememberSaveable { mutableStateOf<String?>(null) }
@@ -112,6 +114,18 @@ internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
         dispatchPendingResult(
             launcherId = launcherId,
             files = null,
+        )
+    }
+
+    fun dispatchLaunchFailure(cause: Throwable) {
+        dispatchAndroidLaunchFailure(
+            failure = FileKitPickerException("Failed to launch the file picker.", cause),
+            clearPendingState = {
+                pendingModeId = null
+                pendingMaxItems = null
+                pendingLauncherId = null
+            },
+            onError = currentOnError,
         )
     }
 
@@ -172,7 +186,7 @@ internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
                             maxItems = modeSnapshot.maxItems,
                         ) -> {
                             when (
-                                resolvePickerLaunchOutcome(
+                                val outcome = resolvePickerLaunchOutcome(
                                     launchPrimary = {
                                         pendingLauncherId = LAUNCHER_VISUAL_SINGLE
                                         launchPickerSafely {
@@ -189,19 +203,17 @@ internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
                             ) {
                                 PickerLaunchOutcome.PrimaryLaunched,
                                 PickerLaunchOutcome.FallbackLaunched,
-                                -> {
-                                    Unit
-                                }
+                                -> {}
 
-                                PickerLaunchOutcome.Cancelled -> {
-                                    dispatchCancelledResult(LAUNCHER_FILE_SINGLE)
+                                is PickerLaunchOutcome.Failed -> {
+                                    dispatchLaunchFailure(outcome.cause)
                                 }
                             }
                         }
 
                         else -> {
                             when (
-                                resolvePickerLaunchOutcome(
+                                val outcome = resolvePickerLaunchOutcome(
                                     launchPrimary = {
                                         pendingLauncherId = LAUNCHER_VISUAL_MULTIPLE
                                         launchPickerSafely {
@@ -223,12 +235,10 @@ internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
                             ) {
                                 PickerLaunchOutcome.PrimaryLaunched,
                                 PickerLaunchOutcome.FallbackLaunched,
-                                -> {
-                                    Unit
-                                }
+                                -> {}
 
-                                PickerLaunchOutcome.Cancelled -> {
-                                    dispatchCancelledResult(LAUNCHER_FILE_MULTIPLE)
+                                is PickerLaunchOutcome.Failed -> {
+                                    dispatchLaunchFailure(outcome.cause)
                                 }
                             }
                         }
@@ -240,21 +250,25 @@ internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
                     when {
                         modeSnapshot.isSingleMode() -> {
                             pendingLauncherId = LAUNCHER_FILE_SINGLE
-                            val isLaunched = launchPickerSafely {
-                                fileSingleLauncher.launch(mimeTypes)
-                            }
-                            if (!isLaunched) {
-                                dispatchCancelledResult(LAUNCHER_FILE_SINGLE)
+                            when (
+                                val launchResult = launchPickerSafely {
+                                    fileSingleLauncher.launch(mimeTypes)
+                                }
+                            ) {
+                                AndroidLaunchResult.Launched -> Unit
+                                is AndroidLaunchResult.Failed -> dispatchLaunchFailure(launchResult.cause)
                             }
                         }
 
                         else -> {
                             pendingLauncherId = LAUNCHER_FILE_MULTIPLE
-                            val isLaunched = launchPickerSafely {
-                                fileMultipleLauncher.launch(mimeTypes)
-                            }
-                            if (!isLaunched) {
-                                dispatchCancelledResult(LAUNCHER_FILE_MULTIPLE)
+                            when (
+                                val launchResult = launchPickerSafely {
+                                    fileMultipleLauncher.launch(mimeTypes)
+                                }
+                            ) {
+                                AndroidLaunchResult.Launched -> Unit
+                                is AndroidLaunchResult.Failed -> dispatchLaunchFailure(launchResult.cause)
                             }
                         }
                     }
@@ -277,10 +291,24 @@ public actual fun rememberDirectoryPickerLauncher(
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
     onResult: (PlatformFile?) -> Unit,
+): PickerResultLauncher = rememberDirectoryPickerLauncher(
+    directory = directory,
+    dialogSettings = dialogSettings,
+    onError = legacyNullResultOnDialogFailure(onResult),
+    onResult = onResult,
+)
+
+@Composable
+public actual fun rememberDirectoryPickerLauncher(
+    directory: PlatformFile?,
+    dialogSettings: FileKitDialogSettings,
+    onError: (FileKitDialogException) -> Unit,
+    onResult: (PlatformFile?) -> Unit,
 ): PickerResultLauncher {
     InitializeAndroidFileKit()
 
     val currentOnResult by rememberUpdatedState(onResult)
+    val currentOnError by rememberUpdatedState(onError)
     val currentDirectory by rememberUpdatedState(directory)
 
     var hasPendingLaunch by rememberSaveable { mutableStateOf(false) }
@@ -297,12 +325,21 @@ public actual fun rememberDirectoryPickerLauncher(
         PickerResultLauncher {
             val initialUri = currentDirectory?.path?.toUri()
             hasPendingLaunch = true
-            val isLaunched = launchPickerSafely {
-                launcher.launch(initialUri)
-            }
-            if (!isLaunched) {
-                hasPendingLaunch = false
-                currentOnResult(null)
+            when (
+                val launchResult = launchPickerSafely {
+                    launcher.launch(initialUri)
+                }
+            ) {
+                AndroidLaunchResult.Launched -> {}
+
+                is AndroidLaunchResult.Failed -> {
+                    dispatchAndroidDialogLaunchResult(
+                        launchResult = launchResult,
+                        message = "Failed to launch the directory picker.",
+                        clearPendingState = { hasPendingLaunch = false },
+                        onError = currentOnError,
+                    )
+                }
             }
         }
     }
@@ -311,11 +348,13 @@ public actual fun rememberDirectoryPickerLauncher(
 @Composable
 internal actual fun rememberPlatformFileSaverLauncher(
     dialogSettings: FileKitDialogSettings,
+    onError: (FileKitDialogException) -> Unit,
     onResult: (PlatformFile?) -> Unit,
 ): SaverResultLauncher {
     InitializeAndroidFileKit()
 
     val currentOnResult by rememberUpdatedState(onResult)
+    val currentOnError by rememberUpdatedState(onError)
 
     var hasPendingLaunch by rememberSaveable { mutableStateOf(false) }
 
@@ -343,13 +382,28 @@ internal actual fun rememberPlatformFileSaverLauncher(
             }
 
             hasPendingLaunch = true
-            launcher.launch(
-                CreateDocumentInput(
-                    mimeType = mimeType,
-                    fileName = fileName,
-                    allowedMimeTypes = allowedMimeTypes,
-                ),
-            )
+            when (
+                val launchResult = launchPickerSafely {
+                    launcher.launch(
+                        CreateDocumentInput(
+                            mimeType = mimeType,
+                            fileName = fileName,
+                            allowedMimeTypes = allowedMimeTypes,
+                        ),
+                    )
+                }
+            ) {
+                AndroidLaunchResult.Launched -> {}
+
+                is AndroidLaunchResult.Failed -> {
+                    dispatchAndroidDialogLaunchResult(
+                        launchResult = launchResult,
+                        message = "Failed to launch the file saver.",
+                        clearPendingState = { hasPendingLaunch = false },
+                        onError = currentOnError,
+                    )
+                }
+            }
         }
     }
 }
@@ -365,6 +419,17 @@ internal actual fun rememberPlatformFileSaverLauncher(
 public actual fun rememberCameraPickerLauncher(
     openCameraSettings: FileKitOpenCameraSettings,
     onResult: (PlatformFile?) -> Unit,
+): PhotoResultLauncher = rememberCameraPickerLauncher(
+    openCameraSettings = openCameraSettings,
+    onError = legacyNullResultOnDialogFailure(onResult),
+    onResult = onResult,
+)
+
+@Composable
+public actual fun rememberCameraPickerLauncher(
+    openCameraSettings: FileKitOpenCameraSettings,
+    onError: (FileKitDialogException) -> Unit,
+    onResult: (PlatformFile?) -> Unit,
 ): PhotoResultLauncher {
     InitializeAndroidFileKit()
 
@@ -378,6 +443,7 @@ public actual fun rememberCameraPickerLauncher(
 
     // Updated callback
     val currentOnResult by rememberUpdatedState(onResult)
+    val currentOnError by rememberUpdatedState(onError)
 
     // Create a stable contract instance (reused across recompositions)
     val contract = remember { TakePictureWithCameraFacing() }
@@ -400,9 +466,7 @@ public actual fun rememberCameraPickerLauncher(
                     pendingDestinationUri = pendingDestinationUri,
                 )
             ) {
-                CameraPermissionResolution.NoOp -> {
-                    Unit
-                }
+                CameraPermissionResolution.NoOp -> {}
 
                 CameraPermissionResolution.ReturnNullResult -> {
                     pendingDestinationUri = null
@@ -415,14 +479,14 @@ public actual fun rememberCameraPickerLauncher(
                     }.getOrDefault(FileKitCameraFacing.System)
 
                     contract.setCameraFacing(cameraFacing)
-                    val isLaunched = launchCameraSafely(
-                        uri = resolution.uri,
-                        launch = launcher::launch,
+                    dispatchCameraLaunchResult(
+                        launchResult = launchCameraSafely(
+                            uri = resolution.uri,
+                            launch = launcher::launch,
+                        ),
+                        clearPendingState = { pendingDestinationUri = null },
+                        onError = currentOnError,
                     )
-                    if (!isLaunched) {
-                        pendingDestinationUri = null
-                        currentOnResult(null)
-                    }
                 }
             }
         }
@@ -437,7 +501,19 @@ public actual fun rememberCameraPickerLauncher(
 
             if (FileKitAndroidCameraPermissionInternal.needsRuntimeCameraPermission(context)) {
                 hasPendingPermissionRequest = true
-                permissionLauncher.launch(Manifest.permission.CAMERA)
+                when (val launchResult = launchPickerSafely { permissionLauncher.launch(Manifest.permission.CAMERA) }) {
+                    AndroidLaunchResult.Launched -> {}
+
+                    is AndroidLaunchResult.Failed -> {
+                        hasPendingPermissionRequest = false
+                        dispatchCameraLaunchResult(
+                            launchResult = launchResult,
+                            clearPendingState = { pendingDestinationUri = null },
+                            onError = currentOnError,
+                            message = "Failed to request camera permission.",
+                        )
+                    }
+                }
                 return@PhotoResultLauncher
             }
 
@@ -445,14 +521,14 @@ public actual fun rememberCameraPickerLauncher(
             contract.setCameraFacing(cameraFacing)
 
             // Launch the camera
-            val isLaunched = launchCameraSafely(
-                uri = uri,
-                launch = launcher::launch,
+            dispatchCameraLaunchResult(
+                launchResult = launchCameraSafely(
+                    uri = uri,
+                    launch = launcher::launch,
+                ),
+                clearPendingState = { pendingDestinationUri = null },
+                onError = currentOnError,
             )
-            if (!isLaunched) {
-                pendingDestinationUri = null
-                currentOnResult(null)
-            }
         }
     }
 }
@@ -480,37 +556,92 @@ internal fun resolveCameraPermissionResult(
 internal fun launchCameraSafely(
     uri: Uri,
     launch: (Uri) -> Unit,
-): Boolean = try {
+): AndroidLaunchResult = try {
     launch(uri)
-    true
-} catch (_: ActivityNotFoundException) {
-    false
-} catch (_: SecurityException) {
-    false
+    AndroidLaunchResult.Launched
+} catch (failure: ActivityNotFoundException) {
+    AndroidLaunchResult.Failed(failure)
+} catch (failure: SecurityException) {
+    AndroidLaunchResult.Failed(failure)
 }
 
 internal fun launchPickerSafely(
     launch: () -> Unit,
-): Boolean = try {
+): AndroidLaunchResult = try {
     launch()
-    true
-} catch (_: ActivityNotFoundException) {
-    false
+    AndroidLaunchResult.Launched
+} catch (failure: ActivityNotFoundException) {
+    AndroidLaunchResult.Failed(failure)
+} catch (failure: SecurityException) {
+    AndroidLaunchResult.Failed(failure)
 }
 
-internal enum class PickerLaunchOutcome {
-    PrimaryLaunched,
-    FallbackLaunched,
-    Cancelled,
+internal fun dispatchCameraLaunchResult(
+    launchResult: AndroidLaunchResult,
+    clearPendingState: () -> Unit,
+    onError: (FileKitDialogException) -> Unit,
+    message: String = "Failed to launch the camera picker.",
+) {
+    dispatchAndroidDialogLaunchResult(
+        launchResult = launchResult,
+        message = message,
+        clearPendingState = clearPendingState,
+        onError = onError,
+    )
+}
+
+internal fun dispatchAndroidDialogLaunchResult(
+    launchResult: AndroidLaunchResult,
+    message: String,
+    clearPendingState: () -> Unit,
+    onError: (FileKitDialogException) -> Unit,
+) {
+    if (launchResult is AndroidLaunchResult.Failed) {
+        dispatchAndroidLaunchFailure(
+            failure = FileKitDialogException(message, launchResult.cause),
+            clearPendingState = clearPendingState,
+            onError = onError,
+        )
+    }
+}
+
+internal sealed interface AndroidLaunchResult {
+    data object Launched : AndroidLaunchResult
+
+    data class Failed(
+        val cause: Throwable,
+    ) : AndroidLaunchResult
+}
+
+internal fun <Failure : FileKitDialogException> dispatchAndroidLaunchFailure(
+    failure: Failure,
+    clearPendingState: () -> Unit,
+    onError: (Failure) -> Unit,
+) {
+    clearPendingState()
+    onError(failure)
+}
+
+internal sealed interface PickerLaunchOutcome {
+    data object PrimaryLaunched : PickerLaunchOutcome
+
+    data object FallbackLaunched : PickerLaunchOutcome
+
+    data class Failed(
+        val cause: Throwable,
+    ) : PickerLaunchOutcome
 }
 
 internal fun resolvePickerLaunchOutcome(
-    launchPrimary: () -> Boolean,
-    launchFallback: () -> Boolean,
-): PickerLaunchOutcome = when {
-    launchPrimary() -> PickerLaunchOutcome.PrimaryLaunched
-    launchFallback() -> PickerLaunchOutcome.FallbackLaunched
-    else -> PickerLaunchOutcome.Cancelled
+    launchPrimary: () -> AndroidLaunchResult,
+    launchFallback: () -> AndroidLaunchResult,
+): PickerLaunchOutcome = when (launchPrimary()) {
+    AndroidLaunchResult.Launched -> PickerLaunchOutcome.PrimaryLaunched
+
+    is AndroidLaunchResult.Failed -> when (val fallback = launchFallback()) {
+        AndroidLaunchResult.Launched -> PickerLaunchOutcome.FallbackLaunched
+        is AndroidLaunchResult.Failed -> PickerLaunchOutcome.Failed(fallback.cause)
+    }
 }
 
 internal fun resolveCameraResult(

--- a/filekit-dialogs-compose/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.kt
+++ b/filekit-dialogs-compose/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.kt
@@ -135,29 +135,35 @@ internal expect fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
 internal suspend fun <PickerResult, ConsumedResult> runFilePickerLauncher(
     mode: FileKitMode<PickerResult, ConsumedResult>,
     openPicker: suspend () -> PickerResult,
+    beforeCallback: () -> Unit = {},
     onError: (FileKitPickerException) -> Unit,
     onResult: (ConsumedResult) -> Unit,
 ) {
     val result = try {
         openPicker()
     } catch (failure: FileKitPickerException) {
+        beforeCallback()
         onError(failure)
         return
     }
+    beforeCallback()
     mode.consumeResult(result, onResult)
 }
 
 internal suspend fun <Result> runDialogLauncher(
     openDialog: suspend () -> Result,
+    beforeCallback: () -> Unit = {},
     onError: (FileKitDialogException) -> Unit,
     onResult: (Result) -> Unit,
 ) {
     val result = try {
         openDialog()
     } catch (failure: FileKitDialogException) {
+        beforeCallback()
         onError(failure)
         return
     }
+    beforeCallback()
     onResult(result)
 }
 
@@ -170,28 +176,31 @@ internal fun legacyIgnoreDialogFailure(): (FileKitDialogException) -> Unit = {}
 internal class LauncherPendingState(
     private val launcherName: String,
 ) {
-    private var pending = false
+    internal class LaunchToken
 
-    fun begin() {
-        check(!pending) { "A $launcherName launch is already pending." }
-        pending = true
+    private var pendingLaunch: LaunchToken? = null
+
+    fun begin(): LaunchToken {
+        check(pendingLaunch == null) { "A $launcherName launch is already pending." }
+        return LaunchToken().also { pendingLaunch = it }
     }
 
-    fun finish() {
-        pending = false
+    fun finish(launch: LaunchToken) {
+        if (pendingLaunch === launch) pendingLaunch = null
     }
 }
 
 internal fun CoroutineScope.launchSinglePendingDialog(
     pendingState: LauncherPendingState,
-    block: suspend () -> Unit,
+    block: suspend (finishPendingLaunch: () -> Unit) -> Unit,
 ) {
-    pendingState.begin()
+    val launch = pendingState.begin()
+    val finishPendingLaunch = { pendingState.finish(launch) }
     launch {
         try {
-            block()
+            block(finishPendingLaunch)
         } finally {
-            pendingState.finish()
+            finishPendingLaunch()
         }
     }
 }

--- a/filekit-dialogs-compose/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.kt
+++ b/filekit-dialogs-compose/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.kt
@@ -4,10 +4,13 @@ package io.github.vinceglb.filekit.dialogs.compose
 
 import androidx.compose.runtime.Composable
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitMode
 import io.github.vinceglb.filekit.dialogs.FileKitPickerException
 import io.github.vinceglb.filekit.dialogs.FileKitType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 /**
  * Creates and remembers a [PickerResultLauncher] for picking files.
@@ -44,7 +47,7 @@ public fun <PickerResult, ConsumedResult> rememberFilePickerLauncher(
  * @param mode The picking mode (e.g. Single, Multiple).
  * @param directory The initial directory. Supported on desktop platforms.
  * @param dialogSettings Platform-specific settings for the dialog.
- * @param onError Callback invoked when FileKit cannot resolve the selected files.
+ * @param onError Callback invoked when FileKit cannot launch the picker or resolve the selected files.
  * @param onResult Callback invoked with the result.
  * @return A [PickerResultLauncher] that can be used to launch the picker.
  */
@@ -99,7 +102,7 @@ public fun rememberFilePickerLauncher(
  * @param type The type of files to pick. Defaults to [FileKitType.File].
  * @param directory The initial directory. Supported on desktop platforms.
  * @param dialogSettings Platform-specific settings for the dialog.
- * @param onError Callback invoked when FileKit cannot resolve the selected file.
+ * @param onError Callback invoked when FileKit cannot launch the picker or resolve the selected file.
  * @param onResult Callback invoked with the picked file, or null if cancelled.
  * @return A [PickerResultLauncher] that can be used to launch the picker.
  */
@@ -144,6 +147,55 @@ internal suspend fun <PickerResult, ConsumedResult> runFilePickerLauncher(
     mode.consumeResult(result, onResult)
 }
 
+internal suspend fun <Result> runDialogLauncher(
+    openDialog: suspend () -> Result,
+    onError: (FileKitDialogException) -> Unit,
+    onResult: (Result) -> Unit,
+) {
+    val result = try {
+        openDialog()
+    } catch (failure: FileKitDialogException) {
+        onError(failure)
+        return
+    }
+    onResult(result)
+}
+
+internal fun <Result> legacyNullResultOnDialogFailure(
+    onResult: (Result?) -> Unit,
+): (FileKitDialogException) -> Unit = { onResult(null) }
+
+internal fun legacyIgnoreDialogFailure(): (FileKitDialogException) -> Unit = {}
+
+internal class LauncherPendingState(
+    private val launcherName: String,
+) {
+    private var pending = false
+
+    fun begin() {
+        check(!pending) { "A $launcherName launch is already pending." }
+        pending = true
+    }
+
+    fun finish() {
+        pending = false
+    }
+}
+
+internal fun CoroutineScope.launchSinglePendingDialog(
+    pendingState: LauncherPendingState,
+    block: suspend () -> Unit,
+) {
+    pendingState.begin()
+    launch {
+        try {
+            block()
+        } finally {
+            pendingState.finish()
+        }
+    }
+}
+
 /**
  * Creates and remembers a [PickerResultLauncher] for picking a directory.
  *
@@ -151,10 +203,30 @@ internal suspend fun <PickerResult, ConsumedResult> runFilePickerLauncher(
  * @param dialogSettings Platform-specific settings for the dialog.
  * @param onResult Callback invoked with the picked directory, or null if cancelled.
  * @return A [PickerResultLauncher] that can be used to launch the picker.
+ *
+ * Dialog failures are reported as `onResult(null)` by this compatibility overload.
+ * Use the overload with `onError` to distinguish failure from cancellation.
  */
 @Composable
 public expect fun rememberDirectoryPickerLauncher(
     directory: PlatformFile? = null,
     dialogSettings: FileKitDialogSettings = FileKitDialogSettings.createDefault(),
+    onResult: (PlatformFile?) -> Unit,
+): PickerResultLauncher
+
+/**
+ * Creates and remembers a [PickerResultLauncher] for picking a directory.
+ *
+ * @param directory The initial directory. Supported on desktop platforms.
+ * @param dialogSettings Platform-specific settings for the dialog.
+ * @param onError Callback invoked when the directory picker fails.
+ * @param onResult Callback invoked with the picked directory, or null if cancelled.
+ * @return A [PickerResultLauncher] that can be used to launch the picker.
+ */
+@Composable
+public expect fun rememberDirectoryPickerLauncher(
+    directory: PlatformFile? = null,
+    dialogSettings: FileKitDialogSettings = FileKitDialogSettings.createDefault(),
+    onError: (FileKitDialogException) -> Unit,
     onResult: (PlatformFile?) -> Unit,
 ): PickerResultLauncher

--- a/filekit-dialogs-compose/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.kt
+++ b/filekit-dialogs-compose/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.kt
@@ -8,6 +8,7 @@ import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitMode
 import io.github.vinceglb.filekit.dialogs.FileKitPickerException
+import io.github.vinceglb.filekit.dialogs.FileKitPickerState
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -146,8 +147,24 @@ internal suspend fun <PickerResult, ConsumedResult> runFilePickerLauncher(
         onError(failure)
         return
     }
-    beforeCallback()
-    mode.consumeResult(result, onResult)
+    mode.consumeResult(result) { consumedResult ->
+        if (mode.isTerminalConsumedResult(consumedResult)) beforeCallback()
+        onResult(consumedResult)
+    }
+}
+
+private fun <PickerResult, ConsumedResult> FileKitMode<PickerResult, ConsumedResult>.isTerminalConsumedResult(
+    result: ConsumedResult,
+): Boolean = when (this) {
+    FileKitMode.Single,
+    is FileKitMode.Multiple,
+    -> true
+
+    FileKitMode.SingleWithState,
+    is FileKitMode.MultipleWithState,
+    -> result is FileKitPickerState.Cancelled ||
+        result is FileKitPickerState.Failed ||
+        result is FileKitPickerState.Completed<*>
 }
 
 internal suspend fun <Result> runDialogLauncher(

--- a/filekit-dialogs-compose/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposeFailureTest.kt
+++ b/filekit-dialogs-compose/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitComposeFailureTest.kt
@@ -2,15 +2,153 @@
 
 package io.github.vinceglb.filekit.dialogs.compose
 
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitMode
 import io.github.vinceglb.filekit.dialogs.FileKitPickerException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class FileKitComposeFailureTest {
+    @Test
+    fun legacyNullResultOnDialogFailure_reportsNullResult() {
+        var result: String? = "unchanged"
+
+        legacyNullResultOnDialogFailure<String> { result = it }
+            .invoke(FileKitDialogException("Dialog failed"))
+
+        assertEquals(null, result)
+    }
+
+    @Test
+    fun legacyDirectoryFailure_reportsNullResult() {
+        assertLegacyResultFailureReportsNull<String>()
+    }
+
+    @Test
+    fun legacyFileSaverFailure_reportsNullResult() {
+        assertLegacyResultFailureReportsNull<String>()
+    }
+
+    @Test
+    fun legacyCameraFailure_reportsNullResult() {
+        assertLegacyResultFailureReportsNull<String>()
+    }
+
+    @Test
+    fun legacyShareFailure_isIgnored() {
+        legacyIgnoreDialogFailure().invoke(FileKitDialogException("Share failed"))
+    }
+
+    @Test
+    fun runDialogLauncher_successInvokesOnlyResult() = runTest {
+        var errorInvoked = false
+        var receivedResult: String? = null
+
+        runDialogLauncher(
+            openDialog = { "picked" },
+            onError = { errorInvoked = true },
+            onResult = { receivedResult = it },
+        )
+
+        assertFalse(errorInvoked)
+        assertEquals("picked", receivedResult)
+    }
+
+    @Test
+    fun runDialogLauncher_reportsDialogException_withoutInvokingResult() = runTest {
+        val failure = FileKitDialogException("Failed to open the dialog.")
+        var reportedFailure: FileKitDialogException? = null
+        var resultInvoked = false
+
+        runDialogLauncher(
+            openDialog = { throw failure },
+            onError = { reportedFailure = it },
+            onResult = { resultInvoked = true },
+        )
+
+        assertEquals(expected = failure, actual = reportedFailure)
+        assertFalse(resultInvoked)
+    }
+
+    @Test
+    fun runDialogLauncher_propagatesCoroutineCancellation_withoutInvokingCallbacks() = runTest {
+        var errorInvoked = false
+        var resultInvoked = false
+
+        assertFailsWith<CancellationException> {
+            runDialogLauncher(
+                openDialog = { throw CancellationException("cancelled") },
+                onError = { errorInvoked = true },
+                onResult = { resultInvoked = true },
+            )
+        }
+
+        assertFalse(errorInvoked)
+        assertFalse(resultInvoked)
+    }
+
+    @Test
+    fun runDialogLauncher_unexpectedExceptionPropagates_withoutInvokingCallbacks() = runTest {
+        val unexpectedFailure = IllegalStateException("Unexpected failure")
+        var errorInvoked = false
+        var resultInvoked = false
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            runDialogLauncher(
+                openDialog = { throw unexpectedFailure },
+                onError = { errorInvoked = true },
+                onResult = { resultInvoked = true },
+            )
+        }
+
+        assertSame(unexpectedFailure, thrown)
+        assertFalse(errorInvoked)
+        assertFalse(resultInvoked)
+    }
+
+    @Test
+    fun runDialogLauncher_resultCallbackExceptionPropagates_withoutInvokingError() = runTest {
+        val callbackFailure = IllegalStateException("Result callback failed")
+        var errorInvoked = false
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            runDialogLauncher(
+                openDialog = { "picked" },
+                onError = { errorInvoked = true },
+                onResult = { throw callbackFailure },
+            )
+        }
+
+        assertSame(callbackFailure, thrown)
+        assertFalse(errorInvoked)
+    }
+
+    @Test
+    fun runDialogLauncher_errorCallbackExceptionPropagatesOnce() = runTest {
+        val callbackFailure = IllegalStateException("Error callback failed")
+        var errorCalls = 0
+
+        val thrown = assertFailsWith<IllegalStateException> {
+            runDialogLauncher(
+                openDialog = { throw FileKitDialogException("Dialog failed") },
+                onError = {
+                    errorCalls++
+                    throw callbackFailure
+                },
+                onResult = { error("Result must not be invoked") },
+            )
+        }
+
+        assertSame(callbackFailure, thrown)
+        assertEquals(1, errorCalls)
+    }
+
     @Test
     fun runFilePickerLauncher_reportsPickerException_withoutInvokingResult() = runTest {
         val failure = FileKitPickerException("Failed to load the selected file.")
@@ -43,4 +181,17 @@ class FileKitComposeFailureTest {
         assertFalse(errorInvoked)
         assertTrue(resultInvoked)
     }
+}
+
+private fun <Result> assertLegacyResultFailureReportsNull() {
+    var callbackInvoked = false
+    var result: Result? = null
+
+    legacyNullResultOnDialogFailure<Result> {
+        callbackInvoked = true
+        result = it
+    }.invoke(FileKitDialogException("Dialog failed"))
+
+    assertTrue(callbackInvoked)
+    assertEquals(null, result)
 }

--- a/filekit-dialogs-compose/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/LauncherCallShapeTest.kt
+++ b/filekit-dialogs-compose/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/LauncherCallShapeTest.kt
@@ -1,0 +1,51 @@
+package io.github.vinceglb.filekit.dialogs.compose
+
+import androidx.compose.runtime.Composable
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
+import io.github.vinceglb.filekit.dialogs.FileKitMode
+import io.github.vinceglb.filekit.dialogs.FileKitType
+
+@Composable
+private fun CompileCommonLauncherCallShapes() {
+    rememberFilePickerLauncher(
+        type = FileKitType.Image,
+        onResult = {},
+    )
+    rememberFilePickerLauncher(type = FileKitType.Image) {}
+    rememberFilePickerLauncher(
+        type = FileKitType.Image,
+        onError = ::handlePickerError,
+        onResult = {},
+    )
+    rememberFilePickerLauncher(
+        type = FileKitType.Image,
+        onError = ::handlePickerError,
+    ) {}
+    rememberFilePickerLauncher(
+        mode = FileKitMode.Multiple(),
+        onResult = {},
+    )
+    rememberFilePickerLauncher(
+        mode = FileKitMode.Multiple(),
+    ) {}
+    rememberFilePickerLauncher(
+        mode = FileKitMode.Multiple(),
+        onError = ::handlePickerError,
+        onResult = {},
+    )
+    rememberFilePickerLauncher(
+        mode = FileKitMode.Multiple(),
+        onError = ::handlePickerError,
+    ) {}
+    rememberDirectoryPickerLauncher(onResult = {})
+    rememberDirectoryPickerLauncher {}
+    rememberDirectoryPickerLauncher(
+        onError = ::handleDialogError,
+        onResult = {},
+    )
+    rememberDirectoryPickerLauncher(onError = ::handleDialogError) {}
+}
+
+private fun handlePickerError(error: FileKitDialogException) = Unit
+
+private fun handleDialogError(error: FileKitDialogException) = Unit

--- a/filekit-dialogs-compose/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/LauncherPendingStateTest.kt
+++ b/filekit-dialogs-compose/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/LauncherPendingStateTest.kt
@@ -2,8 +2,13 @@
 
 package io.github.vinceglb.filekit.dialogs.compose
 
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
+import io.github.vinceglb.filekit.dialogs.FileKitMode
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
 
 class LauncherPendingStateTest {
     @Test
@@ -19,8 +24,81 @@ class LauncherPendingStateTest {
     fun LauncherPendingState_beginAfterFinish_succeeds() {
         val pendingState = LauncherPendingState("directory picker")
 
+        val launch = pendingState.begin()
+        pendingState.finish(launch)
         pendingState.begin()
-        pendingState.finish()
+    }
+
+    @Test
+    fun SinglePendingDialog_resultCallback_canBeginNextLaunch() = runTest {
+        val pendingState = LauncherPendingState("directory picker")
+        var retryFailure: Throwable? = null
+
+        launchSinglePendingDialog(pendingState) { finishPendingLaunch ->
+            runDialogLauncher(
+                openDialog = { "result" },
+                beforeCallback = finishPendingLaunch,
+                onError = {},
+                onResult = {
+                    retryFailure = runCatching { pendingState.begin() }.exceptionOrNull()
+                },
+            )
+        }
+        yield()
+
+        assertNull(retryFailure)
+    }
+
+    @Test
+    fun SinglePendingDialog_errorCallback_canBeginNextLaunch() = runTest {
+        val pendingState = LauncherPendingState("directory picker")
+        var retryFailure: Throwable? = null
+
+        launchSinglePendingDialog(pendingState) { finishPendingLaunch ->
+            runDialogLauncher(
+                openDialog = { throw FileKitDialogException("launch failed") },
+                beforeCallback = finishPendingLaunch,
+                onError = {
+                    retryFailure = runCatching { pendingState.begin() }.exceptionOrNull()
+                },
+                onResult = {},
+            )
+        }
+        yield()
+
+        assertNull(retryFailure)
+    }
+
+    @Test
+    fun SinglePendingFilePicker_resultCallback_canBeginNextLaunch() = runTest {
+        val pendingState = LauncherPendingState("file picker")
+        var retryFailure: Throwable? = null
+
+        launchSinglePendingDialog(pendingState) { finishPendingLaunch ->
+            runFilePickerLauncher(
+                mode = FileKitMode.Single,
+                openPicker = { null },
+                beforeCallback = finishPendingLaunch,
+                onError = {},
+                onResult = {
+                    retryFailure = runCatching { pendingState.begin() }.exceptionOrNull()
+                },
+            )
+        }
+        yield()
+
+        assertNull(retryFailure)
+    }
+
+    @Test
+    fun LauncherPendingState_staleFinish_doesNotClearNewLaunch() {
+        val pendingState = LauncherPendingState("directory picker")
+        val firstLaunch = pendingState.begin()
+        pendingState.finish(firstLaunch)
         pendingState.begin()
+
+        pendingState.finish(firstLaunch)
+
+        assertFailsWith<IllegalStateException> { pendingState.begin() }
     }
 }

--- a/filekit-dialogs-compose/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/LauncherPendingStateTest.kt
+++ b/filekit-dialogs-compose/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/LauncherPendingStateTest.kt
@@ -4,11 +4,15 @@ package io.github.vinceglb.filekit.dialogs.compose
 
 import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitMode
+import io.github.vinceglb.filekit.dialogs.FileKitPickerState
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class LauncherPendingStateTest {
     @Test
@@ -88,6 +92,41 @@ class LauncherPendingStateTest {
         yield()
 
         assertNull(retryFailure)
+    }
+
+    @Test
+    fun SinglePendingStateFilePicker_remainsPendingUntilTerminalCallback() = runTest {
+        val pendingState = LauncherPendingState("file picker")
+        val finishPicker = CompletableDeferred<Unit>()
+        val startedRetryFailure = CompletableDeferred<Throwable?>()
+        val terminalRetryFailure = CompletableDeferred<Throwable?>()
+
+        launchSinglePendingDialog(pendingState) { finishPendingLaunch ->
+            runFilePickerLauncher(
+                mode = FileKitMode.SingleWithState,
+                openPicker = {
+                    flow {
+                        emit(FileKitPickerState.Started(total = 1))
+                        finishPicker.await()
+                        emit(FileKitPickerState.Cancelled)
+                    }
+                },
+                beforeCallback = finishPendingLaunch,
+                onError = {},
+                onResult = { state ->
+                    val retryFailure = runCatching { pendingState.begin() }.exceptionOrNull()
+                    when (state) {
+                        is FileKitPickerState.Started -> startedRetryFailure.complete(retryFailure)
+                        is FileKitPickerState.Cancelled -> terminalRetryFailure.complete(retryFailure)
+                        else -> error("Unexpected picker state: $state")
+                    }
+                },
+            )
+        }
+
+        assertTrue(startedRetryFailure.await() is IllegalStateException)
+        finishPicker.complete(Unit)
+        assertNull(terminalRetryFailure.await())
     }
 
     @Test

--- a/filekit-dialogs-compose/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/LauncherPendingStateTest.kt
+++ b/filekit-dialogs-compose/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/LauncherPendingStateTest.kt
@@ -1,0 +1,26 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+
+package io.github.vinceglb.filekit.dialogs.compose
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class LauncherPendingStateTest {
+    @Test
+    fun LauncherPendingState_secondBeginBeforeFinish_throwsProgrammerError() {
+        val pendingState = LauncherPendingState("directory picker")
+
+        pendingState.begin()
+
+        assertFailsWith<IllegalStateException> { pendingState.begin() }
+    }
+
+    @Test
+    fun LauncherPendingState_beginAfterFinish_succeeds() {
+        val pendingState = LauncherPendingState("directory picker")
+
+        pendingState.begin()
+        pendingState.finish()
+        pendingState.begin()
+    }
+}

--- a/filekit-dialogs-compose/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.ios.kt
+++ b/filekit-dialogs-compose/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.ios.kt
@@ -50,7 +50,7 @@ public actual fun rememberCameraPickerLauncher(
     // FileKit launcher
     val returnedLauncher = remember {
         PhotoResultLauncher { type, cameraFacing, destinationFile ->
-            coroutineScope.launchSinglePendingDialog(pendingState) {
+            coroutineScope.launchSinglePendingDialog(pendingState) { finishPendingLaunch ->
                 runDialogLauncher(
                     openDialog = {
                         fileKit.openCameraPicker(
@@ -60,6 +60,7 @@ public actual fun rememberCameraPickerLauncher(
                             openCameraSettings = currentOpenCameraSettings,
                         )
                     },
+                    beforeCallback = finishPendingLaunch,
                     onError = currentOnError,
                     onResult = currentOnResult,
                 )

--- a/filekit-dialogs-compose/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.ios.kt
+++ b/filekit-dialogs-compose/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.ios.kt
@@ -7,9 +7,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitOpenCameraSettings
 import io.github.vinceglb.filekit.dialogs.openCameraPicker
-import kotlinx.coroutines.launch
 
 /**
  * Creates and remembers a [PhotoResultLauncher] for taking a picture or video with the camera.
@@ -22,13 +22,26 @@ import kotlinx.coroutines.launch
 public actual fun rememberCameraPickerLauncher(
     openCameraSettings: FileKitOpenCameraSettings,
     onResult: (PlatformFile?) -> Unit,
+): PhotoResultLauncher = rememberCameraPickerLauncher(
+    openCameraSettings = openCameraSettings,
+    onError = legacyNullResultOnDialogFailure(onResult),
+    onResult = onResult,
+)
+
+@Composable
+public actual fun rememberCameraPickerLauncher(
+    openCameraSettings: FileKitOpenCameraSettings,
+    onError: (FileKitDialogException) -> Unit,
+    onResult: (PlatformFile?) -> Unit,
 ): PhotoResultLauncher {
     // Coroutine
     val coroutineScope = rememberCoroutineScope()
+    val pendingState = remember { LauncherPendingState("camera picker") }
     val stableOpenCameraSettings = rememberStableOpenCameraSettings(openCameraSettings)
 
     // Updated state
     val currentOpenCameraSettings by rememberUpdatedState(stableOpenCameraSettings)
+    val currentOnError by rememberUpdatedState(onError)
     val currentOnResult by rememberUpdatedState(onResult)
 
     // FileKit
@@ -37,14 +50,19 @@ public actual fun rememberCameraPickerLauncher(
     // FileKit launcher
     val returnedLauncher = remember {
         PhotoResultLauncher { type, cameraFacing, destinationFile ->
-            coroutineScope.launch {
-                val result = fileKit.openCameraPicker(
-                    type = type,
-                    cameraFacing = cameraFacing,
-                    destinationFile = destinationFile,
-                    openCameraSettings = currentOpenCameraSettings,
+            coroutineScope.launchSinglePendingDialog(pendingState) {
+                runDialogLauncher(
+                    openDialog = {
+                        fileKit.openCameraPicker(
+                            type = type,
+                            cameraFacing = cameraFacing,
+                            destinationFile = destinationFile,
+                            openCameraSettings = currentOpenCameraSettings,
+                        )
+                    },
+                    onError = currentOnError,
+                    onResult = currentOnResult,
                 )
-                currentOnResult(result)
             }
         }
     }

--- a/filekit-dialogs-compose/src/jvmAndNativeMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nativeAndJvm.kt
+++ b/filekit-dialogs-compose/src/jvmAndNativeMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nativeAndJvm.kt
@@ -26,7 +26,7 @@ internal actual fun rememberPlatformFileSaverLauncher(
 
     return remember {
         SaverResultLauncher { suggestedName, defaultExtension, allowedExtensions, directory ->
-            coroutineScope.launchSinglePendingDialog(pendingState) {
+            coroutineScope.launchSinglePendingDialog(pendingState) { finishPendingLaunch ->
                 runDialogLauncher(
                     openDialog = {
                         FileKit.openFileSaver(
@@ -37,6 +37,7 @@ internal actual fun rememberPlatformFileSaverLauncher(
                             dialogSettings = currentDialogSettings,
                         )
                     },
+                    beforeCallback = finishPendingLaunch,
                     onError = currentOnError,
                     onResult = currentOnResult,
                 )

--- a/filekit-dialogs-compose/src/jvmAndNativeMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nativeAndJvm.kt
+++ b/filekit-dialogs-compose/src/jvmAndNativeMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nativeAndJvm.kt
@@ -7,31 +7,39 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.openFileSaver
-import kotlinx.coroutines.launch
 
 @Composable
 internal actual fun rememberPlatformFileSaverLauncher(
     dialogSettings: FileKitDialogSettings,
+    onError: (FileKitDialogException) -> Unit,
     onResult: (PlatformFile?) -> Unit,
 ): SaverResultLauncher {
     val coroutineScope = rememberCoroutineScope()
+    val pendingState = remember { LauncherPendingState("file saver") }
     val stableDialogSettings = rememberStableDialogSettings(dialogSettings)
     val currentDialogSettings by rememberUpdatedState(stableDialogSettings)
+    val currentOnError by rememberUpdatedState(onError)
     val currentOnResult by rememberUpdatedState(onResult)
 
     return remember {
         SaverResultLauncher { suggestedName, defaultExtension, allowedExtensions, directory ->
-            coroutineScope.launch {
-                val result = FileKit.openFileSaver(
-                    suggestedName = suggestedName,
-                    defaultExtension = defaultExtension,
-                    allowedExtensions = allowedExtensions,
-                    directory = directory,
-                    dialogSettings = currentDialogSettings,
+            coroutineScope.launchSinglePendingDialog(pendingState) {
+                runDialogLauncher(
+                    openDialog = {
+                        FileKit.openFileSaver(
+                            suggestedName = suggestedName,
+                            defaultExtension = defaultExtension,
+                            allowedExtensions = allowedExtensions,
+                            directory = directory,
+                            dialogSettings = currentDialogSettings,
+                        )
+                    },
+                    onError = currentOnError,
+                    onResult = currentOnResult,
                 )
-                currentOnResult(result)
             }
         }
     }

--- a/filekit-dialogs-compose/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.jvm.kt
+++ b/filekit-dialogs-compose/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.jvm.kt
@@ -5,6 +5,7 @@ package io.github.vinceglb.filekit.dialogs.compose
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.window.WindowScope
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitMode
 import io.github.vinceglb.filekit.dialogs.FileKitPickerException
@@ -83,11 +84,35 @@ public fun WindowScope.rememberDirectoryPickerLauncher(
 )
 
 @Composable
+public fun WindowScope.rememberDirectoryPickerLauncher(
+    directory: PlatformFile? = null,
+    dialogSettings: FileKitDialogSettings? = null,
+    onError: (FileKitDialogException) -> Unit,
+    onResult: (PlatformFile?) -> Unit,
+): PickerResultLauncher = io.github.vinceglb.filekit.dialogs.compose.rememberDirectoryPickerLauncher(
+    directory = directory,
+    dialogSettings = injectDialogSettings(dialogSettings, this.window),
+    onError = onError,
+    onResult = onResult,
+)
+
+@Composable
 public fun WindowScope.rememberFileSaverLauncher(
     dialogSettings: FileKitDialogSettings? = null,
     onResult: (PlatformFile?) -> Unit,
 ): SaverResultLauncher = io.github.vinceglb.filekit.dialogs.compose.rememberFileSaverLauncher(
     dialogSettings = injectDialogSettings(dialogSettings, this.window),
+    onResult = onResult,
+)
+
+@Composable
+public fun WindowScope.rememberFileSaverLauncher(
+    dialogSettings: FileKitDialogSettings? = null,
+    onError: (FileKitDialogException) -> Unit,
+    onResult: (PlatformFile?) -> Unit,
+): SaverResultLauncher = io.github.vinceglb.filekit.dialogs.compose.rememberFileSaverLauncher(
+    dialogSettings = injectDialogSettings(dialogSettings, this.window),
+    onError = onError,
     onResult = onResult,
 )
 

--- a/filekit-dialogs-compose/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/JvmLauncherCallShapeTest.kt
+++ b/filekit-dialogs-compose/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/JvmLauncherCallShapeTest.kt
@@ -1,0 +1,48 @@
+package io.github.vinceglb.filekit.dialogs.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.WindowScope
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
+import io.github.vinceglb.filekit.dialogs.FileKitMode
+
+@Composable
+private fun WindowScope.CompileJvmLauncherCallShapes() {
+    rememberFilePickerLauncher(onResult = {})
+    rememberFilePickerLauncher(
+        onError = ::handleJvmPickerError,
+        onResult = {},
+    )
+    rememberFilePickerLauncher(onError = ::handleJvmPickerError) {}
+    rememberFilePickerLauncher(
+        mode = FileKitMode.Multiple(),
+        onResult = {},
+    )
+    rememberFilePickerLauncher(mode = FileKitMode.Multiple()) {}
+    rememberFilePickerLauncher(
+        mode = FileKitMode.Multiple(),
+        onError = ::handleJvmPickerError,
+        onResult = {},
+    )
+    rememberFilePickerLauncher(
+        mode = FileKitMode.Multiple(),
+        onError = ::handleJvmPickerError,
+    ) {}
+    rememberDirectoryPickerLauncher(onResult = {})
+    rememberDirectoryPickerLauncher {}
+    rememberDirectoryPickerLauncher(
+        onError = ::handleJvmDialogError,
+        onResult = {},
+    )
+    rememberDirectoryPickerLauncher(onError = ::handleJvmDialogError) {}
+    rememberFileSaverLauncher(onResult = {})
+    rememberFileSaverLauncher {}
+    rememberFileSaverLauncher(
+        onError = ::handleJvmDialogError,
+        onResult = {},
+    )
+    rememberFileSaverLauncher(onError = ::handleJvmDialogError) {}
+}
+
+private fun handleJvmPickerError(error: io.github.vinceglb.filekit.dialogs.FileKitPickerException) = Unit
+
+private fun handleJvmDialogError(error: FileKitDialogException) = Unit

--- a/filekit-dialogs-compose/src/mobileMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.mobile.kt
+++ b/filekit-dialogs-compose/src/mobileMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.mobile.kt
@@ -63,9 +63,10 @@ public fun rememberShareFileLauncher(
     // FileKit launcher
     val returnedLauncher = remember {
         ShareResultLauncher { files ->
-            coroutineScope.launchSinglePendingDialog(pendingState) {
+            coroutineScope.launchSinglePendingDialog(pendingState) { finishPendingLaunch ->
                 runDialogLauncher(
                     openDialog = { fileKit.shareFile(files, currentShareSettings) },
+                    beforeCallback = finishPendingLaunch,
                     onError = currentOnError,
                     onResult = {},
                 )

--- a/filekit-dialogs-compose/src/mobileMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.mobile.kt
+++ b/filekit-dialogs-compose/src/mobileMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.mobile.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:compose:param-order-check")
+
 package io.github.vinceglb.filekit.dialogs.compose
 
 import androidx.compose.runtime.Composable
@@ -7,25 +9,53 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitOpenCameraSettings
 import io.github.vinceglb.filekit.dialogs.FileKitShareSettings
 import io.github.vinceglb.filekit.dialogs.shareFile
-import kotlinx.coroutines.launch
 
+/**
+ * Creates a camera launcher whose result is null for cancellation, permission denial, or a dialog failure.
+ * Use the overload with `onError` to distinguish dialog failure from cancellation.
+ */
 @Composable
 public expect fun rememberCameraPickerLauncher(
     openCameraSettings: FileKitOpenCameraSettings = FileKitOpenCameraSettings.createDefault(),
     onResult: (PlatformFile?) -> Unit,
 ): PhotoResultLauncher
 
+/** Creates a camera launcher with an explicit dialog-failure callback. */
+@Composable
+public expect fun rememberCameraPickerLauncher(
+    openCameraSettings: FileKitOpenCameraSettings = FileKitOpenCameraSettings.createDefault(),
+    onError: (FileKitDialogException) -> Unit,
+    onResult: (PlatformFile?) -> Unit,
+): PhotoResultLauncher
+
+/**
+ * Creates a share launcher that ignores dialog failures.
+ * Use the overload with `onError` to observe them.
+ */
 @Composable
 public fun rememberShareFileLauncher(
     shareSettings: FileKitShareSettings = FileKitShareSettings.createDefault(),
+): ShareResultLauncher = rememberShareFileLauncher(
+    shareSettings = shareSettings,
+    onError = legacyIgnoreDialogFailure(),
+)
+
+/** Creates a share launcher with an explicit dialog-failure callback. */
+@Composable
+public fun rememberShareFileLauncher(
+    shareSettings: FileKitShareSettings = FileKitShareSettings.createDefault(),
+    onError: (FileKitDialogException) -> Unit,
 ): ShareResultLauncher {
     // Coroutine
     val coroutineScope = rememberCoroutineScope()
+    val pendingState = remember { LauncherPendingState("share sheet") }
     val stableShareSettings = rememberStableShareSettings(shareSettings)
     val currentShareSettings by rememberUpdatedState(stableShareSettings)
+    val currentOnError by rememberUpdatedState(onError)
 
     // FileKit
     val fileKit = remember { FileKit }
@@ -33,8 +63,12 @@ public fun rememberShareFileLauncher(
     // FileKit launcher
     val returnedLauncher = remember {
         ShareResultLauncher { files ->
-            coroutineScope.launch {
-                fileKit.shareFile(files, currentShareSettings)
+            coroutineScope.launchSinglePendingDialog(pendingState) {
+                runDialogLauncher(
+                    openDialog = { fileKit.shareFile(files, currentShareSettings) },
+                    onError = currentOnError,
+                    onResult = {},
+                )
             }
         }
     }

--- a/filekit-dialogs-compose/src/nonAndroidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nonAndroid.kt
+++ b/filekit-dialogs-compose/src/nonAndroidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nonAndroid.kt
@@ -53,7 +53,7 @@ public actual fun rememberDirectoryPickerLauncher(
 
     return remember {
         PickerResultLauncher {
-            coroutineScope.launchSinglePendingDialog(pendingState) {
+            coroutineScope.launchSinglePendingDialog(pendingState) { finishPendingLaunch ->
                 runDialogLauncher(
                     openDialog = {
                         FileKit.openDirectoryPicker(
@@ -61,6 +61,7 @@ public actual fun rememberDirectoryPickerLauncher(
                             dialogSettings = currentDialogSettings,
                         )
                     },
+                    beforeCallback = finishPendingLaunch,
                     onError = currentOnError,
                     onResult = currentOnResult,
                 )
@@ -91,7 +92,7 @@ internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
 
     return remember {
         PickerResultLauncher {
-            coroutineScope.launchSinglePendingDialog(pendingState) {
+            coroutineScope.launchSinglePendingDialog(pendingState) { finishPendingLaunch ->
                 runFilePickerLauncher(
                     mode = currentMode,
                     openPicker = {
@@ -102,6 +103,7 @@ internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
                             dialogSettings = currentDialogSettings,
                         )
                     },
+                    beforeCallback = finishPendingLaunch,
                     onError = currentOnError,
                     onResult = currentOnConsumed,
                 )

--- a/filekit-dialogs-compose/src/nonAndroidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nonAndroid.kt
+++ b/filekit-dialogs-compose/src/nonAndroidMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nonAndroid.kt
@@ -7,13 +7,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitMode
 import io.github.vinceglb.filekit.dialogs.FileKitPickerException
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.openDirectoryPicker
 import io.github.vinceglb.filekit.dialogs.openFilePicker
-import kotlinx.coroutines.launch
 
 /**
  * Creates and remembers a [PickerResultLauncher] for picking a directory.
@@ -28,22 +28,42 @@ public actual fun rememberDirectoryPickerLauncher(
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
     onResult: (PlatformFile?) -> Unit,
+): PickerResultLauncher = rememberDirectoryPickerLauncher(
+    directory = directory,
+    dialogSettings = dialogSettings,
+    onError = legacyNullResultOnDialogFailure(onResult),
+    onResult = onResult,
+)
+
+@Composable
+public actual fun rememberDirectoryPickerLauncher(
+    directory: PlatformFile?,
+    dialogSettings: FileKitDialogSettings,
+    onError: (FileKitDialogException) -> Unit,
+    onResult: (PlatformFile?) -> Unit,
 ): PickerResultLauncher {
     val coroutineScope = rememberCoroutineScope()
+    val pendingState = remember { LauncherPendingState("directory picker") }
     val stableDialogSettings = rememberStableDialogSettings(dialogSettings)
 
     val currentDirectory by rememberUpdatedState(directory)
     val currentDialogSettings by rememberUpdatedState(stableDialogSettings)
+    val currentOnError by rememberUpdatedState(onError)
     val currentOnResult by rememberUpdatedState(onResult)
 
     return remember {
         PickerResultLauncher {
-            coroutineScope.launch {
-                val result = FileKit.openDirectoryPicker(
-                    directory = currentDirectory,
-                    dialogSettings = currentDialogSettings,
+            coroutineScope.launchSinglePendingDialog(pendingState) {
+                runDialogLauncher(
+                    openDialog = {
+                        FileKit.openDirectoryPicker(
+                            directory = currentDirectory,
+                            dialogSettings = currentDialogSettings,
+                        )
+                    },
+                    onError = currentOnError,
+                    onResult = currentOnResult,
                 )
-                currentOnResult(result)
             }
         }
     }
@@ -59,6 +79,7 @@ internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
     onResult: (ConsumedResult) -> Unit,
 ): PickerResultLauncher {
     val coroutineScope = rememberCoroutineScope()
+    val pendingState = remember { LauncherPendingState("file picker") }
     val stableDialogSettings = rememberStableDialogSettings(dialogSettings)
 
     val currentType by rememberUpdatedState(type)
@@ -70,7 +91,7 @@ internal actual fun <PickerResult, ConsumedResult> rememberPlatformFilePickerLau
 
     return remember {
         PickerResultLauncher {
-            coroutineScope.launch {
+            coroutineScope.launchSinglePendingDialog(pendingState) {
                 runFilePickerLauncher(
                     mode = currentMode,
                     openPicker = {

--- a/filekit-dialogs-compose/src/nonWebMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nonWeb.kt
+++ b/filekit-dialogs-compose/src/nonWebMain/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileKitCompose.nonWeb.kt
@@ -2,6 +2,7 @@ package io.github.vinceglb.filekit.dialogs.compose
 
 import androidx.compose.runtime.Composable
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 
 /**
@@ -10,19 +11,42 @@ import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
  * @param dialogSettings Platform-specific settings for the dialog.
  * @param onResult Callback invoked with the saved file path, or null if cancelled.
  * @return A [SaverResultLauncher] that can be used to launch the saver.
+ *
+ * Dialog failures are reported as `onResult(null)` by this compatibility overload.
+ * Use the overload with `onError` to distinguish failure from cancellation.
  */
 @Composable
 public fun rememberFileSaverLauncher(
     dialogSettings: FileKitDialogSettings,
     onResult: (PlatformFile?) -> Unit,
-): SaverResultLauncher =
-    rememberPlatformFileSaverLauncher(
-        dialogSettings = dialogSettings,
-        onResult = onResult,
-    )
+): SaverResultLauncher = rememberFileSaverLauncher(
+    dialogSettings = dialogSettings,
+    onError = legacyNullResultOnDialogFailure(onResult),
+    onResult = onResult,
+)
+
+/**
+ * Creates and remembers a [SaverResultLauncher] for saving a file.
+ *
+ * @param dialogSettings Platform-specific settings for the dialog.
+ * @param onError Callback invoked when the file saver fails.
+ * @param onResult Callback invoked with the saved file path, or null if cancelled.
+ * @return A [SaverResultLauncher] that can be used to launch the saver.
+ */
+@Composable
+public fun rememberFileSaverLauncher(
+    dialogSettings: FileKitDialogSettings,
+    onError: (FileKitDialogException) -> Unit,
+    onResult: (PlatformFile?) -> Unit,
+): SaverResultLauncher = rememberPlatformFileSaverLauncher(
+    dialogSettings = dialogSettings,
+    onError = onError,
+    onResult = onResult,
+)
 
 @Composable
 internal expect fun rememberPlatformFileSaverLauncher(
     dialogSettings: FileKitDialogSettings,
+    onError: (FileKitDialogException) -> Unit,
     onResult: (PlatformFile?) -> Unit,
 ): SaverResultLauncher

--- a/filekit-dialogs-compose/src/nonWebTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileSaverLauncherCallShapeTest.kt
+++ b/filekit-dialogs-compose/src/nonWebTest/kotlin/io/github/vinceglb/filekit/dialogs/compose/FileSaverLauncherCallShapeTest.kt
@@ -1,0 +1,24 @@
+package io.github.vinceglb.filekit.dialogs.compose
+
+import androidx.compose.runtime.Composable
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
+import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+
+@Composable
+private fun CompileFileSaverLauncherCallShapes() {
+    val dialogSettings = FileKitDialogSettings.createDefault()
+
+    rememberFileSaverLauncher(
+        dialogSettings = dialogSettings,
+        onResult = {},
+    )
+    rememberFileSaverLauncher(dialogSettings) {}
+    rememberFileSaverLauncher(
+        dialogSettings = dialogSettings,
+        onError = ::handleFileSaverError,
+        onResult = {},
+    )
+    rememberFileSaverLauncher(dialogSettings, onError = ::handleFileSaverError) {}
+}
+
+private fun handleFileSaverError(error: FileKitDialogException) = Unit

--- a/filekit-dialogs/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/AndroidPickerLaunchFallbackTest.kt
+++ b/filekit-dialogs/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/AndroidPickerLaunchFallbackTest.kt
@@ -18,7 +18,7 @@ class AndroidPickerLaunchFallbackTest {
     fun PickerLaunch_primaryThrowsActivityNotFound_usesFallbackResult() = runBlocking {
         var fallbackCalls = 0
 
-        val result = runPickerLaunchWithActivityNotFoundFallback(
+        val result = runPickerLaunchWithFallback(
             primary = {
                 throw ActivityNotFoundException("No activity for picker")
             },
@@ -38,7 +38,7 @@ class AndroidPickerLaunchFallbackTest {
 
         val failure = assertFailsWith<FileKitPickerException> {
             runBlocking {
-                runPickerLaunchWithActivityNotFoundFallback(
+                runPickerLaunchWithFallback(
                     primary = {
                         throw ActivityNotFoundException("No activity for visual picker")
                     },
@@ -58,7 +58,62 @@ class AndroidPickerLaunchFallbackTest {
 
         val failure = assertFailsWith<FileKitPickerException> {
             runBlocking {
-                runPickerLaunchWithActivityNotFoundFallback(
+                runPickerLaunchWithFallback(
+                    primary = {
+                        throw launchFailure
+                    },
+                )
+            }
+        }
+
+        assertSame(launchFailure, failure.cause)
+    }
+
+    @Test
+    fun PickerLaunch_primaryThrowsSecurityException_usesFallbackResult() = runBlocking {
+        var fallbackCalls = 0
+
+        val result = runPickerLaunchWithFallback(
+            primary = {
+                throw SecurityException("Visual picker launch denied")
+            },
+            fallback = {
+                fallbackCalls++
+                "fallback-result"
+            },
+        )
+
+        assertEquals("fallback-result", result)
+        assertEquals(1, fallbackCalls)
+    }
+
+    @Test
+    fun PickerLaunch_fallbackThrowsSecurityException_throwsPickerFailure() {
+        val fallbackFailure = SecurityException("Document picker launch denied")
+
+        val failure = assertFailsWith<FileKitPickerException> {
+            runBlocking {
+                runPickerLaunchWithFallback(
+                    primary = {
+                        throw ActivityNotFoundException("No activity for visual picker")
+                    },
+                    fallback = {
+                        throw fallbackFailure
+                    },
+                )
+            }
+        }
+
+        assertSame(fallbackFailure, failure.cause)
+    }
+
+    @Test
+    fun PickerLaunch_primaryThrowsSecurityExceptionWithoutFallback_throwsPickerFailure() {
+        val launchFailure = SecurityException("Document picker launch denied")
+
+        val failure = assertFailsWith<FileKitPickerException> {
+            runBlocking {
+                runPickerLaunchWithFallback(
                     primary = {
                         throw launchFailure
                     },
@@ -73,7 +128,7 @@ class AndroidPickerLaunchFallbackTest {
     fun PickerLaunch_primaryReturnsNull_doesNotInvokeFallback() = runBlocking {
         var fallbackCalls = 0
 
-        val result = runPickerLaunchWithActivityNotFoundFallback<String?>(
+        val result = runPickerLaunchWithFallback<String?>(
             primary = { null },
             fallback = {
                 fallbackCalls++
@@ -89,7 +144,7 @@ class AndroidPickerLaunchFallbackTest {
     fun PickerLaunch_primaryThrowsNonActivityError_rethrows() {
         assertFailsWith<IllegalStateException> {
             runBlocking {
-                runPickerLaunchWithActivityNotFoundFallback(
+                runPickerLaunchWithFallback(
                     primary = {
                         throw IllegalStateException("Unexpected failure")
                     },

--- a/filekit-dialogs/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/AndroidPickerLaunchFallbackTest.kt
+++ b/filekit-dialogs/src/androidHostTest/kotlin/io/github/vinceglb/filekit/dialogs/AndroidPickerLaunchFallbackTest.kt
@@ -9,7 +9,9 @@ import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 
 class AndroidPickerLaunchFallbackTest {
     @Test
@@ -31,28 +33,40 @@ class AndroidPickerLaunchFallbackTest {
     }
 
     @Test
-    fun PickerLaunch_primaryAndFallbackThrowActivityNotFound_returnsNull() = runBlocking {
-        val result = runPickerLaunchWithActivityNotFoundFallback(
-            primary = {
-                throw ActivityNotFoundException("No activity for visual picker")
-            },
-            fallback = {
-                throw ActivityNotFoundException("No activity for document picker")
-            },
-        )
+    fun PickerLaunch_primaryAndFallbackThrowActivityNotFound_throwsPickerFailure() {
+        val fallbackFailure = ActivityNotFoundException("No activity for document picker")
 
-        assertNull(result)
+        val failure = assertFailsWith<FileKitPickerException> {
+            runBlocking {
+                runPickerLaunchWithActivityNotFoundFallback(
+                    primary = {
+                        throw ActivityNotFoundException("No activity for visual picker")
+                    },
+                    fallback = {
+                        throw fallbackFailure
+                    },
+                )
+            }
+        }
+
+        assertSame(fallbackFailure, failure.cause)
     }
 
     @Test
-    fun PickerLaunch_primaryThrowsActivityNotFoundWithoutFallback_returnsNull() = runBlocking {
-        val result = runPickerLaunchWithActivityNotFoundFallback(
-            primary = {
-                throw ActivityNotFoundException("No activity for document picker")
-            },
-        )
+    fun PickerLaunch_primaryThrowsActivityNotFoundWithoutFallback_throwsPickerFailure() {
+        val launchFailure = ActivityNotFoundException("No activity for document picker")
 
-        assertNull(result)
+        val failure = assertFailsWith<FileKitPickerException> {
+            runBlocking {
+                runPickerLaunchWithActivityNotFoundFallback(
+                    primary = {
+                        throw launchFailure
+                    },
+                )
+            }
+        }
+
+        assertSame(launchFailure, failure.cause)
     }
 
     @Test
@@ -85,6 +99,82 @@ class AndroidPickerLaunchFallbackTest {
                 )
             }
         }
+    }
+
+    @Test
+    fun AndroidDialogLaunch_activityNotFound_wrapsCause() {
+        val launchFailure = ActivityNotFoundException("No directory picker")
+
+        val failure = assertFailsWith<FileKitDialogException> {
+            runBlocking {
+                runAndroidDialogLaunch("Failed to launch the directory picker.") {
+                    throw launchFailure
+                }
+            }
+        }
+
+        assertSame(launchFailure, failure.cause)
+    }
+
+    @Test
+    fun AndroidDialogLaunch_securityException_wrapsCause() {
+        val launchFailure = SecurityException("Camera launch denied")
+
+        val failure = assertFailsWith<FileKitDialogException> {
+            runBlocking {
+                runAndroidDialogLaunch("Failed to launch the camera picker.") {
+                    throw launchFailure
+                }
+            }
+        }
+
+        assertIs<SecurityException>(failure.cause)
+        assertSame(launchFailure, failure.cause)
+    }
+
+    @Test
+    fun FileSaverLaunch_activityNotFound_wrapsCause() {
+        val launchFailure = ActivityNotFoundException("No file saver")
+
+        val failure = assertFailsWith<FileKitDialogException> {
+            runBlocking {
+                runAndroidDialogLaunch("Failed to launch the file saver.") {
+                    throw launchFailure
+                }
+            }
+        }
+
+        assertSame(launchFailure, failure.cause)
+    }
+
+    @Test
+    fun ShareLaunch_activityNotFound_wrapsCause() {
+        val launchFailure = ActivityNotFoundException("No share activity")
+
+        val failure = assertFailsWith<FileKitDialogException> {
+            runBlocking {
+                runAndroidDialogLaunch("Failed to launch the share sheet.") {
+                    throw launchFailure
+                }
+            }
+        }
+
+        assertSame(launchFailure, failure.cause)
+    }
+
+    @Test
+    fun AndroidDialogLaunch_unexpectedException_propagates() {
+        val unexpectedFailure = IllegalStateException("Broken registry")
+
+        val failure = assertFailsWith<IllegalStateException> {
+            runBlocking {
+                runAndroidDialogLaunch("Failed to launch the directory picker.") {
+                    throw unexpectedFailure
+                }
+            }
+        }
+
+        assertSame(unexpectedFailure, failure)
     }
 
     @Test

--- a/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.android.kt
+++ b/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.android.kt
@@ -81,15 +81,17 @@ internal actual suspend fun FileKit.platformOpenFileSaver(
         suggestedName = suggestedName,
         extension = normalizedDefaultExtension,
     )
-    val uri = awaitActivityResult(
-        registry = registry,
-        contract = contract,
-        input = CreateDocumentInput(
-            mimeType = mimeType,
-            fileName = fileName,
-            allowedMimeTypes = allowedMimeTypes,
-        ),
-    )
+    val uri = runAndroidDialogLaunch("Failed to launch the file saver.") {
+        awaitActivityResult(
+            registry = registry,
+            contract = contract,
+            input = CreateDocumentInput(
+                mimeType = mimeType,
+                fileName = fileName,
+                allowedMimeTypes = allowedMimeTypes,
+            ),
+        )
+    }
     return uri?.let(::PlatformFile)
 }
 
@@ -107,11 +109,13 @@ public actual suspend fun FileKit.openDirectoryPicker(
     val registry = FileKit.registry
     val contract = ActivityResultContracts.OpenDocumentTree()
     val initialUri = directory?.path?.toUri()
-    val treeUri = awaitActivityResult(
-        registry = registry,
-        contract = contract,
-        input = initialUri,
-    )
+    val treeUri = runAndroidDialogLaunch("Failed to launch the directory picker.") {
+        awaitActivityResult(
+            registry = registry,
+            contract = contract,
+            input = initialUri,
+        )
+    }
     return treeUri?.let(::PlatformFile)
 }
 
@@ -131,20 +135,21 @@ public actual suspend fun FileKit.openCameraPicker(
     openCameraSettings: FileKitOpenCameraSettings,
 ): PlatformFile? {
     val registry = FileKit.registry
-    if (!FileKitAndroidCameraPermissionInternal.requestCameraPermissionIfNeeded(registry, context)) {
+    val hasCameraPermission = runAndroidDialogLaunch("Failed to request camera permission.") {
+        FileKitAndroidCameraPermissionInternal.requestCameraPermissionIfNeeded(registry, context)
+    }
+    if (!hasCameraPermission) {
         return null
     }
 
     val contract = TakePictureWithCameraFacing(cameraFacing)
     val uri = destinationFile.toAndroidUri(openCameraSettings.authority)
-    val isSaved = try {
+    val isSaved = runAndroidDialogLaunch("Failed to launch the camera picker.") {
         awaitActivityResult(
             registry = registry,
             contract = contract,
             input = uri,
         )
-    } catch (_: SecurityException) {
-        return null
     }
     return if (isSaved) destinationFile else null
 }
@@ -316,13 +321,17 @@ public actual suspend fun FileKit.shareFile(
         }
     }
     intentShareSend.flags = FLAG_GRANT_READ_URI_PERMISSION
-    val chooseIntent = Intent.createChooser(intentShareSend, null).apply {
-        flags = FLAG_ACTIVITY_NEW_TASK
-        addFlags(FLAG_GRANT_READ_URI_PERMISSION)
+    val chooseIntent = runAndroidDialogLaunch("Failed to create the share sheet.") {
+        Intent.createChooser(intentShareSend, null).apply {
+            flags = FLAG_ACTIVITY_NEW_TASK
+            addFlags(FLAG_GRANT_READ_URI_PERMISSION)
+        }
     }
     shareSettings.addOptionChooseIntent(chooseIntent)
 
-    context.startActivity(chooseIntent)
+    runAndroidDialogLaunch("Failed to launch the share sheet.") {
+        context.startActivity(chooseIntent)
+    }
 }
 
 /**
@@ -400,7 +409,7 @@ private suspend fun callFilePicker(
                                 input = type.toVisualFallbackMimeTypes(),
                             )
                         },
-                    )?.map(::PlatformFile)
+                    ).map(::PlatformFile)
                 }
 
                 else -> {
@@ -434,7 +443,7 @@ private suspend fun callFilePicker(
                                 input = FileKitAndroidDialogsInternal.getMimeTypes(type.extensions),
                             )
                         },
-                    )?.map(::PlatformFile)
+                    ).map(::PlatformFile)
                 }
             }
         }
@@ -444,15 +453,27 @@ private suspend fun callFilePicker(
 internal suspend fun <O> runPickerLaunchWithActivityNotFoundFallback(
     primary: suspend () -> O,
     fallback: (suspend () -> O)? = null,
-): O? = try {
+): O = try {
     primary()
-} catch (_: ActivityNotFoundException) {
-    val fallbackLaunch = fallback ?: return null
+} catch (primaryFailure: ActivityNotFoundException) {
+    val fallbackLaunch = fallback
+        ?: throw FileKitPickerException("Failed to launch the file picker.", primaryFailure)
     try {
         fallbackLaunch()
-    } catch (_: ActivityNotFoundException) {
-        null
+    } catch (fallbackFailure: ActivityNotFoundException) {
+        throw FileKitPickerException("Failed to launch the file picker fallback.", fallbackFailure)
     }
+}
+
+internal suspend fun <Result> runAndroidDialogLaunch(
+    failureMessage: String,
+    launch: suspend () -> Result,
+): Result = try {
+    launch()
+} catch (failure: ActivityNotFoundException) {
+    throw FileKitDialogException(failureMessage, failure)
+} catch (failure: SecurityException) {
+    throw FileKitDialogException(failureMessage, failure)
 }
 
 internal fun FileKitType.toVisualFallbackMimeTypes(): Array<String> = when (this) {

--- a/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.android.kt
+++ b/filekit-dialogs/src/androidMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.android.kt
@@ -371,7 +371,7 @@ private suspend fun callFilePicker(
 
             when {
                 mode is PickerMode.Single || (mode is PickerMode.Multiple && mode.maxItems == 1) -> {
-                    runPickerLaunchWithActivityNotFoundFallback(
+                    runPickerLaunchWithFallback(
                         primary = {
                             awaitActivityResult(
                                 registry = registry,
@@ -390,7 +390,7 @@ private suspend fun callFilePicker(
                 }
 
                 mode is PickerMode.Multiple -> {
-                    runPickerLaunchWithActivityNotFoundFallback(
+                    runPickerLaunchWithFallback(
                         primary = {
                             val contract = when {
                                 mode.maxItems != null -> PickMultipleVisualMedia(mode.maxItems)
@@ -421,7 +421,7 @@ private suspend fun callFilePicker(
         is FileKitType.File -> {
             when (mode) {
                 is PickerMode.Single -> {
-                    runPickerLaunchWithActivityNotFoundFallback(
+                    runPickerLaunchWithFallback(
                         primary = {
                             awaitActivityResult(
                                 registry = registry,
@@ -435,7 +435,7 @@ private suspend fun callFilePicker(
                 is PickerMode.Multiple -> {
                     // TODO there might be a way to limit the amount of documents, but
                     //  I haven't found it yet.
-                    runPickerLaunchWithActivityNotFoundFallback(
+                    runPickerLaunchWithFallback(
                         primary = {
                             awaitActivityResult(
                                 registry = registry,
@@ -450,18 +450,28 @@ private suspend fun callFilePicker(
     }
 }
 
-internal suspend fun <O> runPickerLaunchWithActivityNotFoundFallback(
+internal suspend fun <O> runPickerLaunchWithFallback(
     primary: suspend () -> O,
     fallback: (suspend () -> O)? = null,
-): O = try {
-    primary()
-} catch (primaryFailure: ActivityNotFoundException) {
-    val fallbackLaunch = fallback
-        ?: throw FileKitPickerException("Failed to launch the file picker.", primaryFailure)
-    try {
-        fallbackLaunch()
-    } catch (fallbackFailure: ActivityNotFoundException) {
-        throw FileKitPickerException("Failed to launch the file picker fallback.", fallbackFailure)
+): O {
+    suspend fun launchFallback(primaryFailure: RuntimeException): O {
+        val fallbackLaunch = fallback
+            ?: throw FileKitPickerException("Failed to launch the file picker.", primaryFailure)
+        return try {
+            fallbackLaunch()
+        } catch (fallbackFailure: ActivityNotFoundException) {
+            throw FileKitPickerException("Failed to launch the file picker fallback.", fallbackFailure)
+        } catch (fallbackFailure: SecurityException) {
+            throw FileKitPickerException("Failed to launch the file picker fallback.", fallbackFailure)
+        }
+    }
+
+    return try {
+        primary()
+    } catch (primaryFailure: ActivityNotFoundException) {
+        launchFallback(primaryFailure)
+    } catch (primaryFailure: SecurityException) {
+        launchFallback(primaryFailure)
     }
 }
 

--- a/filekit-dialogs/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.kt
+++ b/filekit-dialogs/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.Flow
  * @param directory The initial directory. Supported on desktop platforms.
  * @param dialogSettings Platform-specific settings for the dialog.
  * @return The result of the picker, depending on the [mode].
- * @throws FileKitPickerException When the user selected files but FileKit could not resolve them.
+ * @throws FileKitPickerException When FileKit cannot open the picker or resolve the selected files.
  */
 public suspend fun <A, B> FileKit.openFilePicker(
     type: FileKitType = FileKitType.File(),
@@ -36,7 +36,7 @@ public suspend fun <A, B> FileKit.openFilePicker(
  * @param directory The initial directory. Supported on desktop platforms.
  * @param dialogSettings Platform-specific settings for the dialog.
  * @return The picked [PlatformFile], or null if cancelled.
- * @throws FileKitPickerException When the user selected a file but FileKit could not resolve it.
+ * @throws FileKitPickerException When FileKit cannot open the picker or resolve the selected file.
  */
 public suspend fun FileKit.openFilePicker(
     type: FileKitType = FileKitType.File(),
@@ -62,6 +62,7 @@ internal expect suspend fun FileKit.platformOpenFilePicker(
  * @param directory The initial directory. Supported on desktop platforms.
  * @param dialogSettings Platform-specific settings for the dialog.
  * @return The picked directory as a [PlatformFile], or null if cancelled.
+ * @throws FileKitDialogException When FileKit cannot open or complete the directory picker.
  */
 public expect suspend fun FileKit.openDirectoryPicker(
     directory: PlatformFile? = null,

--- a/filekit-dialogs/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitDialogException.kt
+++ b/filekit-dialogs/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitDialogException.kt
@@ -1,0 +1,12 @@
+package io.github.vinceglb.filekit.dialogs
+
+import io.github.vinceglb.filekit.exceptions.FileKitException
+
+/**
+ * An expected operational failure while opening or completing a FileKit dialog.
+ */
+public open class FileKitDialogException : FileKitException {
+    public constructor(message: String) : super(message)
+
+    public constructor(message: String, cause: Throwable) : super(message, cause)
+}

--- a/filekit-dialogs/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitPickerException.kt
+++ b/filekit-dialogs/src/commonMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitPickerException.kt
@@ -1,8 +1,6 @@
 package io.github.vinceglb.filekit.dialogs
 
-import io.github.vinceglb.filekit.exceptions.FileKitException
-
-public class FileKitPickerException : FileKitException {
+public class FileKitPickerException : FileKitDialogException {
     public constructor(message: String) : super(message)
 
     public constructor(message: String, cause: Throwable) : super(message, cause)

--- a/filekit-dialogs/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/FileKitDialogExceptionTest.kt
+++ b/filekit-dialogs/src/commonTest/kotlin/io/github/vinceglb/filekit/dialogs/FileKitDialogExceptionTest.kt
@@ -1,0 +1,18 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+
+package io.github.vinceglb.filekit.dialogs
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class FileKitDialogExceptionTest {
+    @Test
+    fun FileKitPickerException_isADialogException_withItsCausePreserved() {
+        val cause = IllegalStateException("provider failed")
+        val failure = FileKitPickerException("Failed to load the selected file.", cause)
+
+        assertIs<FileKitDialogException>(failure)
+        assertEquals(cause, failure.cause)
+    }
+}

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -180,6 +180,11 @@ internal actual suspend fun FileKit.platformOpenFileSaver(
     requireIosFileSaverWrite(emptyData.writeToURL(fileUrl, true))
 
     suspendCancellableCoroutine { continuation ->
+        val pickerController = UIDocumentPickerViewController(
+            forExportingURLs = listOf(fileUrl),
+        )
+        directory?.let { pickerController.directoryURL = NSURL.fileURLWithPath(it.path) }
+
         lateinit var delegate: DocumentPickerDelegate
         lateinit var session: IosDialogContinuationSession<DocumentPickerDelegate, PlatformFile?>
 
@@ -201,20 +206,13 @@ internal actual suspend fun FileKit.platformOpenFileSaver(
                 session.complete(null)
             },
         )
-        session = IosDialogContinuationSession(
+        session = createIosPresentedDialogSession(
             session = delegate,
             registry = FileKitDialog.documentPickerSessions,
             continuation = continuation,
+            dismiss = pickerController::dismissOnCancellation,
         )
         session.present {
-            // Create a picker controller
-            val pickerController = UIDocumentPickerViewController(
-                forExportingURLs = listOf(fileUrl),
-            )
-
-            // Set the initial directory
-            directory?.let { pickerController.directoryURL = NSURL.fileURLWithPath(it.path) }
-
             // Assign the delegate to the picker controller
             pickerController.delegate = delegate
 
@@ -258,17 +256,11 @@ public actual suspend fun FileKit.openCameraPicker(
                     session.complete(image)
                 },
             )
-            session = IosDialogContinuationSession(
+            session = createIosPresentedDialogSession(
                 session = delegate,
                 registry = FileKitDialog.cameraPickerSessions,
                 continuation = continuation,
-                onCancellation = { finishCleanup ->
-                    dispatch_async(dispatch_get_main_queue()) {
-                        pickerController.dismissViewControllerAnimated(true) {
-                            finishCleanup()
-                        }
-                    }
-                },
+                dismiss = pickerController::dismissOnCancellation,
             )
             session.present {
                 pickerController.delegate = delegate
@@ -430,6 +422,14 @@ private fun FileKitShareSettings.presenterViewController(): UIViewController = r
     failure = { FileKitDialogException("No view controller is available to present the share sheet.") },
 )
 
+private fun UIViewController.dismissOnCancellation(finishDismissal: () -> Unit) {
+    dispatch_async(dispatch_get_main_queue()) {
+        dismissViewControllerAnimated(true) {
+            finishDismissal()
+        }
+    }
+}
+
 private suspend fun callPicker(
     mode: Mode,
     contentTypes: List<UTType>,
@@ -440,6 +440,10 @@ private suspend fun callPicker(
     val presenter = dialogSettings.presenterViewController(missingPresenterFailure)
 
     suspendCancellableCoroutine { continuation ->
+        val pickerController = UIDocumentPickerViewController(forOpeningContentTypes = contentTypes)
+        directory?.let { pickerController.directoryURL = NSURL.fileURLWithPath(it.path) }
+        pickerController.allowsMultipleSelection = mode == Mode.Multiple
+
         lateinit var delegate: DocumentPickerDelegate
         lateinit var session: IosDialogContinuationSession<DocumentPickerDelegate, List<NSURL>?>
 
@@ -447,21 +451,13 @@ private suspend fun callPicker(
             onFilesPicked = { urls -> session.complete(urls) },
             onPickerCancelled = { session.complete(null) },
         )
-        session = IosDialogContinuationSession(
+        session = createIosPresentedDialogSession(
             session = delegate,
             registry = FileKitDialog.documentPickerSessions,
             continuation = continuation,
+            dismiss = pickerController::dismissOnCancellation,
         )
         session.present {
-            // Create a picker controller
-            val pickerController = UIDocumentPickerViewController(forOpeningContentTypes = contentTypes)
-
-            // Set the initial directory
-            directory?.let { pickerController.directoryURL = NSURL.fileURLWithPath(it.path) }
-
-            // Set up the picker mode
-            pickerController.allowsMultipleSelection = mode == Mode.Multiple
-
             // Assign the delegate to the picker controller
             pickerController.delegate = delegate
 
@@ -485,6 +481,31 @@ private suspend fun getPhPickerResults(
     )
 
     return suspendCancellableCoroutine { continuation ->
+        val configuration = PHPickerConfiguration(sharedPhotoLibrary())
+        configuration.selectionLimit = when (mode) {
+            is PickerMode.Multiple -> mode.maxItems?.toLong() ?: 0
+            PickerMode.Single -> 1
+        }
+        configuration.preferredAssetRepresentationMode = when (dialogSettings.assetRepresentationMode) {
+            FileKitAssetRepresentationMode.Automatic -> PHPickerConfigurationAssetRepresentationModeAutomatic
+            FileKitAssetRepresentationMode.Current -> PHPickerConfigurationAssetRepresentationModeCurrent
+            FileKitAssetRepresentationMode.Compatible -> PHPickerConfigurationAssetRepresentationModeCompatible
+        }
+        configuration.filter = when (type) {
+            is FileKitType.Image -> PHPickerFilter.imagesFilter
+
+            is FileKitType.Video -> PHPickerFilter.videosFilter
+
+            is FileKitType.ImageAndVideo -> PHPickerFilter.anyFilterMatchingSubfilters(
+                listOf(
+                    PHPickerFilter.imagesFilter,
+                    PHPickerFilter.videosFilter,
+                ),
+            )
+
+            else -> throw IllegalArgumentException("Unsupported type: $type")
+        }
+
         lateinit var pickerDelegate: PhPickerDelegate
         lateinit var dismissDelegate: PhPickerDismissDelegate
         lateinit var pickerSession: PhotoPickerSession
@@ -493,48 +514,17 @@ private suspend fun getPhPickerResults(
         pickerDelegate = PhPickerDelegate(onFilesPicked = { continuationSession.complete(it) })
         dismissDelegate = PhPickerDismissDelegate(onFilesPicked = { continuationSession.complete(it) })
         pickerSession = PhotoPickerSession(pickerDelegate, dismissDelegate)
-        continuationSession = IosDialogContinuationSession(
+        val controller = PHPickerViewController(configuration = configuration)
+        controller.delegate = pickerDelegate
+        controller.presentationController?.delegate = dismissDelegate
+
+        continuationSession = createIosPresentedDialogSession(
             session = pickerSession,
             registry = FileKitDialog.photoPickerSessions,
             continuation = continuation,
+            dismiss = controller::dismissOnCancellation,
         )
         continuationSession.present {
-            // Define configuration
-            val configuration = PHPickerConfiguration(sharedPhotoLibrary())
-
-            // Number of medias to select
-            configuration.selectionLimit = when (mode) {
-                is PickerMode.Multiple -> mode.maxItems?.toLong() ?: 0
-                PickerMode.Single -> 1
-            }
-
-            configuration.preferredAssetRepresentationMode = when (dialogSettings.assetRepresentationMode) {
-                FileKitAssetRepresentationMode.Automatic -> PHPickerConfigurationAssetRepresentationModeAutomatic
-                FileKitAssetRepresentationMode.Current -> PHPickerConfigurationAssetRepresentationModeCurrent
-                FileKitAssetRepresentationMode.Compatible -> PHPickerConfigurationAssetRepresentationModeCompatible
-            }
-
-            // Filter configuration
-            configuration.filter = when (type) {
-                is FileKitType.Image -> PHPickerFilter.imagesFilter
-
-                is FileKitType.Video -> PHPickerFilter.videosFilter
-
-                is FileKitType.ImageAndVideo -> PHPickerFilter.anyFilterMatchingSubfilters(
-                    listOf(
-                        PHPickerFilter.imagesFilter,
-                        PHPickerFilter.videosFilter,
-                    ),
-                )
-
-                else -> throw IllegalArgumentException("Unsupported type: $type")
-            }
-
-            // Create a picker controller
-            val controller = PHPickerViewController(configuration = configuration)
-            controller.delegate = pickerDelegate
-            controller.presentationController?.delegate = dismissDelegate
-
             // Present the picker controller
             presenter.presentViewController(
                 controller,

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -69,6 +69,7 @@ private object FileKitDialog {
     val documentPickerSessions = IosDialogSessionRegistry<DocumentPickerDelegate>()
     val photoPickerSessions = IosDialogSessionRegistry<PhotoPickerSession>()
     val cameraPickerSessions = IosDialogSessionRegistry<CameraControllerDelegate>()
+    val presentations = IosDialogPresentationRegistry()
 }
 
 private class PhotoPickerSession(
@@ -105,6 +106,9 @@ internal actual suspend fun FileKit.platformOpenFilePicker(
             missingPresenterFailure = {
                 FileKitPickerException("No view controller is available to present the file picker.")
             },
+            overlappingPresenterFailure = {
+                FileKitPickerException("The view controller is already presenting another FileKit dialog.")
+            },
         )?.map { PlatformFile(it) }
 
         if (picked.isNullOrEmpty()) {
@@ -132,6 +136,9 @@ public actual suspend fun FileKit.openDirectoryPicker(
     dialogSettings = dialogSettings,
     missingPresenterFailure = {
         FileKitDialogException("No view controller is available to present the directory picker.")
+    },
+    overlappingPresenterFailure = {
+        FileKitDialogException("The view controller is already presenting another FileKit dialog.")
     },
 )?.firstOrNull()?.let { PlatformFile(it) }
 
@@ -210,6 +217,11 @@ internal actual suspend fun FileKit.platformOpenFileSaver(
             session = delegate,
             registry = FileKitDialog.documentPickerSessions,
             continuation = continuation,
+            presenter = presenter,
+            presentations = FileKitDialog.presentations,
+            overlapFailure = {
+                FileKitDialogException("The view controller is already presenting another FileKit dialog.")
+            },
             dismiss = pickerController::dismissOnCancellation,
         )
         session.present {
@@ -260,6 +272,11 @@ public actual suspend fun FileKit.openCameraPicker(
                 session = delegate,
                 registry = FileKitDialog.cameraPickerSessions,
                 continuation = continuation,
+                presenter = presenter,
+                presentations = FileKitDialog.presentations,
+                overlapFailure = {
+                    FileKitDialogException("The view controller is already presenting another FileKit dialog.")
+                },
                 dismiss = pickerController::dismissOnCancellation,
             )
             session.present {
@@ -436,6 +453,7 @@ private suspend fun callPicker(
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
     missingPresenterFailure: () -> FileKitDialogException,
+    overlappingPresenterFailure: () -> FileKitDialogException,
 ): List<NSURL>? = withContext(Dispatchers.Main) {
     val presenter = dialogSettings.presenterViewController(missingPresenterFailure)
 
@@ -455,6 +473,9 @@ private suspend fun callPicker(
             session = delegate,
             registry = FileKitDialog.documentPickerSessions,
             continuation = continuation,
+            presenter = presenter,
+            presentations = FileKitDialog.presentations,
+            overlapFailure = overlappingPresenterFailure,
             dismiss = pickerController::dismissOnCancellation,
         )
         session.present {
@@ -522,6 +543,11 @@ private suspend fun getPhPickerResults(
             session = pickerSession,
             registry = FileKitDialog.photoPickerSessions,
             continuation = continuation,
+            presenter = presenter,
+            presentations = FileKitDialog.presentations,
+            overlapFailure = {
+                FileKitPickerException("The view controller is already presenting another FileKit dialog.")
+            },
             dismiss = controller::dismissOnCancellation,
         )
         continuationSession.present {

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -59,6 +59,8 @@ import platform.UniformTypeIdentifiers.UTTypeFolder
 import platform.UniformTypeIdentifiers.UTTypeImage
 import platform.UniformTypeIdentifiers.UTTypeItem
 import platform.UniformTypeIdentifiers.UTTypeMovie
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -247,6 +249,9 @@ public actual suspend fun FileKit.openCameraPicker(
         suspendCancellableCoroutine<UIImage?> { continuation ->
             lateinit var delegate: CameraControllerDelegate
             lateinit var session: IosDialogContinuationSession<CameraControllerDelegate, UIImage?>
+            val pickerController = UIImagePickerController()
+            pickerController.sourceType =
+                UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera
 
             delegate = CameraControllerDelegate(
                 onImagePicked = { image ->
@@ -257,11 +262,15 @@ public actual suspend fun FileKit.openCameraPicker(
                 session = delegate,
                 registry = FileKitDialog.cameraPickerSessions,
                 continuation = continuation,
+                onCancellation = { finishCleanup ->
+                    dispatch_async(dispatch_get_main_queue()) {
+                        pickerController.dismissViewControllerAnimated(true) {
+                            finishCleanup()
+                        }
+                    }
+                },
             )
             session.present {
-                val pickerController = UIImagePickerController()
-                pickerController.sourceType =
-                    UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera
                 pickerController.delegate = delegate
 
                 when (cameraFacing) {

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -2,10 +2,6 @@ package io.github.vinceglb.filekit.dialogs
 
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
-import io.github.vinceglb.filekit.dialogs.FileKitDialog.cameraControllerDelegate
-import io.github.vinceglb.filekit.dialogs.FileKitDialog.documentPickerDelegate
-import io.github.vinceglb.filekit.dialogs.FileKitDialog.phPickerDelegate
-import io.github.vinceglb.filekit.dialogs.FileKitDialog.phPickerDismissDelegate
 import io.github.vinceglb.filekit.dialogs.util.CameraControllerDelegate
 import io.github.vinceglb.filekit.dialogs.util.DocumentPickerDelegate
 import io.github.vinceglb.filekit.dialogs.util.PhPickerDelegate
@@ -67,12 +63,16 @@ import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
 private object FileKitDialog {
-    // Create a reference to the picker delegate to prevent it from being garbage collected
-    lateinit var documentPickerDelegate: DocumentPickerDelegate
-    lateinit var phPickerDelegate: PhPickerDelegate
-    lateinit var phPickerDismissDelegate: PhPickerDismissDelegate
-    lateinit var cameraControllerDelegate: CameraControllerDelegate
+    // Keep every active delegate strongly referenced without restricting independent suspend callers.
+    val documentPickerSessions = IosDialogSessionRegistry<DocumentPickerDelegate>()
+    val photoPickerSessions = IosDialogSessionRegistry<PhotoPickerSession>()
+    val cameraPickerSessions = IosDialogSessionRegistry<CameraControllerDelegate>()
 }
+
+private class PhotoPickerSession(
+    val pickerDelegate: PhPickerDelegate,
+    val dismissDelegate: PhPickerDismissDelegate,
+)
 
 internal actual suspend fun FileKit.platformOpenFilePicker(
     type: FileKitType,
@@ -100,6 +100,9 @@ internal actual suspend fun FileKit.platformOpenFilePicker(
             contentTypes = type.contentTypes,
             directory = directory,
             dialogSettings = dialogSettings,
+            missingPresenterFailure = {
+                FileKitPickerException("No view controller is available to present the file picker.")
+            },
         )?.map { PlatformFile(it) }
 
         if (picked.isNullOrEmpty()) {
@@ -125,6 +128,9 @@ public actual suspend fun FileKit.openDirectoryPicker(
     contentTypes = listOf(UTTypeFolder),
     directory = directory,
     dialogSettings = dialogSettings,
+    missingPresenterFailure = {
+        FileKitDialogException("No view controller is available to present the directory picker.")
+    },
 )?.firstOrNull()?.let { PlatformFile(it) }
 
 /**
@@ -145,9 +151,37 @@ internal actual suspend fun FileKit.platformOpenFileSaver(
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
 ): PlatformFile? = withContext(Dispatchers.Main) {
+    val presenter = dialogSettings.presenterViewController(
+        failure = { FileKitDialogException("No view controller is available to present the file saver.") },
+    )
+
+    // the suggestedName cannot include "/" because the OS interprets it as a directory separator.
+    // However, "Files" renders ":" as "/", so we can just use ":" and the user will see "/".
+    val sanitizedSuggestedName = suggestedName.replace("/", ":")
+    val normalizedDefaultExtension = normalizeFileSaverExtension(defaultExtension)
+    val fileName = buildFileSaverSuggestedName(
+        suggestedName = sanitizedSuggestedName,
+        extension = normalizedDefaultExtension,
+    )
+
+    val fileManager = NSFileManager.defaultManager
+    val fileComponents = requireIosFileSaverTemporaryValue(
+        fileManager.temporaryDirectory.pathComponents?.plus(fileName),
+        description = "temporary directory path",
+    )
+    val fileUrl = requireIosFileSaverTemporaryValue(
+        NSURL.fileURLWithPathComponents(fileComponents),
+        description = "temporary file URL",
+    )
+
+    val emptyData = NSData()
+    requireIosFileSaverWrite(emptyData.writeToURL(fileUrl, true))
+
     suspendCancellableCoroutine { continuation ->
-        // Create a picker delegate
-        documentPickerDelegate = DocumentPickerDelegate(
+        lateinit var delegate: DocumentPickerDelegate
+        lateinit var session: IosDialogContinuationSession<DocumentPickerDelegate, PlatformFile?>
+
+        delegate = DocumentPickerDelegate(
             onFilesPicked = { urls ->
                 val file = urls.firstOrNull()?.let { nsUrl ->
                     // UIDocumentPickerViewController(forExportingURLs) creates an empty file at the
@@ -159,56 +193,36 @@ internal actual suspend fun FileKit.platformOpenFileSaver(
                     // Return the file as a PlatformFile
                     PlatformFile(nsUrl)
                 }
-                continuation.resume(file)
+                session.complete(file)
             },
             onPickerCancelled = {
-                continuation.resume(null)
+                session.complete(null)
             },
         )
-
-        // the suggestedName cannot include "/" because the OS interprets it as a directory separator.
-        // However, "Files" renders ":" as "/", so we can just use ":" and the user will see "/".
-        val sanitizedSuggestedName = suggestedName.replace("/", ":")
-        val normalizedDefaultExtension = normalizeFileSaverExtension(defaultExtension)
-        val fileName = buildFileSaverSuggestedName(
-            suggestedName = sanitizedSuggestedName,
-            extension = normalizedDefaultExtension,
+        session = IosDialogContinuationSession(
+            session = delegate,
+            registry = FileKitDialog.documentPickerSessions,
+            continuation = continuation,
         )
+        session.present {
+            // Create a picker controller
+            val pickerController = UIDocumentPickerViewController(
+                forExportingURLs = listOf(fileUrl),
+            )
 
-        // Get the fileManager
-        val fileManager = NSFileManager.defaultManager
+            // Set the initial directory
+            directory?.let { pickerController.directoryURL = NSURL.fileURLWithPath(it.path) }
 
-        // Get the temporary directory
-        val fileComponents = fileManager.temporaryDirectory.pathComponents?.plus(fileName)
-            ?: throw IllegalStateException("Failed to get temporary directory")
+            // Assign the delegate to the picker controller
+            pickerController.delegate = delegate
 
-        // Create a file URL
-        val fileUrl = NSURL.fileURLWithPathComponents(fileComponents)
-            ?: throw IllegalStateException("Failed to create file URL")
-
-        // Write an empty string to the file to ensure it exists
-        val emptyData = NSData()
-        if (!emptyData.writeToURL(fileUrl, true)) {
-            throw IllegalStateException("Failed to write to file URL")
+            // Present the picker controller
+            presenter.presentViewController(
+                pickerController,
+                animated = true,
+                completion = null,
+            )
         }
-
-        // Create a picker controller
-        val pickerController = UIDocumentPickerViewController(
-            forExportingURLs = listOf(fileUrl),
-        )
-
-        // Set the initial directory
-        directory?.let { pickerController.directoryURL = NSURL.fileURLWithPath(it.path) }
-
-        // Assign the delegate to the picker controller
-        pickerController.delegate = documentPickerDelegate
-
-        // Present the picker controller
-        dialogSettings.presenterViewController()?.presentViewController(
-            pickerController,
-            animated = true,
-            completion = null,
-        )
     }
 }
 
@@ -228,37 +242,48 @@ public actual suspend fun FileKit.openCameraPicker(
     openCameraSettings: FileKitOpenCameraSettings,
 ): PlatformFile? {
     val image = withContext(Dispatchers.Main) {
+        val presenter = openCameraSettings.presenterViewController()
+
         suspendCancellableCoroutine<UIImage?> { continuation ->
-            cameraControllerDelegate = CameraControllerDelegate(
+            lateinit var delegate: CameraControllerDelegate
+            lateinit var session: IosDialogContinuationSession<CameraControllerDelegate, UIImage?>
+
+            delegate = CameraControllerDelegate(
                 onImagePicked = { image ->
-                    continuation.resume(image)
+                    session.complete(image)
                 },
             )
-
-            val pickerController = UIImagePickerController()
-            pickerController.sourceType =
-                UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera
-            pickerController.delegate = cameraControllerDelegate
-
-            when (cameraFacing) {
-                FileKitCameraFacing.Front -> {
-                    pickerController.cameraDevice =
-                        UIImagePickerControllerCameraDevice.UIImagePickerControllerCameraDeviceFront
-                }
-
-                FileKitCameraFacing.Back -> {
-                    pickerController.cameraDevice =
-                        UIImagePickerControllerCameraDevice.UIImagePickerControllerCameraDeviceRear
-                }
-
-                FileKitCameraFacing.System -> {}
-            }
-
-            openCameraSettings.presenterViewController()?.presentViewController(
-                pickerController,
-                animated = true,
-                completion = null,
+            session = IosDialogContinuationSession(
+                session = delegate,
+                registry = FileKitDialog.cameraPickerSessions,
+                continuation = continuation,
             )
+            session.present {
+                val pickerController = UIImagePickerController()
+                pickerController.sourceType =
+                    UIImagePickerControllerSourceType.UIImagePickerControllerSourceTypeCamera
+                pickerController.delegate = delegate
+
+                when (cameraFacing) {
+                    FileKitCameraFacing.Front -> {
+                        pickerController.cameraDevice =
+                            UIImagePickerControllerCameraDevice.UIImagePickerControllerCameraDeviceFront
+                    }
+
+                    FileKitCameraFacing.Back -> {
+                        pickerController.cameraDevice =
+                            UIImagePickerControllerCameraDevice.UIImagePickerControllerCameraDeviceRear
+                    }
+
+                    FileKitCameraFacing.System -> {}
+                }
+
+                presenter.presentViewController(
+                    pickerController,
+                    animated = true,
+                    completion = null,
+                )
+            }
         }
     } ?: return null
 
@@ -271,12 +296,9 @@ public actual suspend fun FileKit.openCameraPicker(
         // Create an NSURL for the file path
         val fileUrl = NSURL.fileURLWithPath(destinationFile.path)
 
-        // Write the NSData to the file, returning the saved file on success
-        if (imageData?.writeToURL(fileUrl, true) == true) {
-            destinationFile
-        } else {
-            null
-        }
+        // Write the NSData to the file, returning the saved file on success.
+        requireIosCameraWrite(imageData?.writeToURL(fileUrl, true) == true)
+        destinationFile
     }
 }
 
@@ -310,7 +332,7 @@ public actual suspend fun FileKit.shareFile(
 ) {
     if (files.isEmpty()) return
 
-    val viewController = shareSettings.presenterViewController() ?: return
+    val viewController = shareSettings.presenterViewController()
 
     files.forEach { it.startAccessingSecurityScopedResource() }
     // Ensure we always pass a file URL to the activity items; otherwise iOS may treat the
@@ -379,46 +401,68 @@ private fun isIpad(): Boolean {
     return device.userInterfaceIdiom == UIUserInterfaceIdiomPad
 }
 
-private fun FileKitDialogSettings.presenterViewController(): UIViewController? =
-    presenter ?: UIApplication.sharedApplication.topMostViewController()
+private fun FileKitDialogSettings.presenterViewController(
+    failure: () -> FileKitDialogException,
+): UIViewController = resolveIosDialogPresenter(
+    configuredPresenter = presenter,
+    fallbackPresenter = { UIApplication.sharedApplication.topMostViewController() },
+    failure = failure,
+)
 
-private fun FileKitOpenCameraSettings.presenterViewController(): UIViewController? =
-    presenter ?: UIApplication.sharedApplication.topMostViewController()
+private fun FileKitOpenCameraSettings.presenterViewController(): UIViewController = resolveIosDialogPresenter(
+    configuredPresenter = presenter,
+    fallbackPresenter = { UIApplication.sharedApplication.topMostViewController() },
+    failure = { FileKitDialogException("No view controller is available to present the camera picker.") },
+)
 
-private fun FileKitShareSettings.presenterViewController(): UIViewController? =
-    presenter ?: UIApplication.sharedApplication.topMostViewController()
+private fun FileKitShareSettings.presenterViewController(): UIViewController = resolveIosDialogPresenter(
+    configuredPresenter = presenter,
+    fallbackPresenter = { UIApplication.sharedApplication.topMostViewController() },
+    failure = { FileKitDialogException("No view controller is available to present the share sheet.") },
+)
 
 private suspend fun callPicker(
     mode: Mode,
     contentTypes: List<UTType>,
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
+    missingPresenterFailure: () -> FileKitDialogException,
 ): List<NSURL>? = withContext(Dispatchers.Main) {
+    val presenter = dialogSettings.presenterViewController(missingPresenterFailure)
+
     suspendCancellableCoroutine { continuation ->
-        // Create a picker delegate
-        documentPickerDelegate = DocumentPickerDelegate(
-            onFilesPicked = { urls -> continuation.resume(urls) },
-            onPickerCancelled = { continuation.resume(null) },
+        lateinit var delegate: DocumentPickerDelegate
+        lateinit var session: IosDialogContinuationSession<DocumentPickerDelegate, List<NSURL>?>
+
+        delegate = DocumentPickerDelegate(
+            onFilesPicked = { urls -> session.complete(urls) },
+            onPickerCancelled = { session.complete(null) },
         )
-
-        // Create a picker controller
-        val pickerController = UIDocumentPickerViewController(forOpeningContentTypes = contentTypes)
-
-        // Set the initial directory
-        directory?.let { pickerController.directoryURL = NSURL.fileURLWithPath(it.path) }
-
-        // Set up the picker mode
-        pickerController.allowsMultipleSelection = mode == Mode.Multiple
-
-        // Assign the delegate to the picker controller
-        pickerController.delegate = documentPickerDelegate
-
-        // Present the picker controller
-        dialogSettings.presenterViewController()?.presentViewController(
-            pickerController,
-            animated = true,
-            completion = null,
+        session = IosDialogContinuationSession(
+            session = delegate,
+            registry = FileKitDialog.documentPickerSessions,
+            continuation = continuation,
         )
+        session.present {
+            // Create a picker controller
+            val pickerController = UIDocumentPickerViewController(forOpeningContentTypes = contentTypes)
+
+            // Set the initial directory
+            directory?.let { pickerController.directoryURL = NSURL.fileURLWithPath(it.path) }
+
+            // Set up the picker mode
+            pickerController.allowsMultipleSelection = mode == Mode.Multiple
+
+            // Assign the delegate to the picker controller
+            pickerController.delegate = delegate
+
+            // Present the picker controller
+            presenter.presentViewController(
+                pickerController,
+                animated = true,
+                completion = null,
+            )
+        }
     }
 }
 
@@ -426,53 +470,70 @@ private suspend fun getPhPickerResults(
     mode: PickerMode,
     type: FileKitType,
     dialogSettings: FileKitDialogSettings,
-): List<PHPickerResult> = suspendCancellableCoroutine { continuation ->
-    // Create a picker delegate
-    phPickerDelegate = PhPickerDelegate(onFilesPicked = continuation::resume)
-    phPickerDismissDelegate = PhPickerDismissDelegate(onFilesPicked = continuation::resume)
-
-    // Define configuration
-    val configuration = PHPickerConfiguration(sharedPhotoLibrary())
-
-    // Number of medias to select
-    configuration.selectionLimit = when (mode) {
-        is PickerMode.Multiple -> mode.maxItems?.toLong() ?: 0
-        PickerMode.Single -> 1
-    }
-
-    configuration.preferredAssetRepresentationMode = when (dialogSettings.assetRepresentationMode) {
-        FileKitAssetRepresentationMode.Automatic -> PHPickerConfigurationAssetRepresentationModeAutomatic
-        FileKitAssetRepresentationMode.Current -> PHPickerConfigurationAssetRepresentationModeCurrent
-        FileKitAssetRepresentationMode.Compatible -> PHPickerConfigurationAssetRepresentationModeCompatible
-    }
-
-    // Filter configuration
-    configuration.filter = when (type) {
-        is FileKitType.Image -> PHPickerFilter.imagesFilter
-
-        is FileKitType.Video -> PHPickerFilter.videosFilter
-
-        is FileKitType.ImageAndVideo -> PHPickerFilter.anyFilterMatchingSubfilters(
-            listOf(
-                PHPickerFilter.imagesFilter,
-                PHPickerFilter.videosFilter,
-            ),
-        )
-
-        else -> throw IllegalArgumentException("Unsupported type: $type")
-    }
-
-    // Create a picker controller
-    val controller = PHPickerViewController(configuration = configuration)
-    controller.delegate = phPickerDelegate
-    controller.presentationController?.delegate = phPickerDismissDelegate
-
-    // Present the picker controller
-    dialogSettings.presenterViewController()?.presentViewController(
-        controller,
-        animated = true,
-        completion = null,
+): List<PHPickerResult> {
+    val presenter = dialogSettings.presenterViewController(
+        failure = { FileKitPickerException("No view controller is available to present the photo picker.") },
     )
+
+    return suspendCancellableCoroutine { continuation ->
+        lateinit var pickerDelegate: PhPickerDelegate
+        lateinit var dismissDelegate: PhPickerDismissDelegate
+        lateinit var pickerSession: PhotoPickerSession
+        lateinit var continuationSession: IosDialogContinuationSession<PhotoPickerSession, List<PHPickerResult>>
+
+        pickerDelegate = PhPickerDelegate(onFilesPicked = { continuationSession.complete(it) })
+        dismissDelegate = PhPickerDismissDelegate(onFilesPicked = { continuationSession.complete(it) })
+        pickerSession = PhotoPickerSession(pickerDelegate, dismissDelegate)
+        continuationSession = IosDialogContinuationSession(
+            session = pickerSession,
+            registry = FileKitDialog.photoPickerSessions,
+            continuation = continuation,
+        )
+        continuationSession.present {
+            // Define configuration
+            val configuration = PHPickerConfiguration(sharedPhotoLibrary())
+
+            // Number of medias to select
+            configuration.selectionLimit = when (mode) {
+                is PickerMode.Multiple -> mode.maxItems?.toLong() ?: 0
+                PickerMode.Single -> 1
+            }
+
+            configuration.preferredAssetRepresentationMode = when (dialogSettings.assetRepresentationMode) {
+                FileKitAssetRepresentationMode.Automatic -> PHPickerConfigurationAssetRepresentationModeAutomatic
+                FileKitAssetRepresentationMode.Current -> PHPickerConfigurationAssetRepresentationModeCurrent
+                FileKitAssetRepresentationMode.Compatible -> PHPickerConfigurationAssetRepresentationModeCompatible
+            }
+
+            // Filter configuration
+            configuration.filter = when (type) {
+                is FileKitType.Image -> PHPickerFilter.imagesFilter
+
+                is FileKitType.Video -> PHPickerFilter.videosFilter
+
+                is FileKitType.ImageAndVideo -> PHPickerFilter.anyFilterMatchingSubfilters(
+                    listOf(
+                        PHPickerFilter.imagesFilter,
+                        PHPickerFilter.videosFilter,
+                    ),
+                )
+
+                else -> throw IllegalArgumentException("Unsupported type: $type")
+            }
+
+            // Create a picker controller
+            val controller = PHPickerViewController(configuration = configuration)
+            controller.delegate = pickerDelegate
+            controller.presentationController?.delegate = dismissDelegate
+
+            // Present the picker controller
+            presenter.presentViewController(
+                controller,
+                animated = true,
+                completion = null,
+            )
+        }
+    }
 }
 
 @OptIn(ExperimentalForeignApi::class)
@@ -496,7 +557,7 @@ private fun callPhPicker(
     val fileManager = NSFileManager.defaultManager
     val tempRoot = fileManager.temporaryDirectory
         .URLByAppendingPathComponent(NSUUID().UUIDString)
-        ?: throw IllegalStateException("Failed to create temporary directory")
+        ?: throw FileKitPickerException("Failed to create a temporary directory for the selected files.")
     fileManager.createDirectoryAtURL(
         url = tempRoot,
         withIntermediateDirectories = true,
@@ -556,10 +617,7 @@ private fun callPhPicker(
                         orderedFiles[index] = PlatformFile(src)
                         send(FileKitPickerState.Progress(orderedFiles.filterNotNull(), pickerResults.size))
                     }
-                } catch (cause: Throwable) {
-                    val pickerFailure = cause as? FileKitPickerException
-                        ?: FileKitPickerException("Failed to load the selected file.", cause)
-
+                } catch (pickerFailure: FileKitPickerException) {
                     lock.withLock {
                         if (failure == null) {
                             failure = pickerFailure
@@ -615,11 +673,11 @@ private fun copyToTempFile(
     val fileComponents = fileManager.temporaryDirectory.pathComponents
         ?.plus(id)
         ?.plus(url.lastPathComponent)
-        ?: throw IllegalStateException("Failed to get temporary directory")
+        ?: throw FileKitPickerException("Failed to get the temporary directory for the selected file.")
 
     // Create a file URL
     val fileUrl = NSURL.fileURLWithPathComponents(fileComponents)
-        ?: throw IllegalStateException("Failed to create file URL")
+        ?: throw FileKitPickerException("Failed to create the temporary URL for the selected file.")
 
     // Write the data to the file URL
     val didCopy = fileManager.copyItemAtURL(

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistry.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistry.kt
@@ -24,9 +24,7 @@ internal class IosDialogContinuationSession<Session : Any, Result>(
     private val session: Session,
     private val registry: IosDialogSessionRegistry<Session>,
     private val continuation: CancellableContinuation<Result>,
-    private val onCancellation: (finishCleanup: () -> Unit) -> Unit = { finishCleanup ->
-        finishCleanup()
-    },
+    private val onCancellation: (finishCleanup: () -> Unit) -> Unit,
 ) {
     private var completed = false
 
@@ -55,6 +53,18 @@ internal class IosDialogContinuationSession<Session : Any, Result>(
         registry.release(session)
     }
 }
+
+internal fun <Session : Any, Result> createIosPresentedDialogSession(
+    session: Session,
+    registry: IosDialogSessionRegistry<Session>,
+    continuation: CancellableContinuation<Result>,
+    dismiss: (finishDismissal: () -> Unit) -> Unit,
+): IosDialogContinuationSession<Session, Result> = IosDialogContinuationSession(
+    session = session,
+    registry = registry,
+    continuation = continuation,
+    onCancellation = dismiss,
+)
 
 internal inline fun <Presenter : Any> resolveIosDialogPresenter(
     configuredPresenter: Presenter?,

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistry.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistry.kt
@@ -1,0 +1,75 @@
+package io.github.vinceglb.filekit.dialogs
+
+import kotlinx.coroutines.CancellableContinuation
+import kotlin.coroutines.resume
+
+internal class IosDialogSessionRegistry<Session : Any> {
+    private val sessions = mutableSetOf<Session>()
+
+    val size: Int
+        get() = sessions.size
+
+    fun retain(session: Session) {
+        check(sessions.add(session)) { "The dialog session is already retained." }
+    }
+
+    fun release(session: Session) {
+        sessions.remove(session)
+    }
+
+    fun singleOrNull(): Session? = sessions.singleOrNull()
+}
+
+internal class IosDialogContinuationSession<Session : Any, Result>(
+    private val session: Session,
+    private val registry: IosDialogSessionRegistry<Session>,
+    private val continuation: CancellableContinuation<Result>,
+) {
+    private var completed = false
+
+    init {
+        registry.retain(session)
+        continuation.invokeOnCancellation { release() }
+    }
+
+    fun complete(result: Result) {
+        if (completed || !continuation.isActive) return
+        completed = true
+        release()
+        continuation.resume(result)
+    }
+
+    inline fun present(block: () -> Unit) {
+        try {
+            block()
+        } catch (cause: Throwable) {
+            release()
+            throw cause
+        }
+    }
+
+    fun release() {
+        registry.release(session)
+    }
+}
+
+internal inline fun <Presenter : Any> resolveIosDialogPresenter(
+    configuredPresenter: Presenter?,
+    fallbackPresenter: () -> Presenter?,
+    failure: () -> FileKitDialogException = {
+        FileKitDialogException("No view controller is available to present the dialog.")
+    },
+): Presenter = configuredPresenter ?: fallbackPresenter() ?: throw failure()
+
+internal fun <Value : Any> requireIosFileSaverTemporaryValue(
+    value: Value?,
+    description: String,
+): Value = value ?: throw FileKitDialogException("Failed to create the $description for the file saver.")
+
+internal fun requireIosFileSaverWrite(succeeded: Boolean) {
+    if (!succeeded) throw FileKitDialogException("Failed to create the temporary file for the file saver.")
+}
+
+internal fun requireIosCameraWrite(succeeded: Boolean) {
+    if (!succeeded) throw FileKitDialogException("Failed to write the captured image to its destination.")
+}

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistry.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistry.kt
@@ -20,11 +20,31 @@ internal class IosDialogSessionRegistry<Session : Any> {
     fun singleOrNull(): Session? = sessions.singleOrNull()
 }
 
+internal class IosDialogPresentationRegistry {
+    private class Presentation(
+        val presenter: Any,
+    )
+
+    private val presentations = mutableSetOf<Presentation>()
+
+    fun retain(
+        presenter: Any,
+        overlapFailure: () -> FileKitDialogException,
+    ): () -> Unit {
+        if (presentations.any { it.presenter === presenter }) throw overlapFailure()
+
+        val presentation = Presentation(presenter)
+        presentations.add(presentation)
+        return { presentations.remove(presentation) }
+    }
+}
+
 internal class IosDialogContinuationSession<Session : Any, Result>(
     private val session: Session,
     private val registry: IosDialogSessionRegistry<Session>,
     private val continuation: CancellableContinuation<Result>,
     private val onCancellation: (finishCleanup: () -> Unit) -> Unit,
+    private val releasePresentation: () -> Unit,
 ) {
     private var completed = false
 
@@ -51,6 +71,7 @@ internal class IosDialogContinuationSession<Session : Any, Result>(
 
     fun release() {
         registry.release(session)
+        releasePresentation()
     }
 }
 
@@ -58,13 +79,25 @@ internal fun <Session : Any, Result> createIosPresentedDialogSession(
     session: Session,
     registry: IosDialogSessionRegistry<Session>,
     continuation: CancellableContinuation<Result>,
+    presenter: Any,
+    presentations: IosDialogPresentationRegistry,
+    overlapFailure: () -> FileKitDialogException,
     dismiss: (finishDismissal: () -> Unit) -> Unit,
-): IosDialogContinuationSession<Session, Result> = IosDialogContinuationSession(
-    session = session,
-    registry = registry,
-    continuation = continuation,
-    onCancellation = dismiss,
-)
+): IosDialogContinuationSession<Session, Result> {
+    val releasePresentation = presentations.retain(presenter, overlapFailure)
+    return try {
+        IosDialogContinuationSession(
+            session = session,
+            registry = registry,
+            continuation = continuation,
+            onCancellation = dismiss,
+            releasePresentation = releasePresentation,
+        )
+    } catch (cause: Throwable) {
+        releasePresentation()
+        throw cause
+    }
+}
 
 internal inline fun <Presenter : Any> resolveIosDialogPresenter(
     configuredPresenter: Presenter?,

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistry.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistry.kt
@@ -24,12 +24,15 @@ internal class IosDialogContinuationSession<Session : Any, Result>(
     private val session: Session,
     private val registry: IosDialogSessionRegistry<Session>,
     private val continuation: CancellableContinuation<Result>,
+    private val onCancellation: (finishCleanup: () -> Unit) -> Unit = { finishCleanup ->
+        finishCleanup()
+    },
 ) {
     private var completed = false
 
     init {
         registry.retain(session)
-        continuation.invokeOnCancellation { release() }
+        continuation.invokeOnCancellation { onCancellation(::release) }
     }
 
     fun complete(result: Result) {

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/util/DocumentPickerDelegate.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/util/DocumentPickerDelegate.kt
@@ -8,13 +8,19 @@ import platform.darwin.NSObject
 internal class DocumentPickerDelegate(
     private val onFilesPicked: (List<NSURL>) -> Unit,
     private val onPickerCancelled: () -> Unit,
+    private val dismiss: (UIDocumentPickerViewController, finishDismissal: () -> Unit) -> Unit =
+        { controller, finishDismissal ->
+            controller.dismissViewControllerAnimated(true, finishDismissal)
+        },
 ) : NSObject(),
     UIDocumentPickerDelegateProtocol {
     override fun documentPicker(
         controller: UIDocumentPickerViewController,
         didPickDocumentAtURL: NSURL,
     ) {
-        onFilesPicked(listOf(didPickDocumentAtURL))
+        dismiss(controller) {
+            onFilesPicked(listOf(didPickDocumentAtURL))
+        }
     }
 
     override fun documentPicker(
@@ -22,10 +28,14 @@ internal class DocumentPickerDelegate(
         didPickDocumentsAtURLs: List<*>,
     ) {
         val res = didPickDocumentsAtURLs.mapNotNull { it as? NSURL }
-        onFilesPicked(res)
+        dismiss(controller) {
+            onFilesPicked(res)
+        }
     }
 
     override fun documentPickerWasCancelled(controller: UIDocumentPickerViewController) {
-        onPickerCancelled()
+        dismiss(controller) {
+            onPickerCancelled()
+        }
     }
 }

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/util/PhPickerDelegate.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/util/PhPickerDelegate.kt
@@ -7,6 +7,10 @@ import platform.darwin.NSObject
 
 internal class PhPickerDelegate(
     private val onFilesPicked: (List<PHPickerResult>) -> Unit,
+    private val dismiss: (PHPickerViewController, finishDismissal: () -> Unit) -> Unit =
+        { picker, finishDismissal ->
+            picker.dismissViewControllerAnimated(true, finishDismissal)
+        },
 ) : NSObject(),
     PHPickerViewControllerDelegateProtocol {
     private var hasFinished = false
@@ -15,11 +19,12 @@ internal class PhPickerDelegate(
         if (hasFinished) return
         hasFinished = true
 
-        // Dismiss the picker
-        picker.dismissViewControllerAnimated(true, null)
-
         // Map the results to PHPickerResult
         val res = didFinishPicking.mapNotNull { it as? PHPickerResult }
-        onFilesPicked(res)
+
+        // Keep the delegate and presenter reservation until the dismissal transition completes.
+        dismiss(picker) {
+            onFilesPicked(res)
+        }
     }
 }

--- a/filekit-dialogs/src/iosTest/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistryTest.kt
+++ b/filekit-dialogs/src/iosTest/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistryTest.kt
@@ -1,0 +1,150 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+
+package io.github.vinceglb.filekit.dialogs
+
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class IosDialogSessionRegistryTest {
+    @Test
+    fun resolveIosDialogPresenter_configuredPresenter_wins() {
+        val configured = Any()
+
+        val presenter = resolveIosDialogPresenter(
+            configuredPresenter = configured,
+            fallbackPresenter = { Any() },
+        )
+
+        assertSame(configured, presenter)
+    }
+
+    @Test
+    fun resolveIosDialogPresenter_fallbackPresenter_isUsed() {
+        val fallback = Any()
+
+        val presenter = resolveIosDialogPresenter<Any>(
+            configuredPresenter = null,
+            fallbackPresenter = { fallback },
+        )
+
+        assertSame(fallback, presenter)
+    }
+
+    @Test
+    fun resolveIosDialogPresenter_missingPresenter_throwsDialogFailure() {
+        val failure = assertFailsWith<FileKitDialogException> {
+            resolveIosDialogPresenter<Any>(
+                configuredPresenter = null,
+                fallbackPresenter = { null },
+            )
+        }
+
+        assertTrue(failure.message.orEmpty().contains("view controller"))
+    }
+
+    @Test
+    fun requireIosFileSaverTemporaryValue_missingValue_throwsOperationFailure() {
+        assertFailsWith<FileKitDialogException> {
+            requireIosFileSaverTemporaryValue<Any>(null, "temporary file URL")
+        }
+    }
+
+    @Test
+    fun requireIosFileSaverWrite_failure_throwsOperationFailure() {
+        assertFailsWith<FileKitDialogException> {
+            requireIosFileSaverWrite(succeeded = false)
+        }
+    }
+
+    @Test
+    fun requireIosCameraWrite_failure_throwsOperationFailure() {
+        assertFailsWith<FileKitDialogException> {
+            requireIosCameraWrite(succeeded = false)
+        }
+    }
+
+    @Test
+    fun IosDialogSessionRegistry_multipleSessions_areRetainedIndependently() {
+        val sessions = IosDialogSessionRegistry<Any>()
+        val first = Any()
+        val second = Any()
+
+        sessions.retain(first)
+        sessions.retain(second)
+
+        assertEquals(2, sessions.size)
+        sessions.release(first)
+        assertEquals(1, sessions.size)
+        sessions.release(second)
+        assertEquals(0, sessions.size)
+    }
+
+    @Test
+    fun IosDialogSessionRegistry_staleRelease_doesNotAffectOtherSessions() {
+        val sessions = IosDialogSessionRegistry<Any>()
+        val first = Any()
+        val second = Any()
+
+        sessions.retain(first)
+        sessions.retain(second)
+        sessions.release(first)
+        sessions.release(first)
+
+        assertEquals(1, sessions.size)
+        assertSame(second, sessions.singleOrNull())
+    }
+
+    @Test
+    fun IosDialogContinuationSession_duplicateCompletion_resumesOnce() = runTest {
+        val sessions = IosDialogSessionRegistry<Any>()
+
+        val result = suspendCancellableCoroutine<String> { continuation ->
+            val session = IosDialogContinuationSession(Any(), sessions, continuation)
+            session.complete("first")
+            session.complete("second")
+        }
+
+        assertEquals("first", result)
+        assertEquals(0, sessions.size)
+    }
+
+    @Test
+    fun IosDialogContinuationSession_setupFailure_releasesSession() = runTest {
+        val sessions = IosDialogSessionRegistry<Any>()
+        val defect = IllegalStateException("setup failed")
+
+        val failure = assertFailsWith<IllegalStateException> {
+            suspendCancellableCoroutine<Unit> { continuation ->
+                val session = IosDialogContinuationSession(Any(), sessions, continuation)
+                session.present { throw defect }
+            }
+        }
+
+        assertSame(defect, failure)
+        assertEquals(0, sessions.size)
+    }
+
+    @Test
+    fun IosDialogContinuationSession_cancellation_releasesSession() = runTest {
+        val sessions = IosDialogSessionRegistry<Any>()
+        val job = launch {
+            suspendCancellableCoroutine<Unit> { continuation ->
+                IosDialogContinuationSession(Any(), sessions, continuation)
+            }
+        }
+        yield()
+        assertEquals(1, sessions.size)
+
+        job.cancelAndJoin()
+
+        assertEquals(0, sessions.size)
+    }
+}

--- a/filekit-dialogs/src/iosTest/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistryTest.kt
+++ b/filekit-dialogs/src/iosTest/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistryTest.kt
@@ -2,6 +2,7 @@
 
 package io.github.vinceglb.filekit.dialogs
 
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -107,7 +108,7 @@ class IosDialogSessionRegistryTest {
         val sessions = IosDialogSessionRegistry<Any>()
 
         val result = suspendCancellableCoroutine<String> { continuation ->
-            val session = IosDialogContinuationSession(Any(), sessions, continuation) { it() }
+            val session = createTestContinuationSession(Any(), sessions, continuation) { it() }
             session.complete("first")
             session.complete("second")
         }
@@ -123,7 +124,7 @@ class IosDialogSessionRegistryTest {
 
         val failure = assertFailsWith<IllegalStateException> {
             suspendCancellableCoroutine<Unit> { continuation ->
-                val session = IosDialogContinuationSession(Any(), sessions, continuation) { it() }
+                val session = createTestContinuationSession(Any(), sessions, continuation) { it() }
                 session.present { throw defect }
             }
         }
@@ -137,7 +138,7 @@ class IosDialogSessionRegistryTest {
         val sessions = IosDialogSessionRegistry<Any>()
         val job = launch {
             suspendCancellableCoroutine<Unit> { continuation ->
-                IosDialogContinuationSession(Any(), sessions, continuation) { it() }
+                createTestContinuationSession(Any(), sessions, continuation) { it() }
             }
         }
         yield()
@@ -154,7 +155,7 @@ class IosDialogSessionRegistryTest {
         var retainedDuringCleanup = false
         val job = launch {
             suspendCancellableCoroutine<Unit> { continuation ->
-                IosDialogContinuationSession(
+                createTestContinuationSession(
                     session = Any(),
                     registry = sessions,
                     continuation = continuation,
@@ -179,7 +180,7 @@ class IosDialogSessionRegistryTest {
         var finishCleanup: (() -> Unit)? = null
         val job = launch {
             suspendCancellableCoroutine<Unit> { continuation ->
-                IosDialogContinuationSession(
+                createTestContinuationSession(
                     session = Any(),
                     registry = sessions,
                     continuation = continuation,
@@ -199,6 +200,7 @@ class IosDialogSessionRegistryTest {
     @Test
     fun IosPresentedDialogSession_cancellation_dismissesBeforeReleasingSession() = runTest {
         val sessions = IosDialogSessionRegistry<Any>()
+        val presentations = IosDialogPresentationRegistry()
         var retainedDuringDismissal = false
         val job = launch {
             suspendCancellableCoroutine<Unit> { continuation ->
@@ -206,6 +208,9 @@ class IosDialogSessionRegistryTest {
                     session = Any(),
                     registry = sessions,
                     continuation = continuation,
+                    presenter = Any(),
+                    presentations = presentations,
+                    overlapFailure = { FileKitDialogException("Presenter is already occupied.") },
                     dismiss = { finishDismissal ->
                         retainedDuringDismissal = sessions.size == 1
                         finishDismissal()
@@ -220,4 +225,103 @@ class IosDialogSessionRegistryTest {
         assertTrue(retainedDuringDismissal)
         assertEquals(0, sessions.size)
     }
+
+    @Test
+    fun IosPresentedDialogSession_samePresenter_rejectsOverlapAcrossSessionRegistries() = runTest {
+        val presentations = IosDialogPresentationRegistry()
+        val firstSessions = IosDialogSessionRegistry<Any>()
+        val secondSessions = IosDialogSessionRegistry<Any>()
+        val presenter = Any()
+        val firstJob = launch {
+            suspendCancellableCoroutine<Unit> { continuation ->
+                createIosPresentedDialogSession(
+                    session = Any(),
+                    registry = firstSessions,
+                    continuation = continuation,
+                    presenter = presenter,
+                    presentations = presentations,
+                    overlapFailure = { FileKitDialogException("Presenter is already occupied.") },
+                    dismiss = { it() },
+                )
+            }
+        }
+        yield()
+
+        assertFailsWith<FileKitDialogException> {
+            suspendCancellableCoroutine<Unit> { continuation ->
+                createIosPresentedDialogSession(
+                    session = Any(),
+                    registry = secondSessions,
+                    continuation = continuation,
+                    presenter = presenter,
+                    presentations = presentations,
+                    overlapFailure = { FileKitDialogException("Presenter is already occupied.") },
+                    dismiss = { it() },
+                )
+            }
+        }
+
+        assertEquals(1, firstSessions.size)
+        assertEquals(0, secondSessions.size)
+        firstJob.cancelAndJoin()
+        assertEquals(0, firstSessions.size)
+
+        val result = suspendCancellableCoroutine<String> { continuation ->
+            val session = createIosPresentedDialogSession(
+                session = Any(),
+                registry = secondSessions,
+                continuation = continuation,
+                presenter = presenter,
+                presentations = presentations,
+                overlapFailure = { FileKitDialogException("Presenter is already occupied.") },
+                dismiss = { it() },
+            )
+            session.complete("completed")
+        }
+        assertEquals("completed", result)
+        assertEquals(0, secondSessions.size)
+    }
+
+    @Test
+    fun IosPresentedDialogSession_differentPresenters_allowConcurrentSessions() = runTest {
+        val presentations = IosDialogPresentationRegistry()
+        val sessions = IosDialogSessionRegistry<Any>()
+
+        fun launchSession(presenter: Any) = launch {
+            suspendCancellableCoroutine<Unit> { continuation ->
+                createIosPresentedDialogSession(
+                    session = Any(),
+                    registry = sessions,
+                    continuation = continuation,
+                    presenter = presenter,
+                    presentations = presentations,
+                    overlapFailure = { FileKitDialogException("Presenter is already occupied.") },
+                    dismiss = { it() },
+                )
+            }
+        }
+
+        val firstJob = launchSession(Any())
+        val secondJob = launchSession(Any())
+        yield()
+        assertEquals(2, sessions.size)
+
+        firstJob.cancelAndJoin()
+        assertEquals(1, sessions.size)
+        secondJob.cancelAndJoin()
+        assertEquals(0, sessions.size)
+    }
 }
+
+private fun <Session : Any, Result> createTestContinuationSession(
+    session: Session,
+    registry: IosDialogSessionRegistry<Session>,
+    continuation: CancellableContinuation<Result>,
+    onCancellation: (finishCleanup: () -> Unit) -> Unit,
+): IosDialogContinuationSession<Session, Result> = IosDialogContinuationSession(
+    session = session,
+    registry = registry,
+    continuation = continuation,
+    onCancellation = onCancellation,
+    releasePresentation = {},
+)

--- a/filekit-dialogs/src/iosTest/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistryTest.kt
+++ b/filekit-dialogs/src/iosTest/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistryTest.kt
@@ -147,4 +147,52 @@ class IosDialogSessionRegistryTest {
 
         assertEquals(0, sessions.size)
     }
+
+    @Test
+    fun IosDialogContinuationSession_cancellation_cleansUpBeforeReleasingSession() = runTest {
+        val sessions = IosDialogSessionRegistry<Any>()
+        var retainedDuringCleanup = false
+        val job = launch {
+            suspendCancellableCoroutine<Unit> { continuation ->
+                IosDialogContinuationSession(
+                    session = Any(),
+                    registry = sessions,
+                    continuation = continuation,
+                    onCancellation = { finishCleanup ->
+                        retainedDuringCleanup = sessions.size == 1
+                        finishCleanup()
+                    },
+                )
+            }
+        }
+        yield()
+
+        job.cancelAndJoin()
+
+        assertTrue(retainedDuringCleanup)
+        assertEquals(0, sessions.size)
+    }
+
+    @Test
+    fun IosDialogContinuationSession_cancellation_canDeferReleaseUntilCleanupCompletes() = runTest {
+        val sessions = IosDialogSessionRegistry<Any>()
+        var finishCleanup: (() -> Unit)? = null
+        val job = launch {
+            suspendCancellableCoroutine<Unit> { continuation ->
+                IosDialogContinuationSession(
+                    session = Any(),
+                    registry = sessions,
+                    continuation = continuation,
+                    onCancellation = { finishCleanup = it },
+                )
+            }
+        }
+        yield()
+
+        job.cancelAndJoin()
+
+        assertEquals(1, sessions.size)
+        finishCleanup?.invoke()
+        assertEquals(0, sessions.size)
+    }
 }

--- a/filekit-dialogs/src/iosTest/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistryTest.kt
+++ b/filekit-dialogs/src/iosTest/kotlin/io/github/vinceglb/filekit/dialogs/IosDialogSessionRegistryTest.kt
@@ -107,7 +107,7 @@ class IosDialogSessionRegistryTest {
         val sessions = IosDialogSessionRegistry<Any>()
 
         val result = suspendCancellableCoroutine<String> { continuation ->
-            val session = IosDialogContinuationSession(Any(), sessions, continuation)
+            val session = IosDialogContinuationSession(Any(), sessions, continuation) { it() }
             session.complete("first")
             session.complete("second")
         }
@@ -123,7 +123,7 @@ class IosDialogSessionRegistryTest {
 
         val failure = assertFailsWith<IllegalStateException> {
             suspendCancellableCoroutine<Unit> { continuation ->
-                val session = IosDialogContinuationSession(Any(), sessions, continuation)
+                val session = IosDialogContinuationSession(Any(), sessions, continuation) { it() }
                 session.present { throw defect }
             }
         }
@@ -137,7 +137,7 @@ class IosDialogSessionRegistryTest {
         val sessions = IosDialogSessionRegistry<Any>()
         val job = launch {
             suspendCancellableCoroutine<Unit> { continuation ->
-                IosDialogContinuationSession(Any(), sessions, continuation)
+                IosDialogContinuationSession(Any(), sessions, continuation) { it() }
             }
         }
         yield()
@@ -193,6 +193,31 @@ class IosDialogSessionRegistryTest {
 
         assertEquals(1, sessions.size)
         finishCleanup?.invoke()
+        assertEquals(0, sessions.size)
+    }
+
+    @Test
+    fun IosPresentedDialogSession_cancellation_dismissesBeforeReleasingSession() = runTest {
+        val sessions = IosDialogSessionRegistry<Any>()
+        var retainedDuringDismissal = false
+        val job = launch {
+            suspendCancellableCoroutine<Unit> { continuation ->
+                createIosPresentedDialogSession(
+                    session = Any(),
+                    registry = sessions,
+                    continuation = continuation,
+                    dismiss = { finishDismissal ->
+                        retainedDuringDismissal = sessions.size == 1
+                        finishDismissal()
+                    },
+                )
+            }
+        }
+        yield()
+
+        job.cancelAndJoin()
+
+        assertTrue(retainedDuringDismissal)
         assertEquals(0, sessions.size)
     }
 }

--- a/filekit-dialogs/src/iosTest/kotlin/io/github/vinceglb/filekit/dialogs/IosPickerDelegateTest.kt
+++ b/filekit-dialogs/src/iosTest/kotlin/io/github/vinceglb/filekit/dialogs/IosPickerDelegateTest.kt
@@ -1,0 +1,55 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+
+package io.github.vinceglb.filekit.dialogs
+
+import io.github.vinceglb.filekit.dialogs.util.DocumentPickerDelegate
+import io.github.vinceglb.filekit.dialogs.util.PhPickerDelegate
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Photos.PHPhotoLibrary.Companion.sharedPhotoLibrary
+import platform.PhotosUI.PHPickerConfiguration
+import platform.PhotosUI.PHPickerViewController
+import platform.UIKit.UIDocumentPickerViewController
+import platform.UniformTypeIdentifiers.UTTypeItem
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalForeignApi::class)
+class IosPickerDelegateTest {
+    @Test
+    fun DocumentPickerDelegate_cancellation_reportsResultAfterDismissal() {
+        lateinit var finishDismissal: () -> Unit
+        var resultReported = false
+        val delegate = DocumentPickerDelegate(
+            onFilesPicked = {},
+            onPickerCancelled = { resultReported = true },
+            dismiss = { _, finish -> finishDismissal = finish },
+        )
+        val controller = UIDocumentPickerViewController(forOpeningContentTypes = listOf(UTTypeItem))
+
+        delegate.documentPickerWasCancelled(controller)
+
+        assertFalse(resultReported)
+        finishDismissal()
+        assertTrue(resultReported)
+    }
+
+    @Test
+    fun PhPickerDelegate_selection_reportsResultAfterDismissal() {
+        lateinit var finishDismissal: () -> Unit
+        var resultReported = false
+        val delegate = PhPickerDelegate(
+            onFilesPicked = { resultReported = true },
+            dismiss = { _, finish -> finishDismissal = finish },
+        )
+        val controller = PHPickerViewController(
+            configuration = PHPickerConfiguration(sharedPhotoLibrary()),
+        )
+
+        delegate.picker(controller, emptyList<Any>())
+
+        assertFalse(resultReported)
+        finishDismissal()
+        assertTrue(resultReported)
+    }
+}

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.jvm.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.jvm.kt
@@ -2,7 +2,9 @@ package io.github.vinceglb.filekit.dialogs
 
 import io.github.vinceglb.filekit.FileKit
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.platform.JvmDialogOperationException
 import io.github.vinceglb.filekit.dialogs.platform.PlatformFilePicker
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.withContext
@@ -13,36 +15,40 @@ internal actual suspend fun FileKit.platformOpenFilePicker(
     mode: PickerMode,
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
-): Flow<FileKitPickerState<List<PlatformFile>>> = withContext(Dispatchers.IO) {
-    // Filter by extension
-    val extensions = when (type) {
-        FileKitType.Image -> imageExtensions
-        FileKitType.Video -> videoExtensions
-        FileKitType.ImageAndVideo -> imageExtensions + videoExtensions
-        is FileKitType.File -> type.extensions
-    }
-
-    val files = when (mode) {
-        PickerMode.Single -> {
-            PlatformFilePicker.current
-                .openFilePicker(
-                    directory = directory,
-                    fileExtensions = extensions,
-                    dialogSettings = dialogSettings,
-                )?.let { listOf(PlatformFile(it)) }
+): Flow<FileKitPickerState<List<PlatformFile>>> = runJvmDialogOperation(
+    failure = { FileKitPickerException("Failed to open the file picker.", it) },
+) {
+    withContext(Dispatchers.IO) {
+        // Filter by extension
+        val extensions = when (type) {
+            FileKitType.Image -> imageExtensions
+            FileKitType.Video -> videoExtensions
+            FileKitType.ImageAndVideo -> imageExtensions + videoExtensions
+            is FileKitType.File -> type.extensions
         }
 
-        is PickerMode.Multiple -> {
-            PlatformFilePicker.current
-                .openFilesPicker(
-                    directory = directory,
-                    fileExtensions = extensions,
-                    dialogSettings = dialogSettings,
-                )?.map { PlatformFile(it) }
-        }
-    }
+        val files = when (mode) {
+            PickerMode.Single -> {
+                PlatformFilePicker.current
+                    .openFilePicker(
+                        directory = directory,
+                        fileExtensions = extensions,
+                        dialogSettings = dialogSettings,
+                    )?.let { listOf(PlatformFile(it)) }
+            }
 
-    files.toPickerStateFlow()
+            is PickerMode.Multiple -> {
+                PlatformFilePicker.current
+                    .openFilesPicker(
+                        directory = directory,
+                        fileExtensions = extensions,
+                        dialogSettings = dialogSettings,
+                    )?.map { PlatformFile(it) }
+            }
+        }
+
+        files.toPickerStateFlow()
+    }
 }
 
 /**
@@ -55,15 +61,19 @@ internal actual suspend fun FileKit.platformOpenFilePicker(
 public actual suspend fun FileKit.openDirectoryPicker(
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
-): PlatformFile? = withContext(Dispatchers.IO) {
-    // Open native file picker
-    val file = PlatformFilePicker.current.openDirectoryPicker(
-        directory = directory,
-        dialogSettings = dialogSettings,
-    )
+): PlatformFile? = runJvmDialogOperation(
+    failure = { FileKitDialogException("Failed to open the directory picker.", it) },
+) {
+    withContext(Dispatchers.IO) {
+        // Open native file picker
+        val file = PlatformFilePicker.current.openDirectoryPicker(
+            directory = directory,
+            dialogSettings = dialogSettings,
+        )
 
-    // Return result
-    file?.let { PlatformFile(it) }
+        // Return result
+        file?.let { PlatformFile(it) }
+    }
 }
 
 /**
@@ -81,17 +91,34 @@ internal actual suspend fun FileKit.platformOpenFileSaver(
     allowedExtensions: Set<String>?,
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
-): PlatformFile? = withContext(Dispatchers.IO) {
-    val normalizedDefaultExtension = normalizeFileSaverExtension(defaultExtension)
-    val normalizedAllowedExtensions = normalizeFileSaverExtensions(allowedExtensions)
-    val result = PlatformFilePicker.current.openFileSaver(
-        suggestedName = suggestedName,
-        defaultExtension = normalizedDefaultExtension,
-        allowedExtensions = normalizedAllowedExtensions,
-        directory = directory,
-        dialogSettings = dialogSettings,
-    )
-    result?.let { PlatformFile(result) }
+): PlatformFile? = runJvmDialogOperation(
+    failure = { FileKitDialogException("Failed to open the file saver.", it) },
+) {
+    withContext(Dispatchers.IO) {
+        val normalizedDefaultExtension = normalizeFileSaverExtension(defaultExtension)
+        val normalizedAllowedExtensions = normalizeFileSaverExtensions(allowedExtensions)
+        val result = PlatformFilePicker.current.openFileSaver(
+            suggestedName = suggestedName,
+            defaultExtension = normalizedDefaultExtension,
+            allowedExtensions = normalizedAllowedExtensions,
+            directory = directory,
+            dialogSettings = dialogSettings,
+        )
+        result?.let { PlatformFile(result) }
+    }
+}
+
+internal suspend fun <Result> runJvmDialogOperation(
+    failure: (Throwable) -> FileKitDialogException,
+    block: suspend () -> Result,
+): Result = try {
+    block()
+} catch (cause: CancellationException) {
+    throw cause
+} catch (cause: FileKitDialogException) {
+    throw cause
+} catch (cause: JvmDialogOperationException) {
+    throw failure(cause.cause ?: cause)
 }
 
 /**

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/JvmDialogOperationException.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/JvmDialogOperationException.kt
@@ -1,0 +1,9 @@
+package io.github.vinceglb.filekit.dialogs.platform
+
+internal class JvmDialogOperationException : IllegalStateException {
+    constructor(message: String) : super(message)
+
+    constructor(message: String, cause: Throwable) : super(message, cause)
+
+    constructor(cause: Throwable) : super(cause)
+}

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtDialogOperation.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtDialogOperation.kt
@@ -1,0 +1,29 @@
+package io.github.vinceglb.filekit.dialogs.platform.awt
+
+import io.github.vinceglb.filekit.dialogs.platform.JvmDialogOperationException
+import java.awt.HeadlessException
+
+internal inline fun <Result> runAwtDialogOperation(
+    message: String,
+    block: () -> Result,
+): Result = try {
+    block()
+} catch (cause: HeadlessException) {
+    throw JvmDialogOperationException(message, cause)
+}
+
+internal inline fun <Result> dispatchAwtDialogOperation(
+    isActive: () -> Boolean,
+    operation: () -> Result,
+    onResult: (Result) -> Unit,
+    onFailure: (Throwable) -> Unit,
+) {
+    if (!isActive()) return
+
+    try {
+        val result = operation()
+        if (isActive()) onResult(result)
+    } catch (failure: Throwable) {
+        if (isActive()) onFailure(failure)
+    }
+}

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtFilePicker.kt
@@ -2,6 +2,7 @@ package io.github.vinceglb.filekit.dialogs.platform.awt
 
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+import io.github.vinceglb.filekit.dialogs.platform.JvmDialogOperationException
 import io.github.vinceglb.filekit.dialogs.platform.PlatformFilePicker
 import io.github.vinceglb.filekit.path
 import kotlinx.coroutines.suspendCancellableCoroutine
@@ -14,6 +15,7 @@ import java.awt.Window
 import java.io.File
 import java.io.FilenameFilter
 import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 internal class AwtFilePicker : PlatformFilePicker {
     override suspend fun openFilePicker(
@@ -43,7 +45,7 @@ internal class AwtFilePicker : PlatformFilePicker {
     override suspend fun openDirectoryPicker(
         directory: PlatformFile?,
         dialogSettings: FileKitDialogSettings,
-    ): File? = throw UnsupportedOperationException("Directory picker is not supported on Linux yet.")
+    ): File? = throw JvmDialogOperationException("Directory picker is not supported on Linux yet.")
 
     private suspend fun callAwtPicker(
         title: String?,
@@ -53,32 +55,41 @@ internal class AwtFilePicker : PlatformFilePicker {
         parentWindow: Window?,
     ): List<File>? = suspendCancellableCoroutine { continuation ->
         // Handle parentWindow: Dialog, Frame, or null
-        val dialog = when (parentWindow) {
-            is Dialog -> FileDialog(parentWindow, title, LOAD)
-            else -> FileDialog(parentWindow as? Frame, title, LOAD)
-        }
-
-        EventQueue.invokeLater {
-            // Set multiple mode
-            dialog.isMultipleMode = isMultipleMode
-
-            // Set mime types
-            dialog.filenameFilter = FilenameFilter { _, name ->
-                fileExtensions?.any { name.endsWith(suffix = it) } ?: true
+        val dialog = runAwtDialogOperation("Failed to initialize the AWT file picker") {
+            when (parentWindow) {
+                is Dialog -> FileDialog(parentWindow, title, LOAD)
+                else -> FileDialog(parentWindow as? Frame, title, LOAD)
             }
-
-            // Set initial directory
-            directory?.let { dialog.directory = directory.path }
-
-            // Show the dialog
-            dialog.isVisible = true
-
-            val files = dialog.files.takeIf { it.isNotEmpty() }
-            val result = files ?: dialog.file?.let { arrayOf(File(it)) }
-
-            continuation.resume(value = result?.toList())
         }
 
         continuation.invokeOnCancellation { dialog.dispose() }
+
+        EventQueue.invokeLater {
+            dispatchAwtDialogOperation(
+                isActive = { continuation.isActive },
+                operation = {
+                    runAwtDialogOperation("Failed to present the AWT file picker") {
+                        // Set multiple mode
+                        dialog.isMultipleMode = isMultipleMode
+
+                        // Set mime types
+                        dialog.filenameFilter = FilenameFilter { _, name ->
+                            fileExtensions?.any { name.endsWith(suffix = it) } ?: true
+                        }
+
+                        // Set initial directory
+                        directory?.let { dialog.directory = directory.path }
+
+                        // Show the dialog
+                        dialog.isVisible = true
+
+                        val files = dialog.files.takeIf { it.isNotEmpty() }
+                        files ?: dialog.file?.let { arrayOf(File(it)) }
+                    }?.toList()
+                },
+                onResult = continuation::resume,
+                onFailure = continuation::resumeWithException,
+            )
+        }
     }
 }

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtFileSaver.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtFileSaver.kt
@@ -19,49 +19,53 @@ internal object AwtFileSaver {
         dialogSettings: FileKitDialogSettings?,
     ): File? = suspendCancellableCoroutine { continuation ->
         fun handleResult(value: Boolean, files: Array<File>?) {
-            if (value) {
+            if (value && continuation.isActive) {
                 val file = files?.firstOrNull()
                 continuation.resume(file)
             }
         }
 
         // Handle parentWindow: Dialog, Frame, or null
-        val dialog = when (dialogSettings?.parentWindow) {
-            is Dialog -> object : FileDialog(dialogSettings.parentWindow, "Save dialog", SAVE) {
-                override fun setVisible(value: Boolean) {
-                    super.setVisible(value)
-                    handleResult(value, files)
+        val dialog = runAwtDialogOperation("Failed to initialize the AWT file saver") {
+            when (dialogSettings?.parentWindow) {
+                is Dialog -> object : FileDialog(dialogSettings.parentWindow, "Save dialog", SAVE) {
+                    override fun setVisible(value: Boolean) {
+                        super.setVisible(value)
+                        handleResult(value, files)
+                    }
+                }
+
+                else -> object : FileDialog(dialogSettings?.parentWindow as? Frame, "Save dialog", SAVE) {
+                    override fun setVisible(value: Boolean) {
+                        super.setVisible(value)
+                        handleResult(value, files)
+                    }
                 }
             }
-
-            else -> object : FileDialog(dialogSettings?.parentWindow as? Frame, "Save dialog", SAVE) {
-                override fun setVisible(value: Boolean) {
-                    super.setVisible(value)
-                    handleResult(value, files)
-                }
-            }
         }
 
-        // Set initial directory
-        directory?.let { dialog.directory = directory.path }
-
-        val filterExtensions = allowedExtensions ?: defaultExtension?.let { setOf(it) }
-        filterExtensions?.let { extensions ->
-            dialog.filenameFilter = java.io.FilenameFilter { _, name ->
-                extensions.any { extension -> name.endsWith(".$extension", ignoreCase = true) }
-            }
-        }
-
-        // Set file name
-        dialog.file = when {
-            defaultExtension != null -> "$suggestedName.$defaultExtension"
-            else -> suggestedName
-        }
-
-        // Show the dialog
-        dialog.isVisible = true
-
-        // Dispose the dialog when the continuation is cancelled
+        // Dispose the dialog when the continuation is cancelled.
         continuation.invokeOnCancellation { dialog.dispose() }
+
+        runAwtDialogOperation("Failed to present the AWT file saver") {
+            // Set initial directory
+            directory?.let { dialog.directory = directory.path }
+
+            val filterExtensions = allowedExtensions ?: defaultExtension?.let { setOf(it) }
+            filterExtensions?.let { extensions ->
+                dialog.filenameFilter = java.io.FilenameFilter { _, name ->
+                    extensions.any { extension -> name.endsWith(".$extension", ignoreCase = true) }
+                }
+            }
+
+            // Set file name
+            dialog.file = when {
+                defaultExtension != null -> "$suggestedName.$defaultExtension"
+                else -> suggestedName
+            }
+
+            // Show the dialog
+            dialog.isVisible = true
+        }
     }
 }

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/mac/MacOSFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/mac/MacOSFilePicker.kt
@@ -4,6 +4,7 @@ import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.FileKitMacOSSettings
 import io.github.vinceglb.filekit.dialogs.buildFileSaverAllowedFileTypes
+import io.github.vinceglb.filekit.dialogs.platform.JvmDialogOperationException
 import io.github.vinceglb.filekit.dialogs.platform.PlatformFilePicker
 import io.github.vinceglb.filekit.dialogs.platform.mac.foundation.Foundation
 import io.github.vinceglb.filekit.dialogs.platform.mac.foundation.ID
@@ -93,6 +94,11 @@ internal class MacOSFilePicker : PlatformFilePicker {
                 val result = Foundation.invoke(savePanel, "runModal")
                 if (result.toInt() == NS_MODAL_RESPONSE_OK) {
                     response = singlePath(savePanel)
+                        ?: throw JvmDialogOperationException("The macOS save dialog returned no selection")
+                } else if (result.toInt() != NS_MODAL_RESPONSE_CANCEL) {
+                    throw JvmDialogOperationException(
+                        "The macOS save dialog failed with response code ${result.toInt()}",
+                    )
                 }
             }
 
@@ -147,6 +153,11 @@ internal class MacOSFilePicker : PlatformFilePicker {
                 // Get the path(s) from the file picker if the user validated the selection
                 if (result.toInt() == 1) {
                     response = mode.getResult(openPanel)
+                        ?: throw JvmDialogOperationException("The macOS open dialog returned no selection")
+                } else if (result.toInt() != NS_MODAL_RESPONSE_CANCEL) {
+                    throw JvmDialogOperationException(
+                        "The macOS open dialog failed with response code ${result.toInt()}",
+                    )
                 }
             }
 
@@ -158,6 +169,7 @@ internal class MacOSFilePicker : PlatformFilePicker {
 
     private companion object {
         const val NS_MODAL_RESPONSE_OK = 1
+        const val NS_MODAL_RESPONSE_CANCEL = 0
 
         fun Collection<String>.toNsStringArray(): ID? {
             if (isEmpty()) {

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/mac/foundation/Foundation.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/mac/foundation/Foundation.kt
@@ -8,6 +8,7 @@ import com.sun.jna.Native
 import com.sun.jna.Pointer
 import com.sun.jna.PointerType
 import com.sun.jna.ptr.PointerByReference
+import io.github.vinceglb.filekit.dialogs.platform.JvmDialogOperationException
 import org.jetbrains.annotations.NonNls
 import java.io.File
 import java.lang.reflect.Proxy
@@ -26,12 +27,12 @@ internal fun registerObjcRunnableClass(
 ): ID {
     val runnableClass = allocate(className)
     if (runnableClass == null || runnableClass == ID.NIL) {
-        throw IllegalStateException("Unable to allocate Objective-C runnable adapter class '$className'")
+        throw JvmDialogOperationException("Unable to allocate Objective-C runnable adapter class '$className'")
     }
 
     if (!addMethod(runnableClass)) {
         dispose(runnableClass)
-        throw IllegalStateException("Unable to add run: method to Objective-C runnable adapter class '$className'")
+        throw JvmDialogOperationException("Unable to add run: method to Objective-C runnable adapter class '$className'")
     }
 
     register(runnableClass)
@@ -105,7 +106,7 @@ internal object Foundation {
         val cls = getObjcClass(stringCls)
         val selector = createSelector(stringSelector)
         if (!invoke(cls, "respondsToSelector:", selector).booleanValue()) {
-            throw RuntimeException(
+            throw JvmDialogOperationException(
                 String.format(
                     "Missing selector %s for %s",
                     stringSelector,
@@ -129,7 +130,7 @@ internal object Foundation {
     fun safeInvoke(id: ID, stringSelector: String?, vararg args: Any): ID {
         val selector = createSelector(stringSelector)
         if (id != ID.NIL && !invoke(id, "respondsToSelector:", selector).booleanValue()) {
-            throw RuntimeException(
+            throw JvmDialogOperationException(
                 String.format(
                     "Missing selector %s for %s",
                     stringSelector,
@@ -245,7 +246,7 @@ internal object Foundation {
             buffer.size,
             FoundationLibrary.kCFStringEncodingUTF8,
         )
-        if (ok.toInt() == 0) throw RuntimeException("Could not convert string")
+        if (ok.toInt() == 0) throw JvmDialogOperationException("Could not convert string")
         return Native.toString(buffer)
     }
 

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/swing/SwingFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/swing/SwingFilePicker.kt
@@ -2,12 +2,15 @@ package io.github.vinceglb.filekit.dialogs.platform.swing
 
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+import io.github.vinceglb.filekit.dialogs.platform.JvmDialogOperationException
 import io.github.vinceglb.filekit.dialogs.platform.PlatformFilePicker
+import io.github.vinceglb.filekit.dialogs.platform.awt.runAwtDialogOperation
 import io.github.vinceglb.filekit.path
 import kotlinx.coroutines.suspendCancellableCoroutine
 import java.io.File
 import javax.swing.JFileChooser
 import javax.swing.UIManager
+import javax.swing.UnsupportedLookAndFeelException
 import javax.swing.filechooser.FileNameExtensionFilter
 import kotlin.coroutines.resume
 
@@ -15,7 +18,9 @@ internal class SwingFilePicker : PlatformFilePicker {
     init {
         try {
             UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName())
-        } catch (_: Throwable) {
+        } catch (_: ReflectiveOperationException) {
+            println("Failed to set native UI for JFileChooser")
+        } catch (_: UnsupportedLookAndFeelException) {
             println("Failed to set native UI for JFileChooser")
         }
     }
@@ -63,26 +68,55 @@ internal class SwingFilePicker : PlatformFilePicker {
         fileExtensions: Set<String>?,
         dialogSettings: FileKitDialogSettings,
     ): List<File>? = suspendCancellableCoroutine { continuation ->
-        val jFileChooser = JFileChooser(directory?.path)
-        jFileChooser.fileSelectionMode = mode
-        jFileChooser.isMultiSelectionEnabled = isMultiSelectionEnabled
+        val jFileChooser = runAwtDialogOperation("Failed to initialize the Swing file picker") {
+            JFileChooser(directory?.path).apply {
+                fileSelectionMode = mode
+                this.isMultiSelectionEnabled = isMultiSelectionEnabled
 
-        if (fileExtensions != null) {
-            val filter = FileNameExtensionFilter(null, *fileExtensions.toTypedArray())
-            jFileChooser.addChoosableFileFilter(filter)
-        }
+                if (fileExtensions != null) {
+                    val filter = FileNameExtensionFilter(null, *fileExtensions.toTypedArray())
+                    addChoosableFileFilter(filter)
+                }
 
-        if (dialogSettings.title != null) {
-            jFileChooser.dialogTitle = dialogSettings.title
-        }
-
-        val returnValue = jFileChooser.showOpenDialog(dialogSettings.parentWindow)
-        if (returnValue == JFileChooser.APPROVE_OPTION) {
-            continuation.resume(
-                jFileChooser.selectedFiles.toList().takeIf { it.isNotEmpty() } ?: jFileChooser.selectedFile?.let { listOf(it) },
-            )
+                if (dialogSettings.title != null) {
+                    dialogTitle = dialogSettings.title
+                }
+            }
         }
 
         continuation.invokeOnCancellation { jFileChooser.cancelSelection() }
+
+        val returnValue = runAwtDialogOperation("Failed to present the Swing file picker") {
+            jFileChooser.showOpenDialog(dialogSettings.parentWindow)
+        }
+        continuation.resume(
+            resolveSwingDialogResult(
+                returnValue = returnValue,
+                selectedFiles = jFileChooser.selectedFiles,
+                selectedFile = jFileChooser.selectedFile,
+            ),
+        )
+    }
+}
+
+internal fun resolveSwingDialogResult(
+    returnValue: Int,
+    selectedFiles: Array<File>,
+    selectedFile: File?,
+): List<File>? = when (returnValue) {
+    JFileChooser.CANCEL_OPTION -> {
+        null
+    }
+
+    JFileChooser.APPROVE_OPTION -> {
+        selectedFiles
+            .toList()
+            .takeIf { it.isNotEmpty() }
+            ?: selectedFile?.let(::listOf)
+            ?: throw JvmDialogOperationException("The Swing file picker returned no selection")
+    }
+
+    else -> {
+        throw JvmDialogOperationException("The Swing file picker failed with result code $returnValue")
     }
 }

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsDialogExecutor.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsDialogExecutor.kt
@@ -1,6 +1,7 @@
 package io.github.vinceglb.filekit.dialogs.platform.windows
 
 import com.sun.jna.platform.win32.Ole32
+import io.github.vinceglb.filekit.dialogs.platform.JvmDialogOperationException
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.withContext
 import java.util.concurrent.Executors
@@ -43,7 +44,7 @@ internal class WindowsDialogExecutor(
     suspend fun <T> execute(block: () -> T): T = withContext(dispatcher) {
         val initializationResult = comRuntime.initializeSta()
         if (initializationResult != S_OK && initializationResult != S_FALSE) {
-            throw RuntimeException(
+            throw JvmDialogOperationException(
                 "CoInitializeEx failed with HRESULT 0x${initializationResult.toUInt().toString(16)}",
             )
         }

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsFilePicker.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/windows/WindowsFilePicker.kt
@@ -16,6 +16,7 @@ import com.sun.jna.ptr.IntByReference
 import com.sun.jna.ptr.PointerByReference
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+import io.github.vinceglb.filekit.dialogs.platform.JvmDialogOperationException
 import io.github.vinceglb.filekit.dialogs.platform.PlatformFilePicker
 import io.github.vinceglb.filekit.dialogs.platform.windows.jna.FileDialog
 import io.github.vinceglb.filekit.dialogs.platform.windows.jna.FileOpenDialog
@@ -221,7 +222,7 @@ internal class WindowsFilePicker(
 
         // Invalid error codes: throw exception
         if (FAILED(resultFolder)) {
-            throw RuntimeException("SHCreateItemFromParsingName failed")
+            throw JvmDialogOperationException("SHCreateItemFromParsingName failed")
         }
 
         // Create ShellItem from the folder
@@ -274,7 +275,7 @@ internal class WindowsFilePicker(
 
         // Invalid error codes: throw exception
         if (FAILED(openDialogResult)) {
-            throw RuntimeException("Show failed")
+            throw JvmDialogOperationException("Show failed")
         }
 
         return block(this)
@@ -368,7 +369,7 @@ internal class WindowsFilePicker(
 
     private fun HRESULT.verify(exceptionMessage: String): HRESULT {
         if (FAILED(this)) {
-            throw RuntimeException(exceptionMessage)
+            throw JvmDialogOperationException(exceptionMessage)
         } else {
             return this
         }

--- a/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/xdg/XdgFilePickerPortal.kt
+++ b/filekit-dialogs/src/jvmMain/kotlin/io/github/vinceglb/filekit/dialogs/platform/xdg/XdgFilePickerPortal.kt
@@ -3,6 +3,7 @@ package io.github.vinceglb.filekit.dialogs.platform.xdg
 import com.sun.jna.Native
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
+import io.github.vinceglb.filekit.dialogs.platform.JvmDialogOperationException
 import io.github.vinceglb.filekit.dialogs.platform.PlatformFilePicker
 import io.github.vinceglb.filekit.path
 import kotlinx.coroutines.CompletableDeferred
@@ -15,6 +16,8 @@ import org.freedesktop.dbus.annotations.DBusProperty.Access
 import org.freedesktop.dbus.annotations.Position
 import org.freedesktop.dbus.connections.impl.DBusConnection
 import org.freedesktop.dbus.connections.impl.DBusConnectionBuilder
+import org.freedesktop.dbus.exceptions.DBusException
+import org.freedesktop.dbus.exceptions.DBusExecutionException
 import org.freedesktop.dbus.interfaces.DBusInterface
 import org.freedesktop.dbus.interfaces.DBusSigHandler
 import org.freedesktop.dbus.interfaces.Properties
@@ -91,7 +94,7 @@ internal class XdgFilePickerPortal : PlatformFilePicker {
         parentWindow: Window?,
         multiple: Boolean,
         openDirectory: Boolean,
-    ): List<File>? {
+    ): List<File>? = runXdgPortalOperation {
         DBusConnectionBuilder.forSessionBus().build().use { connection ->
             val handleToken = UUID.randomUUID().toString().replace("-", "")
             val options: MutableMap<String, Variant<*>> = HashMap()
@@ -107,8 +110,7 @@ internal class XdgFilePickerPortal : PlatformFilePicker {
                 title = title ?: "",
                 options = options,
             )
-            val files = deferredResult.await()?.map { File(it) }
-            return files
+            deferredResult.await()?.map { File(it) }
         }
     }
 
@@ -118,7 +120,7 @@ internal class XdgFilePickerPortal : PlatformFilePicker {
         allowedExtensions: Set<String>?,
         directory: PlatformFile?,
         dialogSettings: FileKitDialogSettings,
-    ): File? {
+    ): File? = runXdgPortalOperation {
         DBusConnectionBuilder.forSessionBus().build().use { connection ->
             val handleToken = UUID.randomUUID().toString().replace("-", "")
             val options: MutableMap<String, Variant<*>> = HashMap()
@@ -140,7 +142,7 @@ internal class XdgFilePickerPortal : PlatformFilePicker {
                 options = options,
             )
 
-            return deferredResult.await()?.first()?.let { File(it) }
+            deferredResult.await()?.firstOrNull()?.let { File(it) }
         }
     }
 
@@ -155,8 +157,11 @@ internal class XdgFilePickerPortal : PlatformFilePicker {
         val result = CompletableDeferred<List<URI>?>()
         val matchRule = DBusMatchRule("signal", "org.freedesktop.portal.Request", "Response")
         val registration = AtomicReference<AutoCloseable?>(null)
-        val handler = ResponseHandler(path) { uris ->
-            result.complete(uris)
+        val handler = ResponseHandler(path) { response ->
+            response.fold(
+                onSuccess = result::complete,
+                onFailure = result::completeExceptionally,
+            )
         }
         registration.set(
             addGenericSigHandlerCompat(
@@ -173,22 +178,25 @@ internal class XdgFilePickerPortal : PlatformFilePicker {
 
     private class ResponseHandler(
         private val path: String,
-        private val onComplete: (result: List<URI>?) -> Unit,
+        private val onComplete: (result: Result<List<URI>?>) -> Unit,
     ) : DBusSigHandler<DBusSignal> {
         @Suppress("UNCHECKED_CAST")
         override fun handle(signal: DBusSignal) {
             if (path == signal.path) {
-                val params = signal.parameters
-                val response = params[0] as UInt32
-                val results = params[1] as Map<String, Variant<*>>
-
-                if (response.toInt() == 0) {
-                    val uris = (results["uris"]!!.value as List<String>).map { path ->
-                        path.toURI()
+                try {
+                    val params = signal.parameters
+                    val response = params.getOrNull(0) as? UInt32
+                        ?: throw JvmDialogOperationException("The XDG portal returned no response code")
+                    val results = params.getOrNull(1) as? Map<*, *>
+                    val uriValues = (results?.get("uris") as? Variant<*>)?.value as? List<*>
+                    val uris = uriValues?.map { value ->
+                        value as? String
+                            ?: throw JvmDialogOperationException("The XDG portal returned an invalid file URI")
                     }
-                    onComplete(uris)
-                } else {
-                    onComplete(null)
+                    onComplete(Result.success(resolveXdgPortalResponse(response.toInt(), uris)))
+                } catch (cause: Throwable) {
+                    // Forward asynchronous callback failures to the suspended caller unchanged.
+                    onComplete(Result.failure(cause))
                 }
             }
         }
@@ -209,14 +217,16 @@ internal class XdgFilePickerPortal : PlatformFilePicker {
                 candidate.parameterTypes.size == 2 &&
                 candidate.parameterTypes[0].isAssignableFrom(matchRule.javaClass) &&
                 candidate.parameterTypes[1].isAssignableFrom(handler.javaClass)
-        } ?: error("No compatible DBusConnection signal-registration method found")
+        } ?: throw JvmDialogOperationException("No compatible DBusConnection signal-registration method found")
 
         try {
             val registration = method.invoke(connection, matchRule, handler)
             return registration as? AutoCloseable
-                ?: error("DBusConnection signal-registration method did not return AutoCloseable")
+                ?: throw JvmDialogOperationException(
+                    "DBusConnection signal-registration method did not return AutoCloseable",
+                )
         } catch (error: InvocationTargetException) {
-            throw error.targetException
+            throw JvmDialogOperationException("Failed to register the DBus response handler", error.targetException)
         }
     }
 
@@ -253,6 +263,38 @@ internal class XdgFilePickerPortal : PlatformFilePicker {
         System.arraycopy(stringBytes, 0, nullTerminated, 0, stringBytes.size)
         return Variant(nullTerminated)
     }
+}
+
+internal fun resolveXdgPortalResponse(
+    responseCode: Int,
+    uris: List<String>?,
+): List<URI>? = when (responseCode) {
+    0 -> {
+        uris
+            ?.takeIf { it.isNotEmpty() }
+            ?.map(String::toURI)
+            ?: throw JvmDialogOperationException("The XDG portal returned no selected file")
+    }
+
+    1 -> {
+        null
+    }
+
+    else -> {
+        throw JvmDialogOperationException("The XDG portal failed with response code $responseCode")
+    }
+}
+
+internal suspend inline fun <Result> runXdgPortalOperation(
+    block: () -> Result,
+): Result = try {
+    block()
+} catch (cause: JvmDialogOperationException) {
+    throw cause
+} catch (cause: DBusExecutionException) {
+    throw JvmDialogOperationException("The XDG portal operation failed", cause)
+} catch (cause: DBusException) {
+    throw JvmDialogOperationException("The XDG portal connection failed", cause)
 }
 
 @DBusInterfaceName(value = "org.freedesktop.portal.FileChooser")

--- a/filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/JvmDialogFailureTest.kt
+++ b/filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/JvmDialogFailureTest.kt
@@ -1,0 +1,53 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+
+package io.github.vinceglb.filekit.dialogs
+
+import io.github.vinceglb.filekit.dialogs.platform.JvmDialogOperationException
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+class JvmDialogFailureTest {
+    @Test
+    fun runJvmDialogOperation_knownNativeFailure_wrapsAndPreservesCause() = runTest {
+        val nativeFailure = UnsupportedOperationException("Dialog unavailable")
+
+        val failure = assertFailsWith<FileKitDialogException> {
+            runJvmDialogOperation(
+                failure = { FileKitDialogException("Failed to open the dialog.", it) },
+                block = { throw JvmDialogOperationException(nativeFailure) },
+            )
+        }
+
+        assertSame(nativeFailure, failure.cause)
+    }
+
+    @Test
+    fun runJvmDialogOperation_unexpectedRuntimeFailure_propagates() = runTest {
+        val defect = IllegalStateException("Unexpected invariant violation")
+
+        val failure = assertFailsWith<IllegalStateException> {
+            runJvmDialogOperation(
+                failure = { FileKitDialogException("Failed to open the dialog.", it) },
+                block = { throw defect },
+            )
+        }
+
+        assertSame(defect, failure)
+    }
+
+    @Test
+    fun runJvmDialogOperation_invalidArgument_propagates() = runTest {
+        val invalidArgument = IllegalArgumentException("Unsupported mode")
+
+        val failure = assertFailsWith<IllegalArgumentException> {
+            runJvmDialogOperation(
+                failure = { FileKitDialogException("Failed to open the dialog.", it) },
+                block = { throw invalidArgument },
+            )
+        }
+
+        assertSame(invalidArgument, failure)
+    }
+}

--- a/filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtDialogOperationTest.kt
+++ b/filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/platform/awt/AwtDialogOperationTest.kt
@@ -1,0 +1,66 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+
+package io.github.vinceglb.filekit.dialogs.platform.awt
+
+import io.github.vinceglb.filekit.dialogs.platform.JvmDialogOperationException
+import java.awt.HeadlessException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+
+class AwtDialogOperationTest {
+    @Test
+    fun AwtDialogOperation_headlessFailure_wrapsCause() {
+        val headlessFailure = HeadlessException("No display")
+
+        val failure = assertFailsWith<JvmDialogOperationException> {
+            runAwtDialogOperation<Unit>("Failed to present dialog") { throw headlessFailure }
+        }
+
+        assertEquals("Failed to present dialog", failure.message)
+        assertSame(headlessFailure, failure.cause)
+    }
+
+    @Test
+    fun AwtDialogOperation_unexpectedFailure_propagates() {
+        val unexpectedFailure = IllegalArgumentException("Unexpected")
+
+        val failure = assertFailsWith<IllegalArgumentException> {
+            runAwtDialogOperation<Unit>("Failed to present dialog") { throw unexpectedFailure }
+        }
+
+        assertSame(unexpectedFailure, failure)
+    }
+
+    @Test
+    fun AwtDialogDispatch_cancelledBeforeDispatch_skipsPresentation() {
+        var presented = false
+
+        dispatchAwtDialogOperation(
+            isActive = { false },
+            operation = {
+                presented = true
+            },
+            onResult = {},
+            onFailure = {},
+        )
+
+        assertEquals(false, presented)
+    }
+
+    @Test
+    fun AwtDialogDispatch_unexpectedFailure_forwardsOriginalFailure() {
+        val unexpectedFailure = IllegalArgumentException("Unexpected")
+        var reportedFailure: Throwable? = null
+
+        dispatchAwtDialogOperation(
+            isActive = { true },
+            operation = { throw unexpectedFailure },
+            onResult = {},
+            onFailure = { reportedFailure = it },
+        )
+
+        assertSame(unexpectedFailure, reportedFailure)
+    }
+}

--- a/filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/platform/swing/SwingFilePickerResultTest.kt
+++ b/filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/platform/swing/SwingFilePickerResultTest.kt
@@ -1,0 +1,42 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+
+package io.github.vinceglb.filekit.dialogs.platform.swing
+
+import io.github.vinceglb.filekit.dialogs.platform.JvmDialogOperationException
+import java.io.File
+import javax.swing.JFileChooser
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class SwingFilePickerResultTest {
+    @Test
+    fun SwingResult_cancel_returnsNull() {
+        assertNull(resolveSwingDialogResult(JFileChooser.CANCEL_OPTION, emptyArray(), null))
+    }
+
+    @Test
+    fun SwingResult_approvedSelection_returnsFiles() {
+        val selectedFile = File("selected.txt")
+
+        assertEquals(
+            listOf(selectedFile),
+            resolveSwingDialogResult(JFileChooser.APPROVE_OPTION, emptyArray(), selectedFile),
+        )
+    }
+
+    @Test
+    fun SwingResult_approvedWithoutSelection_throwsOperationFailure() {
+        assertFailsWith<JvmDialogOperationException> {
+            resolveSwingDialogResult(JFileChooser.APPROVE_OPTION, emptyArray(), null)
+        }
+    }
+
+    @Test
+    fun SwingResult_error_throwsOperationFailure() {
+        assertFailsWith<JvmDialogOperationException> {
+            resolveSwingDialogResult(JFileChooser.ERROR_OPTION, emptyArray(), null)
+        }
+    }
+}

--- a/filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/platform/xdg/XdgPortalResponseTest.kt
+++ b/filekit-dialogs/src/jvmTest/kotlin/io/github/vinceglb/filekit/dialogs/platform/xdg/XdgPortalResponseTest.kt
@@ -1,0 +1,45 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+
+package io.github.vinceglb.filekit.dialogs.platform.xdg
+
+import io.github.vinceglb.filekit.dialogs.platform.JvmDialogOperationException
+import kotlinx.coroutines.test.runTest
+import org.freedesktop.dbus.exceptions.DBusExecutionException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class XdgPortalResponseTest {
+    @Test
+    fun XdgPortalResponse_success_returnsUris() {
+        assertEquals(
+            listOf("file:///tmp/example.txt"),
+            resolveXdgPortalResponse(0, listOf("file:///tmp/example.txt"))?.map { it.toString() },
+        )
+    }
+
+    @Test
+    fun XdgPortalResponse_cancel_returnsNull() {
+        assertNull(resolveXdgPortalResponse(1, null))
+    }
+
+    @Test
+    fun XdgPortalResponse_error_throwsOperationFailure() {
+        assertFailsWith<JvmDialogOperationException> {
+            resolveXdgPortalResponse(2, null)
+        }
+    }
+
+    @Test
+    fun XdgPortalOperation_dbusFailure_wrapsCause() = runTest {
+        val dbusFailure = DBusExecutionException("Portal unavailable")
+
+        val failure = assertFailsWith<JvmDialogOperationException> {
+            runXdgPortalOperation<Unit> { throw dbusFailure }
+        }
+
+        assertSame(dbusFailure, failure.cause)
+    }
+}

--- a/filekit-dialogs/src/macosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.macos.kt
+++ b/filekit-dialogs/src/macosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.macos.kt
@@ -5,6 +5,7 @@ import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.absolutePath
 import io.github.vinceglb.filekit.path
 import kotlinx.coroutines.flow.Flow
+import platform.AppKit.NSModalResponseCancel
 import platform.AppKit.NSModalResponseOK
 import platform.AppKit.NSOpenPanel
 import platform.AppKit.NSSavePanel
@@ -89,20 +90,11 @@ internal actual suspend fun FileKit.platformOpenFileSaver(
     nsSavePanel.canCreateDirectories = dialogSettings.canCreateDirectories
 
     // Run the NSSavePanel
-    val result = nsSavePanel.runModal()
-
-    // If the user canceled the operation, return null
-    if (result != NSModalResponseOK) {
-        return null
+    return resolveMacosDialogResponse(nsSavePanel.runModal()) {
+        nsSavePanel.URL?.let { nsUrl ->
+            PlatformFile(nsUrl)
+        }
     }
-
-    // Return the result
-    val platformFile = nsSavePanel.URL?.let { nsUrl ->
-        // Create the PlatformFile
-        PlatformFile(nsUrl)
-    }
-
-    return platformFile
 }
 
 /**
@@ -145,15 +137,21 @@ private fun callPicker(
     )
 
     // Run the NSOpenPanel
-    val result = nsOpenPanel.runModal()
-
-    // If the user canceled the operation, return null
-    if (result != NSModalResponseOK) {
-        return null
+    return resolveMacosDialogResponse(nsOpenPanel.runModal()) {
+        nsOpenPanel.URLs.mapNotNull { it as? NSURL }.takeIf { it.isNotEmpty() }
     }
+}
 
-    // Return the result
-    return nsOpenPanel.URLs.mapNotNull { it as? NSURL }
+internal inline fun <Result : Any> resolveMacosDialogResponse(
+    response: Long,
+    selection: () -> Result?,
+): Result? = when (response) {
+    NSModalResponseCancel -> null
+
+    NSModalResponseOK -> selection()
+        ?: throw FileKitDialogException("The macOS dialog completed without a selection.")
+
+    else -> throw FileKitDialogException("The macOS dialog failed with response code $response.")
 }
 
 private fun NSOpenPanel.configure(

--- a/filekit-dialogs/src/macosTest/kotlin/io/github/vinceglb/filekit/dialogs/MacosDialogResponseTest.kt
+++ b/filekit-dialogs/src/macosTest/kotlin/io/github/vinceglb/filekit/dialogs/MacosDialogResponseTest.kt
@@ -1,0 +1,37 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+
+package io.github.vinceglb.filekit.dialogs
+
+import platform.AppKit.NSModalResponseAbort
+import platform.AppKit.NSModalResponseCancel
+import platform.AppKit.NSModalResponseOK
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class MacosDialogResponseTest {
+    @Test
+    fun resolveMacosDialogResponse_cancel_returnsNull() {
+        assertNull(resolveMacosDialogResponse(NSModalResponseCancel) { "selection" })
+    }
+
+    @Test
+    fun resolveMacosDialogResponse_ok_returnsSelection() {
+        assertEquals("selection", resolveMacosDialogResponse(NSModalResponseOK) { "selection" })
+    }
+
+    @Test
+    fun resolveMacosDialogResponse_okWithoutSelection_throwsDialogFailure() {
+        assertFailsWith<FileKitDialogException> {
+            resolveMacosDialogResponse<String>(NSModalResponseOK) { null }
+        }
+    }
+
+    @Test
+    fun resolveMacosDialogResponse_abort_throwsDialogFailure() {
+        assertFailsWith<FileKitDialogException> {
+            resolveMacosDialogResponse(NSModalResponseAbort) { "selection" }
+        }
+    }
+}

--- a/filekit-dialogs/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.mingw.kt
+++ b/filekit-dialogs/src/mingwX64Main/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.mingw.kt
@@ -79,16 +79,23 @@ internal actual suspend fun FileKit.platformOpenFilePicker(
         FileKitType.ImageAndVideo -> imageExtensions + videoExtensions
         is FileKitType.File -> type.extensions
     }
-    return showOpenDialog(extensions, directory, dialogSettings.title, pickFolders = false, mode is PickerMode.Multiple)
-        .toPickerStateFlow()
+    return try {
+        showOpenDialog(extensions, directory, dialogSettings.title, pickFolders = false, mode is PickerMode.Multiple)
+            .toPickerStateFlow()
+    } catch (cause: IllegalStateException) {
+        throw FileKitPickerException("Failed to open the file picker.", cause)
+    }
 }
 
 public actual suspend fun FileKit.openDirectoryPicker(
     directory: PlatformFile?,
     dialogSettings: FileKitDialogSettings,
-): PlatformFile? =
+): PlatformFile? = try {
     showOpenDialog(null, directory, dialogSettings.title, pickFolders = true, allowMultiple = false)
         ?.firstOrNull()
+} catch (cause: IllegalStateException) {
+    throw FileKitDialogException("Failed to open the directory picker.", cause)
+}
 
 internal actual suspend fun FileKit.platformOpenFileSaver(
     suggestedName: String,
@@ -99,7 +106,11 @@ internal actual suspend fun FileKit.platformOpenFileSaver(
 ): PlatformFile? {
     val ext = normalizeFileSaverExtension(defaultExtension)
     val filters = normalizeFileSaverExtensions(allowedExtensions)
-    return showSaveDialog(buildFileSaverSuggestedName(suggestedName, ext), ext, filters, directory, dialogSettings.title)
+    return try {
+        showSaveDialog(buildFileSaverSuggestedName(suggestedName, ext), ext, filters, directory, dialogSettings.title)
+    } catch (cause: IllegalStateException) {
+        throw FileKitDialogException("Failed to open the file saver.", cause)
+    }
 }
 
 public actual fun FileKit.openFileWithDefaultApplication(

--- a/filekit-dialogs/src/mobileMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.mobile.kt
+++ b/filekit-dialogs/src/mobileMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.mobile.kt
@@ -13,6 +13,12 @@ public enum class FileKitCameraFacing {
     Back,
 }
 
+/**
+ * Opens the system camera picker.
+ *
+ * @return The captured file, or null if the user cancels or denies the runtime camera permission.
+ * @throws FileKitDialogException When FileKit cannot open the camera or write the captured file.
+ */
 @OptIn(ExperimentalUuidApi::class)
 public expect suspend fun FileKit.openCameraPicker(
     type: FileKitCameraType = FileKitCameraType.Photo,
@@ -21,11 +27,21 @@ public expect suspend fun FileKit.openCameraPicker(
     openCameraSettings: FileKitOpenCameraSettings = FileKitOpenCameraSettings.createDefault(),
 ): PlatformFile?
 
+/**
+ * Opens the system share dialog for [file].
+ *
+ * @throws FileKitDialogException When FileKit cannot create or present the share dialog.
+ */
 public expect suspend fun FileKit.shareFile(
     file: PlatformFile,
     shareSettings: FileKitShareSettings = FileKitShareSettings.createDefault(),
 )
 
+/**
+ * Opens the system share dialog for [files].
+ *
+ * @throws FileKitDialogException When FileKit cannot create or present the share dialog.
+ */
 public expect suspend fun FileKit.shareFile(
     files: List<PlatformFile>,
     shareSettings: FileKitShareSettings = FileKitShareSettings.createDefault(),

--- a/filekit-dialogs/src/nonWebMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.nonWeb.kt
+++ b/filekit-dialogs/src/nonWebMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.nonWeb.kt
@@ -17,6 +17,7 @@ import io.github.vinceglb.filekit.PlatformFile
  * @param directory The initial directory. Supported on desktop platforms.
  * @param dialogSettings Platform-specific settings for the dialog.
  * @return The path where the file should be saved as a [PlatformFile], or null if cancelled.
+ * @throws FileKitDialogException When FileKit cannot open or prepare the file saver.
  */
 public suspend fun FileKit.openFileSaver(
     suggestedName: String,
@@ -40,6 +41,7 @@ public suspend fun FileKit.openFileSaver(
  * @param directory The initial directory. Supported on desktop platforms.
  * @param dialogSettings Platform-specific settings for the dialog.
  * @return The path where the file should be saved as a [PlatformFile], or null if cancelled.
+ * @throws FileKitDialogException When FileKit cannot open or prepare the file saver.
  */
 @Deprecated(
     message = "Use defaultExtension. The extension parameter is a default extension hint, not a filter.",

--- a/filekit-dialogs/src/webMain/kotlin/io/github/vinceglb/filekit/dialogs/BrowserFileInput.web.kt
+++ b/filekit-dialogs/src/webMain/kotlin/io/github/vinceglb/filekit/dialogs/BrowserFileInput.web.kt
@@ -11,24 +11,23 @@ import org.w3c.dom.asList
 import org.w3c.files.FileList
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
+import kotlin.js.JsException
 
 @OptIn(ExperimentalWasmJsInterop::class)
 internal suspend fun openBrowserFileInput(
     type: FileKitType,
     multipleMode: Boolean,
     directoryMode: Boolean,
+    failure: (Throwable) -> FileKitDialogException,
 ): List<WebFile.FileWrapper>? = withContext(Dispatchers.Default) {
     suspendCancellableCoroutine { continuation ->
         val inputElement = document.createElement("input")
         val input = inputElement as BrowserFileInputElement
-        (inputElement as HTMLElement).style.display = "none"
-        document.body?.appendChild(inputElement)
 
-        input.apply {
-            this.type = "file"
-            accept = type.acceptAttribute
-            multiple = multipleMode
-            webkitdirectory = directoryMode
+        fun cleanup() {
+            input.onchange = null
+            input.oncancel = null
+            inputElement.parentNode?.removeChild(inputElement)
         }
 
         input.onchange = {
@@ -37,20 +36,37 @@ internal suspend fun openBrowserFileInput(
                     ?.asList()
                     ?.map { WebFile.FileWrapper(it.unsafeCast<BrowserFile>()) }
 
-                continuation.resume(result)
-            } catch (e: Throwable) {
-                continuation.resumeWithException(e)
+                if (continuation.isActive) continuation.resume(result)
+            } catch (cause: JsException) {
+                if (continuation.isActive) continuation.resumeWithException(failure(cause))
+            } catch (cause: Throwable) {
+                if (continuation.isActive) continuation.resumeWithException(cause)
             } finally {
-                document.body?.removeChild(inputElement)
+                cleanup()
             }
         }
 
         input.oncancel = {
-            continuation.resume(null)
-            document.body?.removeChild(inputElement)
+            if (continuation.isActive) continuation.resume(null)
+            cleanup()
         }
 
-        input.click()
+        continuation.invokeOnCancellation { cleanup() }
+
+        try {
+            (inputElement as HTMLElement).style.display = "none"
+            document.body?.appendChild(inputElement)
+            input.apply {
+                this.type = "file"
+                accept = type.acceptAttribute
+                multiple = multipleMode
+                webkitdirectory = directoryMode
+            }
+            input.click()
+        } catch (cause: JsException) {
+            cleanup()
+            if (continuation.isActive) continuation.resumeWithException(failure(cause))
+        }
     }
 }
 

--- a/filekit-dialogs/src/webMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.web.kt
+++ b/filekit-dialogs/src/webMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.web.kt
@@ -15,6 +15,7 @@ internal actual suspend fun FileKit.platformOpenFilePicker(
         type = type,
         multipleMode = mode is PickerMode.Multiple,
         directoryMode = false,
+        failure = { FileKitPickerException("Failed to open the browser file picker.", it) },
     )?.map { PlatformFile(it) }.toPickerStateFlow()
 
 public actual suspend fun FileKit.openDirectoryPicker(
@@ -25,6 +26,7 @@ public actual suspend fun FileKit.openDirectoryPicker(
         type = FileKitType.File(),
         multipleMode = false,
         directoryMode = true,
+        failure = { FileKitDialogException("Failed to open the browser directory picker.", it) },
     )
     return PlatformFile.fromWebDirectoryFiles(fileList.orEmpty())
 }

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/camerapicker/CameraPickerLauncher.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/camerapicker/CameraPickerLauncher.kt
@@ -2,6 +2,7 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.camerapicker
 
 import androidx.compose.runtime.Composable
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 
 internal enum class CameraFacingOption {
     System,
@@ -17,5 +18,6 @@ internal interface CameraPickerLauncher {
 
 @Composable
 internal expect fun rememberCameraPickerLauncher(
+    onError: (FileKitDialogException) -> Unit,
     onResult: (PlatformFile?) -> Unit,
 ): CameraPickerLauncher

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/camerapicker/CameraPickerScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/camerapicker/CameraPickerScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.tooling.preview.AndroidUiModes
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.sample.shared.ui.components.AppDottedBorderCard
 import io.github.vinceglb.filekit.sample.shared.ui.components.AppDropdown
 import io.github.vinceglb.filekit.sample.shared.ui.components.AppDropdownItem
@@ -63,13 +64,21 @@ private fun CameraPickerScreen(
     var buttonState by remember { mutableStateOf(AppScreenHeaderButtonState.Enabled) }
     var cameraFacing by remember { mutableStateOf(CameraFacingOption.System) }
     var capturedFiles by remember { mutableStateOf(emptyList<PlatformFile>()) }
+    var pickerError by remember { mutableStateOf<String?>(null) }
 
-    val cameraLauncher = rememberCameraPickerLauncher { file ->
-        buttonState = AppScreenHeaderButtonState.Enabled
-        if (file != null) {
-            capturedFiles = listOf(file) + capturedFiles
-        }
-    }
+    val cameraLauncher = rememberCameraPickerLauncher(
+        onError = { failure: FileKitDialogException ->
+            buttonState = AppScreenHeaderButtonState.Enabled
+            pickerError = failure.message
+        },
+        onResult = { file ->
+            buttonState = AppScreenHeaderButtonState.Enabled
+            pickerError = null
+            if (file != null) {
+                capturedFiles = listOf(file) + capturedFiles
+            }
+        },
+    )
     val isSupported = cameraLauncher.isSupported
     val primaryButtonText = if (isSupported) "Open Camera" else "Camera Unavailable"
 
@@ -130,7 +139,7 @@ private fun CameraPickerScreen(
             item {
                 AppPickerResultsCard(
                     files = capturedFiles,
-                    emptyText = "No photos captured yet",
+                    emptyText = pickerError ?: "No photos captured yet",
                     emptyIcon = LucideIcons.Camera,
                     onFileClick = onDisplayFileDetails,
                     modifier = Modifier.sizeIn(maxWidth = AppMaxWidth),

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/directorypicker/DirectoryPickerScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/directorypicker/DirectoryPickerScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.tooling.preview.AndroidUiModes
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.compose.rememberDirectoryPickerLauncher
 import io.github.vinceglb.filekit.name
 import io.github.vinceglb.filekit.sample.shared.ui.components.AppDottedBorderCard
@@ -64,18 +65,28 @@ private fun DirectoryPickerScreen(
     var startDirectory by remember { mutableStateOf<PlatformFile?>(null) }
     var pickedDirectories by remember { mutableStateOf(emptyList<PlatformFile>()) }
     var selectedFile by remember { mutableStateOf<PlatformFile?>(null) }
+    var pickerError by remember { mutableStateOf<String?>(null) }
+
+    val onPickerError: (FileKitDialogException) -> Unit = { failure ->
+        buttonState = AppScreenHeaderButtonState.Enabled
+        pickerError = failure.message
+    }
 
     val directoryLauncher = rememberDirectoryPickerLauncher(
         directory = startDirectory,
+        onError = onPickerError,
     ) { directory ->
         buttonState = AppScreenHeaderButtonState.Enabled
+        pickerError = null
         if (directory != null) {
             pickedDirectories = listOf(directory) + pickedDirectories
         }
     }
     val startDirectoryLauncher = rememberDirectoryPickerLauncher(
         directory = startDirectory,
+        onError = onPickerError,
     ) { directory ->
+        pickerError = null
         if (directory != null) {
             startDirectory = directory
         }
@@ -142,7 +153,7 @@ private fun DirectoryPickerScreen(
                 item {
                     AppPickerResultsCard(
                         files = pickedDirectories,
-                        emptyText = "No directory selected yet",
+                        emptyText = pickerError ?: "No directory selected yet",
                         emptyIcon = LucideIcons.Folder,
                         onFileClick = onDisplayFileDetails,
                         modifier = Modifier.sizeIn(maxWidth = AppMaxWidth),

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.kt
@@ -2,6 +2,7 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.filesaver
 
 import androidx.compose.runtime.Composable
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 
 internal interface FileSaverLauncher {
     val isSupported: Boolean
@@ -16,5 +17,6 @@ internal interface FileSaverLauncher {
 
 @Composable
 internal expect fun rememberFileSaverLauncher(
+    onError: (FileKitDialogException) -> Unit,
     onResult: (PlatformFile?) -> Unit,
 ): FileSaverLauncher

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.tooling.preview.AndroidUiModes
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.compose.rememberDirectoryPickerLauncher
 import io.github.vinceglb.filekit.name
 import io.github.vinceglb.filekit.sample.shared.ui.components.AppDottedBorderCard
@@ -67,16 +68,28 @@ private fun FileSaverScreen(
     var allowedExtensions by remember { mutableStateOf("pdf, txt") }
     var saveDirectory by remember { mutableStateOf<PlatformFile?>(null) }
     var savedFiles by remember { mutableStateOf(emptyList<PlatformFile>()) }
+    var pickerError by remember { mutableStateOf<String?>(null) }
 
-    val fileSaverLauncher = rememberFileSaverLauncher { file ->
+    val onPickerError: (FileKitDialogException) -> Unit = { failure ->
         buttonState = AppScreenHeaderButtonState.Enabled
-        if (file != null) {
-            savedFiles = listOf(file) + savedFiles
-        }
+        pickerError = failure.message
     }
+
+    val fileSaverLauncher = rememberFileSaverLauncher(
+        onError = onPickerError,
+        onResult = { file ->
+            buttonState = AppScreenHeaderButtonState.Enabled
+            pickerError = null
+            if (file != null) {
+                savedFiles = listOf(file) + savedFiles
+            }
+        },
+    )
     val directoryPickerLauncher = rememberDirectoryPickerLauncher(
         directory = saveDirectory,
+        onError = onPickerError,
     ) { directory ->
+        pickerError = null
         if (directory != null) {
             saveDirectory = directory
         }
@@ -165,7 +178,7 @@ private fun FileSaverScreen(
             item {
                 AppPickerResultsCard(
                     files = savedFiles,
-                    emptyText = "No save locations selected yet",
+                    emptyText = pickerError ?: "No save locations selected yet",
                     emptyIcon = LucideIcons.File,
                     onFileClick = onDisplayFileDetails,
                     modifier = Modifier.sizeIn(maxWidth = AppMaxWidth),

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/sharefile/ShareFileLauncher.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/sharefile/ShareFileLauncher.kt
@@ -2,6 +2,7 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.sharefile
 
 import androidx.compose.runtime.Composable
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 
 internal interface ShareFileLauncher {
     val isSupported: Boolean
@@ -10,4 +11,6 @@ internal interface ShareFileLauncher {
 }
 
 @Composable
-internal expect fun rememberShareFileLauncher(): ShareFileLauncher
+internal expect fun rememberShareFileLauncher(
+    onError: (FileKitDialogException) -> Unit,
+): ShareFileLauncher

--- a/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/sharefile/ShareFileScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/sharefile/ShareFileScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.tooling.preview.AndroidUiModes
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitMode
 import io.github.vinceglb.filekit.dialogs.FileKitType
 import io.github.vinceglb.filekit.dialogs.compose.rememberFilePickerLauncher
@@ -65,8 +66,11 @@ private fun ShareFileScreen(
     val buttonState = AppScreenHeaderButtonState.Enabled
     var pickerMode by remember { mutableStateOf(ShareMode.Multiple) }
     var selectedFiles by remember { mutableStateOf(emptyList<PlatformFile>()) }
+    var pickerError by remember { mutableStateOf<String?>(null) }
 
-    val shareLauncher = rememberShareFileLauncher()
+    val shareLauncher = rememberShareFileLauncher { failure: FileKitDialogException ->
+        pickerError = failure.message
+    }
     val isSupported = shareLauncher.isSupported
     val primaryButtonText = when (selectedFiles.size) {
         0 -> "Share File"
@@ -99,6 +103,7 @@ private fun ShareFileScreen(
         if (!isSupported || selectedFiles.isEmpty()) {
             return
         }
+        pickerError = null
         shareLauncher.launch(selectedFiles)
     }
 
@@ -160,7 +165,7 @@ private fun ShareFileScreen(
             item {
                 AppPickerResultsCard(
                     files = selectedFiles,
-                    emptyText = "No files selected yet",
+                    emptyText = pickerError ?: "No files selected yet",
                     emptyIcon = LucideIcons.Share,
                     onFileClick = onDisplayFileDetails,
                     modifier = Modifier.sizeIn(maxWidth = AppMaxWidth),

--- a/sample/shared/src/jvmMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/camerapicker/CameraPickerLauncher.jvm.kt
+++ b/sample/shared/src/jvmMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/camerapicker/CameraPickerLauncher.jvm.kt
@@ -3,9 +3,11 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.camerapicker
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 
 @Composable
 internal actual fun rememberCameraPickerLauncher(
+    onError: (FileKitDialogException) -> Unit,
     onResult: (PlatformFile?) -> Unit,
 ): CameraPickerLauncher = remember {
     object : CameraPickerLauncher {

--- a/sample/shared/src/jvmMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.jvm.kt
+++ b/sample/shared/src/jvmMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.jvm.kt
@@ -3,15 +3,18 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.filesaver
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.compose.rememberFileSaverLauncher as rememberFileKitSaverLauncher
 
 @Composable
 internal actual fun rememberFileSaverLauncher(
+    onError: (FileKitDialogException) -> Unit,
     onResult: (PlatformFile?) -> Unit,
 ): FileSaverLauncher {
     val launcher = rememberFileKitSaverLauncher(
         dialogSettings = FileKitDialogSettings.createDefault(),
+        onError = onError,
         onResult = onResult,
     )
 

--- a/sample/shared/src/jvmMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/sharefile/ShareFileLauncher.jvm.kt
+++ b/sample/shared/src/jvmMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/sharefile/ShareFileLauncher.jvm.kt
@@ -3,9 +3,12 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.sharefile
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 
 @Composable
-internal actual fun rememberShareFileLauncher(): ShareFileLauncher = remember {
+internal actual fun rememberShareFileLauncher(
+    onError: (FileKitDialogException) -> Unit,
+): ShareFileLauncher = remember {
     object : ShareFileLauncher {
         override val isSupported: Boolean = false
 

--- a/sample/shared/src/macosMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/camerapicker/CameraPickerLauncher.macos.kt
+++ b/sample/shared/src/macosMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/camerapicker/CameraPickerLauncher.macos.kt
@@ -3,9 +3,11 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.camerapicker
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 
 @Composable
 internal actual fun rememberCameraPickerLauncher(
+    onError: (FileKitDialogException) -> Unit,
     onResult: (PlatformFile?) -> Unit,
 ): CameraPickerLauncher = remember {
     object : CameraPickerLauncher {

--- a/sample/shared/src/macosMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.macos.kt
+++ b/sample/shared/src/macosMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.macos.kt
@@ -3,15 +3,18 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.filesaver
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.compose.rememberFileSaverLauncher as rememberFileKitSaverLauncher
 
 @Composable
 internal actual fun rememberFileSaverLauncher(
+    onError: (FileKitDialogException) -> Unit,
     onResult: (PlatformFile?) -> Unit,
 ): FileSaverLauncher {
     val launcher = rememberFileKitSaverLauncher(
         dialogSettings = FileKitDialogSettings.createDefault(),
+        onError = onError,
         onResult = onResult,
     )
 

--- a/sample/shared/src/macosMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/sharefile/ShareFileLauncher.macos.kt
+++ b/sample/shared/src/macosMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/sharefile/ShareFileLauncher.macos.kt
@@ -3,9 +3,12 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.sharefile
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 
 @Composable
-internal actual fun rememberShareFileLauncher(): ShareFileLauncher = remember {
+internal actual fun rememberShareFileLauncher(
+    onError: (FileKitDialogException) -> Unit,
+): ShareFileLauncher = remember {
     object : ShareFileLauncher {
         override val isSupported: Boolean = false
 

--- a/sample/shared/src/mobileMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/camerapicker/CameraPickerLauncher.mobile.kt
+++ b/sample/shared/src/mobileMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/camerapicker/CameraPickerLauncher.mobile.kt
@@ -4,13 +4,18 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.dialogs.FileKitCameraFacing
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.compose.rememberCameraPickerLauncher as rememberFileKitCameraPickerLauncher
 
 @Composable
 internal actual fun rememberCameraPickerLauncher(
+    onError: (FileKitDialogException) -> Unit,
     onResult: (PlatformFile?) -> Unit,
 ): CameraPickerLauncher {
-    val launcher = rememberFileKitCameraPickerLauncher(onResult = onResult)
+    val launcher = rememberFileKitCameraPickerLauncher(
+        onError = onError,
+        onResult = onResult,
+    )
 
     return remember(launcher) {
         object : CameraPickerLauncher {

--- a/sample/shared/src/mobileMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.mobile.kt
+++ b/sample/shared/src/mobileMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.mobile.kt
@@ -3,15 +3,18 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.filesaver
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.compose.rememberFileSaverLauncher as rememberFileKitSaverLauncher
 
 @Composable
 internal actual fun rememberFileSaverLauncher(
+    onError: (FileKitDialogException) -> Unit,
     onResult: (PlatformFile?) -> Unit,
 ): FileSaverLauncher {
     val launcher = rememberFileKitSaverLauncher(
         dialogSettings = FileKitDialogSettings.createDefault(),
+        onError = onError,
         onResult = onResult,
     )
 

--- a/sample/shared/src/mobileMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/sharefile/ShareFileLauncher.mobile.kt
+++ b/sample/shared/src/mobileMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/sharefile/ShareFileLauncher.mobile.kt
@@ -3,11 +3,14 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.sharefile
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 import io.github.vinceglb.filekit.dialogs.compose.rememberShareFileLauncher as rememberFileKitShareLauncher
 
 @Composable
-internal actual fun rememberShareFileLauncher(): ShareFileLauncher {
-    val launcher = rememberFileKitShareLauncher()
+internal actual fun rememberShareFileLauncher(
+    onError: (FileKitDialogException) -> Unit,
+): ShareFileLauncher {
+    val launcher = rememberFileKitShareLauncher(onError = onError)
 
     return remember(launcher) {
         object : ShareFileLauncher {

--- a/sample/shared/src/webMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/camerapicker/CameraPickerLauncher.web.kt
+++ b/sample/shared/src/webMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/camerapicker/CameraPickerLauncher.web.kt
@@ -3,9 +3,11 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.camerapicker
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 
 @Composable
 internal actual fun rememberCameraPickerLauncher(
+    onError: (FileKitDialogException) -> Unit,
     onResult: (PlatformFile?) -> Unit,
 ): CameraPickerLauncher = remember {
     object : CameraPickerLauncher {

--- a/sample/shared/src/webMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.web.kt
+++ b/sample/shared/src/webMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/filesaver/FileSaverLauncher.web.kt
@@ -3,9 +3,11 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.filesaver
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 
 @Composable
 internal actual fun rememberFileSaverLauncher(
+    onError: (FileKitDialogException) -> Unit,
     onResult: (PlatformFile?) -> Unit,
 ): FileSaverLauncher = remember {
     object : FileSaverLauncher {

--- a/sample/shared/src/webMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/sharefile/ShareFileLauncher.web.kt
+++ b/sample/shared/src/webMain/kotlin/io/github/vinceglb/filekit/sample/shared/ui/screens/sharefile/ShareFileLauncher.web.kt
@@ -3,9 +3,12 @@ package io.github.vinceglb.filekit.sample.shared.ui.screens.sharefile
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import io.github.vinceglb.filekit.PlatformFile
+import io.github.vinceglb.filekit.dialogs.FileKitDialogException
 
 @Composable
-internal actual fun rememberShareFileLauncher(): ShareFileLauncher = remember {
+internal actual fun rememberShareFileLauncher(
+    onError: (FileKitDialogException) -> Unit,
+): ShareFileLauncher = remember {
     object : ShareFileLauncher {
         override val isSupported: Boolean = false
 

--- a/specs/compose-launcher-error-management/ABI-VERIFICATION.md
+++ b/specs/compose-launcher-error-management/ABI-VERIFICATION.md
@@ -1,0 +1,82 @@
+# Compose Launcher ABI Verification
+
+Baseline: `3380b8c8`
+
+The baseline and current artifacts were built separately. Rebuilding samples is not treated as binary-compatibility evidence.
+
+```bash
+git worktree add /tmp/filekit-abi-3380b8c8 3380b8c8
+(cd /tmp/filekit-abi-3380b8c8 && ./gradlew assemble)
+./gradlew assemble
+
+javap -classpath filekit-dialogs-compose/build/libs/filekit-dialogs-compose-jvm.jar \
+  -s -p io.github.vinceglb.filekit.dialogs.compose.FileKitComposeKt
+
+$KONAN_HOME/bin/klib dump-metadata \
+  filekit-dialogs-compose/build/libs/filekit-dialogs-compose-wasm-js.klib
+$KONAN_HOME/bin/klib dump-metadata \
+  filekit-dialogs-compose/build/classes/kotlin/iosSimulatorArm64/main/klib/filekit-dialogs-compose
+```
+
+The same `javap` and `klib dump-metadata` commands were run under `/tmp/filekit-abi-3380b8c8`. Every baseline line below was then matched byte-for-byte in the current output. Current output may contain additive declarations.
+
+## JVM baseline descriptors
+
+```text
+FileKitPickerException|(Ljava/lang/String;)V
+FileKitPickerException|(Ljava/lang/String;Ljava/lang/Throwable;)V
+FileKitComposeKt|(Lio/github/vinceglb/filekit/dialogs/FileKitType;Lio/github/vinceglb/filekit/dialogs/FileKitMode;Lio/github/vinceglb/filekit/PlatformFile;Lio/github/vinceglb/filekit/dialogs/FileKitDialogSettings;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lio/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher;
+FileKitComposeKt|(Lio/github/vinceglb/filekit/dialogs/FileKitType;Lio/github/vinceglb/filekit/dialogs/FileKitMode;Lio/github/vinceglb/filekit/PlatformFile;Lio/github/vinceglb/filekit/dialogs/FileKitDialogSettings;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lio/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher;
+FileKitComposeKt|(Lio/github/vinceglb/filekit/dialogs/FileKitType;Lio/github/vinceglb/filekit/PlatformFile;Lio/github/vinceglb/filekit/dialogs/FileKitDialogSettings;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lio/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher;
+FileKitComposeKt|(Lio/github/vinceglb/filekit/dialogs/FileKitType;Lio/github/vinceglb/filekit/PlatformFile;Lio/github/vinceglb/filekit/dialogs/FileKitDialogSettings;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lio/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher;
+FileKitCompose_nonAndroidKt|(Lio/github/vinceglb/filekit/PlatformFile;Lio/github/vinceglb/filekit/dialogs/FileKitDialogSettings;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lio/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher;
+FileKitCompose_nonWebKt|(Lio/github/vinceglb/filekit/dialogs/FileKitDialogSettings;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)Lio/github/vinceglb/filekit/dialogs/compose/SaverResultLauncher;
+FileKitCompose_jvmKt|(Landroidx/compose/ui/window/WindowScope;Lio/github/vinceglb/filekit/dialogs/FileKitType;Lio/github/vinceglb/filekit/dialogs/FileKitMode;Lio/github/vinceglb/filekit/PlatformFile;Lio/github/vinceglb/filekit/dialogs/FileKitDialogSettings;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lio/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher;
+FileKitCompose_jvmKt|(Landroidx/compose/ui/window/WindowScope;Lio/github/vinceglb/filekit/dialogs/FileKitType;Lio/github/vinceglb/filekit/dialogs/FileKitMode;Lio/github/vinceglb/filekit/PlatformFile;Lio/github/vinceglb/filekit/dialogs/FileKitDialogSettings;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lio/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher;
+FileKitCompose_jvmKt|(Landroidx/compose/ui/window/WindowScope;Lio/github/vinceglb/filekit/dialogs/FileKitType;Lio/github/vinceglb/filekit/PlatformFile;Lio/github/vinceglb/filekit/dialogs/FileKitDialogSettings;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lio/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher;
+FileKitCompose_jvmKt|(Landroidx/compose/ui/window/WindowScope;Lio/github/vinceglb/filekit/dialogs/FileKitType;Lio/github/vinceglb/filekit/PlatformFile;Lio/github/vinceglb/filekit/dialogs/FileKitDialogSettings;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lio/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher;
+FileKitCompose_jvmKt|(Landroidx/compose/ui/window/WindowScope;Lio/github/vinceglb/filekit/PlatformFile;Lio/github/vinceglb/filekit/dialogs/FileKitDialogSettings;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lio/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher;
+FileKitCompose_jvmKt|(Landroidx/compose/ui/window/WindowScope;Lio/github/vinceglb/filekit/dialogs/FileKitDialogSettings;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lio/github/vinceglb/filekit/dialogs/compose/SaverResultLauncher;
+```
+
+## KLIB baseline declarations
+
+Wasm baseline (5 declarations):
+
+```text
+public final fun <T#0 /* PickerResult */, T#1 /* ConsumedResult */> rememberFilePickerLauncher(type: io/github/vinceglb/filekit/dialogs/FileKitType /* = ... */, mode: io/github/vinceglb/filekit/dialogs/FileKitMode<T#0, T#1>, directory: io/github/vinceglb/filekit/PlatformFile? /* = ... */, dialogSettings: io/github/vinceglb/filekit/dialogs/FileKitDialogSettings /* = ... */, onResult: kotlin/Function1<T#1, kotlin/Unit>): io/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher
+public final fun <T#0 /* PickerResult */, T#1 /* ConsumedResult */> rememberFilePickerLauncher(type: io/github/vinceglb/filekit/dialogs/FileKitType /* = ... */, mode: io/github/vinceglb/filekit/dialogs/FileKitMode<T#0, T#1>, directory: io/github/vinceglb/filekit/PlatformFile? /* = ... */, dialogSettings: io/github/vinceglb/filekit/dialogs/FileKitDialogSettings /* = ... */, onError: kotlin/Function1<io/github/vinceglb/filekit/dialogs/FileKitPickerException, kotlin/Unit>, onResult: kotlin/Function1<T#1, kotlin/Unit>): io/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher
+public final fun rememberFilePickerLauncher(type: io/github/vinceglb/filekit/dialogs/FileKitType /* = ... */, directory: io/github/vinceglb/filekit/PlatformFile? /* = ... */, dialogSettings: io/github/vinceglb/filekit/dialogs/FileKitDialogSettings /* = ... */, onResult: kotlin/Function1<io/github/vinceglb/filekit/PlatformFile?, kotlin/Unit>): io/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher
+public final fun rememberFilePickerLauncher(type: io/github/vinceglb/filekit/dialogs/FileKitType /* = ... */, directory: io/github/vinceglb/filekit/PlatformFile? /* = ... */, dialogSettings: io/github/vinceglb/filekit/dialogs/FileKitDialogSettings /* = ... */, onError: kotlin/Function1<io/github/vinceglb/filekit/dialogs/FileKitPickerException, kotlin/Unit>, onResult: kotlin/Function1<io/github/vinceglb/filekit/PlatformFile?, kotlin/Unit>): io/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher
+public final fun rememberDirectoryPickerLauncher(directory: io/github/vinceglb/filekit/PlatformFile? /* = ... */, dialogSettings: io/github/vinceglb/filekit/dialogs/FileKitDialogSettings /* = ... */, onResult: kotlin/Function1<io/github/vinceglb/filekit/PlatformFile?, kotlin/Unit>): io/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher
+```
+
+iOS simulator ARM64 baseline (8 declarations):
+
+```text
+public final fun <T#0 /* PickerResult */, T#1 /* ConsumedResult */> rememberFilePickerLauncher(type: io/github/vinceglb/filekit/dialogs/FileKitType /* = ... */, mode: io/github/vinceglb/filekit/dialogs/FileKitMode<T#0, T#1>, directory: io/github/vinceglb/filekit/PlatformFile? /* = ... */, dialogSettings: io/github/vinceglb/filekit/dialogs/FileKitDialogSettings /* = ... */, onResult: kotlin/Function1<T#1, kotlin/Unit>): io/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher
+public final fun <T#0 /* PickerResult */, T#1 /* ConsumedResult */> rememberFilePickerLauncher(type: io/github/vinceglb/filekit/dialogs/FileKitType /* = ... */, mode: io/github/vinceglb/filekit/dialogs/FileKitMode<T#0, T#1>, directory: io/github/vinceglb/filekit/PlatformFile? /* = ... */, dialogSettings: io/github/vinceglb/filekit/dialogs/FileKitDialogSettings /* = ... */, onError: kotlin/Function1<io/github/vinceglb/filekit/dialogs/FileKitPickerException, kotlin/Unit>, onResult: kotlin/Function1<T#1, kotlin/Unit>): io/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher
+public final fun rememberFilePickerLauncher(type: io/github/vinceglb/filekit/dialogs/FileKitType /* = ... */, directory: io/github/vinceglb/filekit/PlatformFile? /* = ... */, dialogSettings: io/github/vinceglb/filekit/dialogs/FileKitDialogSettings /* = ... */, onResult: kotlin/Function1<io/github/vinceglb/filekit/PlatformFile?, kotlin/Unit>): io/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher
+public final fun rememberFilePickerLauncher(type: io/github/vinceglb/filekit/dialogs/FileKitType /* = ... */, directory: io/github/vinceglb/filekit/PlatformFile? /* = ... */, dialogSettings: io/github/vinceglb/filekit/dialogs/FileKitDialogSettings /* = ... */, onError: kotlin/Function1<io/github/vinceglb/filekit/dialogs/FileKitPickerException, kotlin/Unit>, onResult: kotlin/Function1<io/github/vinceglb/filekit/PlatformFile?, kotlin/Unit>): io/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher
+public final fun rememberCameraPickerLauncher(openCameraSettings: io/github/vinceglb/filekit/dialogs/FileKitOpenCameraSettings /* = ... */, onResult: kotlin/Function1<io/github/vinceglb/filekit/PlatformFile?, kotlin/Unit>): io/github/vinceglb/filekit/dialogs/compose/PhotoResultLauncher
+public final fun rememberShareFileLauncher(shareSettings: io/github/vinceglb/filekit/dialogs/FileKitShareSettings /* = ... */): io/github/vinceglb/filekit/dialogs/compose/ShareResultLauncher
+public final fun rememberDirectoryPickerLauncher(directory: io/github/vinceglb/filekit/PlatformFile? /* = ... */, dialogSettings: io/github/vinceglb/filekit/dialogs/FileKitDialogSettings /* = ... */, onResult: kotlin/Function1<io/github/vinceglb/filekit/PlatformFile?, kotlin/Unit>): io/github/vinceglb/filekit/dialogs/compose/PickerResultLauncher
+public final fun rememberFileSaverLauncher(dialogSettings: io/github/vinceglb/filekit/dialogs/FileKitDialogSettings, onResult: kotlin/Function1<io/github/vinceglb/filekit/PlatformFile?, kotlin/Unit>): io/github/vinceglb/filekit/dialogs/compose/SaverResultLauncher
+```
+
+The current Wasm KLIB retained all 5 declarations. The current iOS KLIB retained all 8 and added exactly 4 error-aware declarations.
+
+## Precompiled JVM consumer
+
+[`PrecompiledConsumer.java`](abi/PrecompiledConsumer.java) was compiled with `javac` against the baseline core/dialogs/Compose JARs. The resulting class was then run, without recompilation, against the current JARs. It resolved the legacy directory-picker, file-saver, and JVM `WindowScope` methods and exited with status 0.
+
+## Source call shapes
+
+Compile-only tests cover named arguments and trailing lambdas for legacy and error-aware file, directory, saver, camera, share, and JVM `WindowScope` launchers, including generic `FileKitMode` overloads. They include the exact compatibility call:
+
+```kotlin
+rememberFilePickerLauncher(
+    type = FileKitType.Image,
+    onResult = ::handleResult,
+)
+```

--- a/specs/compose-launcher-error-management/PLAN.md
+++ b/specs/compose-launcher-error-management/PLAN.md
@@ -1,0 +1,357 @@
+# Compose Launcher Error Management
+
+## Status
+
+Approved after independent design review. Implementation is complete and awaiting independent code review.
+
+Baseline: `main` at `3380b8c8` (merge of PR #631).
+
+## Objective
+
+Give every callback-style Compose launcher a consistent, explicit failure path without changing the throwing behavior of FileKit's suspend functions, conflating user cancellation with failure, swallowing coroutine cancellation, or breaking applications compiled against existing launcher overloads.
+
+The implementation should make this invariant true across every platform adapter for a supported launch while no earlier launch from the same launcher is pending:
+
+> A launch terminates exactly once as a successful result, user cancellation, coroutine cancellation, or an expected operational failure.
+
+## Verified Current Behavior
+
+- `rememberFilePickerLauncher` now catches its documented `FileKitPickerException` and can route it to `onError`. Its original overloads remain as binary-compatible adapters that ignore that error.
+- Non-Android `rememberDirectoryPickerLauncher`, JVM/Native `rememberFileSaverLauncher`, iOS `rememberCameraPickerLauncher`, and mobile `rememberShareFileLauncher` each start a suspend operation in a Compose-owned coroutine without an error channel.
+- Those underlying operations have real failure paths. Examples include unsupported or failed desktop native dialogs, iOS file-saver temporary-file preparation, camera destination handling, and share-sheet launch failures.
+- Android Compose launchers use Activity Result adapters rather than the suspend implementations. Several launch failures are currently converted to `null`, making them indistinguishable from user cancellation; the Android file saver does not consistently guard synchronous launch failure.
+- Several iOS operations present through a nullable view controller from inside a suspended continuation. A missing presenter can currently result in a silent no-op or a continuation that never completes.
+- Existing public overload descriptors must remain present. Adding a defaulted `onError` parameter to an existing function is source-compatible after recompilation but is not sufficient for already-compiled JVM or KLIB consumers.
+
+## Design Alternatives
+
+### 1. One ambient Compose error provider
+
+Install an application- or subtree-wide handler through a `CompositionLocal`, then let all launchers report to it implicitly.
+
+This has the smallest public surface and supports centralized logging, but it makes local behavior harder to discover, introduces precedence rules beside the already-published file-picker `onError`, and changes error handling through ambient state.
+
+**Decision:** Reject as the primary interface. It can be reconsidered later as an additive convenience if repeated per-launcher handlers become a demonstrated problem.
+
+### 2. A failure envelope with extensible codes and platform details
+
+Return a non-throwable object containing operation identifiers, stable failure codes, the cause, and optional platform details.
+
+This is flexible for telemetry, but exposes several new concepts before FileKit has evidence that callers need programmatic recovery by failure code. It also creates two error models: exceptions for suspend callers and envelopes for Compose callers.
+
+**Decision:** Reject for now. Preserve the same exception model at both seams.
+
+### 3. Explicit `onError` overloads backed by one internal execution module
+
+Keep default launcher usage unchanged and add overloads with a required `onError` parameter immediately before `onResult`. Normalize only expected dialog-operation failures into one dialog-specific exception hierarchy and route them through a common internal runner.
+
+This follows the interface already established for `rememberFilePickerLauncher`, keeps behavior visible at the call site, and concentrates cancellation and callback-dispatch rules in one module.
+
+**Decision:** Adopt.
+
+## Public Error Contract
+
+### Dialog exception
+
+Add one public, open `FileKitDialogException` extending `FileKitException` as a narrow recoverability marker:
+
+```kotlin
+public open class FileKitDialogException : FileKitException {
+    public constructor(message: String)
+    public constructor(message: String, cause: Throwable)
+}
+```
+
+Change `FileKitPickerException` to extend `FileKitDialogException`, while preserving both existing constructor descriptors.
+
+The new type intentionally has no operation enum, failure code, or platform details. The launcher call site already identifies the operation. Its purpose is only to distinguish callback-safe operational failures from unrelated `FileKitException` subclasses such as initialization, configuration, bookmark, and filesystem failures.
+
+This gives callers one reusable handler:
+
+```kotlin
+fun handleDialogError(error: FileKitDialogException) {
+    logger.error(error)
+}
+```
+
+Because function parameters are contravariant, that handler can also be passed to the existing file-picker overload that expects `(FileKitPickerException) -> Unit`.
+
+Changing the direct superclass is a go/no-go requirement for this interface. Before broad implementation edits, verify that the existing `FileKitPickerException` constructors and public launcher descriptors remain linkable for JVM and KLIB consumers. If that prototype fails, stop, revise this public contract, and repeat plan review; do not ship two unrelated exception families or an unsafe cast.
+
+### Failure classification
+
+`FileKitDialogException` represents an expected operational failure of opening, presenting, resolving, or completing a dialog-backed operation. Platform adapters must preserve the original exception as `cause` when one exists.
+
+The following are not dialog failures and must not be routed to `onError`:
+
+- user cancellation;
+- coroutine `CancellationException`;
+- invalid arguments and unsupported programmer-selected modes;
+- initialization or configuration errors such as `FileKitNotInitializedException`;
+- Android `FileProvider` authority/path configuration failures;
+- exceptions thrown by the application's `onResult` or `onError` callback;
+- VM errors, linkage errors, assertions, and other unexpected defects.
+
+Do not catch every `Throwable` or every `Exception` at the Compose seam. Convert known operational failures at the closest platform adapter, so the common runner only needs to catch `FileKitDialogException`.
+
+## Compose Interface
+
+Keep every existing overload unchanged and add error-aware siblings:
+
+```kotlin
+@Composable
+public fun rememberDirectoryPickerLauncher(
+    directory: PlatformFile? = null,
+    dialogSettings: FileKitDialogSettings = FileKitDialogSettings.createDefault(),
+    onError: (FileKitDialogException) -> Unit,
+    onResult: (PlatformFile?) -> Unit,
+): PickerResultLauncher
+
+@Composable
+public fun rememberFileSaverLauncher(
+    dialogSettings: FileKitDialogSettings,
+    onError: (FileKitDialogException) -> Unit,
+    onResult: (PlatformFile?) -> Unit,
+): SaverResultLauncher
+
+@Composable
+public fun rememberCameraPickerLauncher(
+    openCameraSettings: FileKitOpenCameraSettings = FileKitOpenCameraSettings.createDefault(),
+    onError: (FileKitDialogException) -> Unit,
+    onResult: (PlatformFile?) -> Unit,
+): PhotoResultLauncher
+
+@Composable
+public fun rememberShareFileLauncher(
+    shareSettings: FileKitShareSettings = FileKitShareSettings.createDefault(),
+    onError: (FileKitDialogException) -> Unit,
+): ShareResultLauncher
+```
+
+The error parameter is required on the new overloads. Do not replace the old overload with a defaulted parameter.
+
+Mirror the directory-picker and file-saver overloads on the JVM `WindowScope` adapters. Preserve the current file-picker overloads and their narrower `FileKitPickerException` callback.
+
+## Observable Outcome Rules
+
+For every error-aware launcher:
+
+1. Success invokes `onResult` exactly once.
+2. User cancellation invokes `onResult(null)` exactly once for result-bearing launchers.
+3. Expected operational failure invokes `onError` exactly once and never invokes `onResult`.
+4. Coroutine cancellation propagates and invokes neither callback.
+5. An exception thrown by either application callback propagates unchanged and is never fed back into `onError`.
+6. Exhausting a platform fallback is an error; choosing to cancel an opened system dialog is cancellation.
+
+For compatibility overloads:
+
+- Keep the merged file-picker behavior: ignore `FileKitPickerException` and do not invoke `onResult` for that failure.
+- For directory, saver, and camera launchers, map an expected failure to `onResult(null)`. This preserves Android's existing observable behavior while replacing non-Android coroutine crashes with the only failure representation available to those legacy interfaces.
+- For the share launcher, ignore the expected failure because the legacy interface has no callback.
+
+Document this compatibility behavior explicitly. New code that must distinguish cancellation from failure uses the error-aware overload.
+
+For state-tracking file-picker modes, continue delivering selection-processing failures through `FileKitPickerState.Failed`. The launcher's `onError` is for failures that occur before a state flow can be handed to the caller; do not report the same failure through both channels.
+
+## Internal Module and Seam
+
+Add a reusable internal Compose execution module in `commonMain` for directory, saver, camera, and share launchers:
+
+```kotlin
+internal suspend fun <Result> runDialogLauncher(
+    openDialog: suspend () -> Result,
+    onError: (FileKitDialogException) -> Unit,
+    onResult: (Result) -> Unit,
+)
+```
+
+Its implementation must isolate the dialog call from callback invocation:
+
+1. Execute `openDialog` inside the `try` block.
+2. Catch only `FileKitDialogException`, invoke `onError`, and return.
+3. Invoke `onResult` after the `try` block.
+
+This placement ensures callback exceptions are not reclassified. `CancellationException` propagates naturally because it is not a `FileKitDialogException`; add an explicit regression test so this remains an intentional invariant.
+
+Keep the existing picker-specific `runFilePickerLauncher` adapter because its public error callback is narrower: `(FileKitPickerException) -> Unit`. Do not pass that callback to the broader runner and do not use casts. Every operational failure in the file-picker path, including missing iOS presenters and exhausted Android launch fallbacks, must be normalized to `FileKitPickerException` rather than only the base class.
+
+Keep file-picker mode consumption outside the protected dialog call so exceptions produced by application collection or callbacks are not caught.
+
+All Compose implementations must read the latest callbacks through `rememberUpdatedState`, including `onError`.
+
+## Platform Adapter Changes
+
+### Android
+
+- Replace Boolean-only `launchPickerSafely` and `launchCameraSafely` outcomes with an internal result that distinguishes launched, fallback-required, and failed-with-cause.
+- File/gallery picker: attempt the existing fallback first and report a dialog failure only when every viable launcher fails.
+- Directory picker: convert `ActivityNotFoundException` into a directory-picker failure.
+- File saver: guard synchronous `launcher.launch` failures and report them instead of letting them escape.
+- Camera: keep runtime permission denial as cancellation; convert `ActivityNotFoundException`, launch-time `SecurityException`, and genuine destination I/O preparation failures into camera-picker failures. Let `FileProvider.getUriForFile` authority/path configuration errors propagate as configuration errors.
+- Share: convert chooser creation or `startActivity` launch failures into share failures.
+- Preserve pending-launch cleanup before dispatching either callback so a failed launch cannot later consume a stale Activity Result.
+
+### iOS
+
+- Resolve and require the presenter before entering `suspendCancellableCoroutine`. A missing presenter is a dialog failure; no continuation may be left pending because a nullable presenter was unavailable.
+- Directory and document picker: cancellation remains `null`; synchronously detectable setup failures become dialog failures.
+- File saver: convert temporary-directory, URL-construction, empty-file-write, and synchronously detectable setup failures into file-saver failures.
+- Camera: cancellation and permission/user dismissal remain `null`; destination encoding or write failure becomes a camera-picker failure instead of `null`.
+- Share: a missing presenter becomes a share failure rather than a silent return.
+- Do not claim generic UIKit presentation-failure detection: `presentViewController` has no failure callback. Only failures FileKit can observe synchronously or through its delegates belong in this contract.
+- Keep each delegate/controller strongly owned for the supported single in-flight launch and guard completion so success, dismissal, and coroutine cancellation cannot complete the same continuation twice. Register cancellation cleanup before presentation.
+
+The existing interface does not define concurrent or re-entrant launches from the same launcher. This work must document that only one launch may be pending per launcher and must prevent an overlapping iOS launch from overwriting the active delegate/continuation owner. A second launch should fail immediately as an `IllegalStateException`, which is a programmer error and is not routed to `onError`. Add a deterministic ownership-policy test. General multi-launch support is out of scope.
+
+### JVM, macOS Native, Windows Native, JS, and WASM
+
+- Convert known native dialog initialization, presentation, and result-resolution failures into the appropriate `FileKitDialogException`, preserving the cause.
+- Treat genuinely unsupported runtime paths as operational failures when they can occur through a documented launcher configuration; keep invalid caller arguments as programming errors.
+- Preserve user-dismissal behavior as `null`.
+- Do not change native-dialog threading, parent-window selection, picker modality, browser activation rules, or result ordering as part of this work.
+
+## Implementation Plan
+
+### 1. Establish and verify the exception interface
+
+Prototype and verify the superclass change first. Then add the dialog exception under `filekit-dialogs/src/commonMain` and adapt `FileKitPickerException`.
+
+Add KDoc to every suspend dialog operation documenting its dialog failure and cancellation behavior. Suspend callers continue receiving exceptions; no suspend function gains a `Result` return type.
+
+### 2. Normalize expected failures at platform seams
+
+Update the Android, iOS, JVM, macOS Native, Windows Native, JS, and WASM adapters operation by operation. Replace raw operational `IllegalStateException`, `RuntimeException`, `ActivityNotFoundException`, and relevant `SecurityException` paths with `FileKitDialogException` while preserving their cause.
+
+Do not mechanically replace every raw exception in a platform file. Classify each throw site against the failure rules above.
+
+### 3. Generalize callback execution
+
+Add the common runner and migrate non-Android directory, saver, camera, and share launchers through it. Keep the picker-specific runner and its typed callback. Keep operation-specific result consumption outside the protected call.
+
+### 4. Add error-aware overloads and compatibility adapters
+
+Add the new common/non-Web/mobile declarations, all required actual implementations, and the JVM `WindowScope` forwarding overloads. Keep every existing declaration as a real function with its original descriptor.
+
+Implement the legacy outcome mappings defined above instead of relying on a default parameter.
+
+### 5. Align Android's direct Activity Result adapters
+
+Route Android synchronous launch failures into the same caller-visible contract, preserving fallback order, permission-denial behavior, process-recreation state, and pending-state cleanup.
+
+### 6. Update examples and documentation
+
+- Update the directory picker, file saver, camera picker, and share file documentation with error-aware examples and the cancellation distinction.
+- Update representative shared sample screens for each operation to display or log `FileKitDialogException` rather than silently failing.
+- Keep the short quick-start examples on the compatibility overload so the default case remains trivial.
+- Document that one `(FileKitDialogException) -> Unit` handler can be reused across launchers, including the file picker.
+
+## Test Plan
+
+### Common tests
+
+Test the internal runner through its interface:
+
+1. Success invokes only `onResult`.
+2. `FileKitDialogException` invokes only `onError`.
+3. `CancellationException` propagates and invokes neither callback.
+4. An unexpected exception propagates.
+5. An exception from `onResult` propagates and does not invoke `onError`.
+6. An exception from `onError` propagates exactly once.
+7. The original cause survives normalization.
+
+Add compile-time call-shape coverage for trailing-lambda and named-parameter uses of every legacy and error-aware overload.
+
+### Android host tests
+
+Cover:
+
+- primary picker failure followed by successful fallback;
+- exhaustion of both picker launchers reports failure;
+- directory and saver Activity Result launch failure;
+- camera permission denial versus camera launch failure;
+- destination URI failure;
+- share launch failure;
+- pending state is cleared before failure dispatch;
+- legacy overloads retain their documented null/ignore behavior.
+
+### Native and desktop tests
+
+- Add an iOS-testable presenter-resolution seam proving a missing presenter completes with failure instead of hanging.
+- Add iOS file-saver preparation and camera-write outcome tests without presenting real UI.
+- Add an iOS ownership-policy test proving an overlapping launch cannot overwrite the active continuation owner.
+- Add JVM/native tests that map representative dialog initialization/result failures while preserving cancellation.
+- Ensure at least one non-JVM target runs the common runner and exception tests.
+
+### Compatibility verification
+
+Before changing implementation behavior:
+
+1. Record the JVM descriptors and KLIB declarations for all existing launchers at baseline `3380b8c8`.
+2. After the change, prove those declarations still exist unchanged.
+3. Compile a small consumer against the baseline artifacts and run/link it against the new artifacts for JVM; perform the equivalent KLIB compatibility check available in the project toolchain.
+4. Cover the exact named-parameter call shape:
+
+   ```kotlin
+   rememberFilePickerLauncher(
+       type = FileKitType.Image,
+       onResult = ::handleResult,
+   )
+   ```
+
+Do not treat recompiling the samples as proof of binary compatibility.
+
+## Acceptance Criteria
+
+- Every Compose launcher offers an explicit error-aware interface.
+- Existing launcher overloads and their compiled descriptors remain available.
+- A single `FileKitDialogException` handler can be reused across all launchers.
+- User cancellation and expected operational failure are distinguishable through the new overloads.
+- Coroutine cancellation and unexpected defects are never swallowed.
+- Result and error callbacks are mutually exclusive and invoked at most once per launch.
+- Missing iOS presenters cannot leave a suspend call pending indefinitely.
+- Android only reports picker launch failure after configured fallbacks are exhausted.
+- Suspend APIs continue throwing and document their expected dialog failure.
+- Relevant docs and sample screens demonstrate the new contract.
+- Focused tests, module checks, every CI target represented in `.github/workflows/ci.yml`, formatting, root `check`, and root `assemble` pass.
+
+## Verification
+
+Run at minimum:
+
+```bash
+./gradlew :filekit-dialogs:check :filekit-dialogs-compose:check --no-daemon
+./gradlew testAndroidHostTest --no-daemon
+./gradlew jvmTest --no-daemon
+./gradlew iosSimulatorArm64Test --no-daemon
+./gradlew macosArm64Test --no-daemon
+./gradlew linuxX64Test --no-daemon
+./gradlew check assemble --no-daemon
+
+ktlint '**/*.kt' '**/*.kts' '!**/build/**' \
+  -R ktlint-compose-0.6.0-all.jar
+
+git diff --check
+```
+
+Use the ktlint and Compose-rule versions pinned by `.github/workflows/ci.yml`.
+
+Perform supplemental manual smoke tests for one launcher on Android and iOS. Manual interaction supplements the deterministic adapter tests; it does not replace them.
+
+## Pull Request Structure
+
+Ship this as one cohesive PR with two reviewable commits:
+
+1. **Dialog failure contract and platform normalization** in `filekit-dialogs`, including suspend KDoc and platform tests.
+2. **Compose launcher error callbacks** in `filekit-dialogs-compose`, including compatibility overloads, samples, docs, and callback tests.
+
+Keeping both commits in one PR allows CI and reviewers to validate the complete caller-visible contract while preserving a clear internal seam between suspend error normalization and Compose callback adaptation.
+
+## Out of Scope
+
+- Replacing nullable cancellation results with a new sealed result type.
+- Adding retries, fallback UI, logging, crash reporting, or user-facing error messages inside FileKit.
+- Adding an ambient Compose error provider.
+- Exposing native status codes or platform-specific error-detail types.
+- Supporting multiple concurrent launches from the same launcher.
+- Changing picker selection modes, ordering, limits, permissions policy, dialog ownership, or lifecycle guidance unrelated to terminal failure.
+- Catching callback exceptions or unexpected `Throwable`s merely to keep the application alive.

--- a/specs/compose-launcher-error-management/PLAN.md
+++ b/specs/compose-launcher-error-management/PLAN.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Approved after independent design review. Implementation is complete and awaiting independent code review.
+Implemented and approved after independent specification and standards reviews. Local and hosted verification are complete.
 
 Baseline: `main` at `3380b8c8` (merge of PR #631).
 

--- a/specs/compose-launcher-error-management/abi/PrecompiledConsumer.java
+++ b/specs/compose-launcher-error-management/abi/PrecompiledConsumer.java
@@ -1,0 +1,63 @@
+import androidx.compose.runtime.Composer;
+import androidx.compose.ui.window.WindowScope;
+import io.github.vinceglb.filekit.PlatformFile;
+import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings;
+import io.github.vinceglb.filekit.dialogs.FileKitPickerException;
+import io.github.vinceglb.filekit.exceptions.FileKitException;
+import kotlin.jvm.functions.Function1;
+
+public final class PrecompiledConsumer {
+    public static void main(String[] args) throws ReflectiveOperationException {
+        FileKitException failure = new FileKitPickerException("picker failed");
+        if (!"picker failed".equals(failure.getMessage())) {
+            throw new AssertionError("Unexpected message: " + failure.getMessage());
+        }
+
+        Class<?> nonAndroid = Class.forName(
+            "io.github.vinceglb.filekit.dialogs.compose.FileKitCompose_nonAndroidKt"
+        );
+        nonAndroid.getDeclaredMethod(
+            "rememberDirectoryPickerLauncher",
+            PlatformFile.class,
+            FileKitDialogSettings.class,
+            Function1.class,
+            Composer.class,
+            int.class,
+            int.class
+        );
+
+        Class<?> nonWeb = Class.forName(
+            "io.github.vinceglb.filekit.dialogs.compose.FileKitCompose_nonWebKt"
+        );
+        nonWeb.getDeclaredMethod(
+            "rememberFileSaverLauncher",
+            FileKitDialogSettings.class,
+            Function1.class,
+            Composer.class,
+            int.class
+        );
+
+        Class<?> jvm = Class.forName(
+            "io.github.vinceglb.filekit.dialogs.compose.FileKitCompose_jvmKt"
+        );
+        jvm.getDeclaredMethod(
+            "rememberDirectoryPickerLauncher",
+            WindowScope.class,
+            PlatformFile.class,
+            FileKitDialogSettings.class,
+            Function1.class,
+            Composer.class,
+            int.class,
+            int.class
+        );
+        jvm.getDeclaredMethod(
+            "rememberFileSaverLauncher",
+            WindowScope.class,
+            FileKitDialogSettings.class,
+            Function1.class,
+            Composer.class,
+            int.class,
+            int.class
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- add FileKitDialogException as the shared operational-failure marker while keeping FileKitPickerException compatible
- add explicit onError overloads for directory, saver, camera, share, and JVM WindowScope launchers while preserving every legacy overload
- normalize observable platform dialog failures without conflating cancellation, coroutine cancellation, callback failures, or programmer errors
- harden Android, iOS, JVM, macOS, Windows, JS, and WASM terminal behavior and update samples and documentation

## Compatibility

- existing JVM launcher descriptors are retained
- baseline Wasm and iOS KLIB declarations are retained
- a JVM consumer compiled against baseline 3380b8c8 runs against the new artifacts without recompilation
- named-argument and trailing-lambda call shapes are compile-tested, including the original rememberFilePickerLauncher call

## Verification

- independent specification review: pass
- independent standards review: pass
- ./gradlew assemble jvmTest testAndroidHostTest iosSimulatorArm64Test watchosSimulatorArm64Test macosArm64Test linuxX64Test --no-daemon
- ./gradlew check assemble --no-daemon
- ktlint with the CI-pinned 1.8.0 binary and Compose rules 0.6.0
- git diff --check

Manual UI smoke testing was not performed; native failure, cancellation, ownership, and terminal-state behavior is covered by deterministic adapter tests.