### PR TITLE
📝 Add DevAnalyzer to the project references

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ FileKit is trusted by developers building amazing cross-platform applications:
 - **[Dancing Decibels](https://www.dancingdecibels.com)** - Multi-platform app for music festivals and live entertainment experiences, using FileKit for image imports and schedule import/export
 - **[Kai](https://github.com/SimonSchubert/Kai)** - OpenClaw alternative in your pocket, using FileKit in production across Android, iOS, desktop, and web
 - **[Hammer Editor](https://github.com/Wavesonics/hammer-editor)** - Multi-platform tool for writing stories and novels, using FileKit to select project directories and images
+- **[DevAnalyzer](https://github.com/Coding-Meet/DevAnalyzer)** - Developer productivity tool for analyzing and understanding software projects, using FileKit for file and directory handling in its project analysis workflow
 
 *Using FileKit in your project? [Let us know!](https://github.com/vinceglb/FileKit/discussions/343)*
 

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -83,6 +83,7 @@ FileKit is trusted by developers building amazing cross-platform applications:
 - **[Dancing Decibels](https://www.dancingdecibels.com)** - Multi-platform app for music festivals and live entertainment experiences, using FileKit for image imports and schedule import/export
 - **[Kai](https://github.com/SimonSchubert/Kai)** - OpenClaw alternative in your pocket, using FileKit in production across Android, iOS, desktop, and web
 - **[Hammer Editor](https://github.com/Wavesonics/hammer-editor)** - Multi-platform tool for writing stories and novels, using FileKit to select project directories and images
+- **[DevAnalyzer](https://github.com/Coding-Meet/DevAnalyzer)** - Developer productivity tool for analyzing and understanding software projects, using FileKit for file and directory handling in its project analysis workflow
 
 ## Key Features
 


### PR DESCRIPTION
## Summary

- Add DevAnalyzer to the list of projects using FileKit in the README
- Add the same entry to the documentation introduction

## Testing

Not run (not requested)