### PR TITLE
✨ Support Nucleus 2.3 dialog parenting on Linux/X11

### DIFF
--- a/docs/dialogs/dialog-settings.mdx
+++ b/docs/dialogs/dialog-settings.mdx
@@ -92,28 +92,39 @@ There is no compatibility `parentWindow` property or constructor.
 
 #### Nucleus with the Tao backend
 
-Nucleus 2.1.10 exposes a native HWND for Tao windows on Windows. Adapt that
-framework-specific window locally and pass the resulting settings to a plain,
-non-`WindowScope` launcher:
+Nucleus 2.3.2 exposes the native identities needed to parent Tao dialogs on
+Windows and Linux/X11. Adapt the framework-specific window locally and pass the
+resulting settings to a plain, non-`WindowScope` launcher:
 
 ```kotlin
-val parent = when (Platform.Current) {
-    Platform.Windows -> nucleusWindow.unsafe.taoWindow
-        ?.nativeHandle
-        ?.takeIf { it != 0L }
-        ?.let(FileKitDialogParent::windows)
-    else -> null
+private fun NucleusWindow.fileKitDialogParent(): FileKitDialogParent? {
+    unsafe.awtWindow?.let { return FileKitDialogParent.awt(it) }
+
+    return when (Platform.Current) {
+        Platform.Windows -> unsafe.taoWindow
+            ?.nativeHandle
+            ?.takeIf { it != 0L }
+            ?.let(FileKitDialogParent::windows)
+        Platform.Linux -> unsafe.taoWindow
+            ?.x11WindowId
+            ?.let(FileKitDialogParent::x11)
+        else -> null
+    }
 }
 
-val settings = FileKitDialogSettings(parent = parent)
+val settings = FileKitDialogSettings(parent = nucleusWindow.fileKitDialogParent())
+val launcher = rememberFilePickerLauncher(dialogSettings = settings) { file ->
+    // Use the selected file.
+}
 ```
 
 Do not pass `nucleusWindow.unsafe.taoHandle`: it is an opaque Tao event-loop
-identity, not an operating-system dialog parent. Nucleus currently does not
-expose an X11 XID or `xdg_foreign` export for Tao on Linux. On macOS it exposes
-an NSView, while FileKit's JVM picker would need a separate NSWindow sheet
-implementation. Tao parenting is therefore currently supported through this
-adapter on Windows only.
+identity, not an operating-system dialog parent. On Wayland, `x11WindowId` is
+`null`, so this adapter deliberately opens an unparented dialog. Wayland parent
+exports and macOS NSWindow sheets are deferred pending community feedback; both
+require lifecycle handling beyond these direct Windows and X11 conversions.
+The dialog also remains unparented when the Nucleus window has not exposed a
+supported identity yet.
 
 ### iOS and macOS Settings
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ kotlinx-datetime = "0.8.0"
 kotlinx-io = "0.9.1"
 leakcanaryAndroid = "2.14"
 material-icons-core = "1.7.3"
-nucleus = "2.2.0"
+nucleus = "2.3.2"
 test-android-robolectric = "4.16.1"
 vanniktech-mavenPublish = "0.37.0"
 

--- a/sample/nucleusApp/src/main/kotlin/io/github/vinceglb/filekit/sample/nucleus/Main.kt
+++ b/sample/nucleusApp/src/main/kotlin/io/github/vinceglb/filekit/sample/nucleus/Main.kt
@@ -42,8 +42,13 @@ private fun NucleusWindow.fileKitDialogParent(): FileKitDialogParent? {
                 ?.let(FileKitDialogParent::windows)
         }
 
-        // Tao does not expose an XDG portal identifier on Linux, and its macOS
-        // handle is an NSView rather than the NSWindow required for a sheet.
+        Platform.Linux -> {
+            // Nucleus returns null here when Tao is using Wayland.
+            unsafe.taoWindow
+                ?.x11WindowId
+                ?.let(FileKitDialogParent::x11)
+        }
+
         else -> {
             null
         }

--- a/specs/CONTEXT.md
+++ b/specs/CONTEXT.md
@@ -1,0 +1,25 @@
+# FileKit
+
+FileKit provides framework-independent file operations and native dialogs across platforms. This glossary names the ownership concepts shared by dialog implementations and framework adapters.
+
+## Dialog ownership
+
+**Framework adapter**:
+An application-boundary conversion from a framework-specific window identity into a FileKit dialog parent. It remains outside the framework-independent dialog API.
+_Avoid_: Framework integration layer
+
+**Dialog parent**:
+The borrowed identity of the application window that owns a native dialog. The parent remains owned by the caller and valid until the dialog operation completes.
+_Avoid_: Parent window, native parent
+
+**Native window identity**:
+The platform-specific value that identifies a dialog parent to the operating system or desktop portal.
+_Avoid_: Native handle
+
+**Wayland parent export**:
+A compositor-issued capability that lets the desktop portal associate dialogs with a Wayland window. The caller keeps the export active while that window may own dialogs and releases it when the window is disposed.
+_Avoid_: Wayland window ID, surface pointer
+
+**Unparented dialog**:
+A native dialog with no owning application window, including when a framework has no supported or currently available identity. This is an explicit absence of a dialog parent, not a fallback for an invalid or incompatible value.
+_Avoid_: Default parent


### PR DESCRIPTION
## Summary

- Upgrade Nucleus to 2.3.2.
- Add X11 dialog parenting for Tao windows on Linux.
- Update Nucleus integration documentation and sample code.
- Document dialog ownership terminology and Wayland limitations.

## Testing

Not run (not requested).