### PR TITLE
🐛 [iOS] Present the camera from a dedicated window by default

### DIFF
--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -7,6 +7,7 @@ import io.github.vinceglb.filekit.dialogs.FileKitDialog.documentPickerDelegate
 import io.github.vinceglb.filekit.dialogs.FileKitDialog.phPickerDelegate
 import io.github.vinceglb.filekit.dialogs.FileKitDialog.phPickerDismissDelegate
 import io.github.vinceglb.filekit.dialogs.util.CameraControllerDelegate
+import io.github.vinceglb.filekit.dialogs.util.CameraPresenterWindow
 import io.github.vinceglb.filekit.dialogs.util.DocumentPickerDelegate
 import io.github.vinceglb.filekit.dialogs.util.PhPickerDelegate
 import io.github.vinceglb.filekit.dialogs.util.PhPickerDismissDelegate
@@ -287,37 +288,45 @@ public actual suspend fun FileKit.openCameraPicker(
                 null
             }
         }
-        val presentation = prepareAppleCameraPresentation(
-            sourceAvailable = UIImagePickerController.isSourceTypeAvailable(cameraSource),
-            presenter = openCameraSettings.presenterViewController(),
-            requestedCamera = requestedCamera,
-        )
-
-        suspendCancellableCoroutine<UIImage?> { continuation ->
-            cameraControllerDelegate = CameraControllerDelegate(
-                onImagePicked = { image ->
-                    try {
-                        continuation.resume(
-                            requireAppleCameraImage(image),
-                        )
-                    } catch (failure: FileKitDialogException) {
-                        continuation.resumeWithException(failure)
-                    }
-                },
-                onPickerCancelled = { continuation.resume(null) },
+        val presenterWindow = when (openCameraSettings.presenter) {
+            null -> CameraPresenterWindow()
+            else -> null
+        }
+        try {
+            val presentation = prepareAppleCameraPresentation(
+                sourceAvailable = UIImagePickerController.isSourceTypeAvailable(cameraSource),
+                presenter = openCameraSettings.presenter ?: presenterWindow?.attach(),
+                requestedCamera = requestedCamera,
             )
 
-            val pickerController = UIImagePickerController()
-            pickerController.sourceType = cameraSource
-            pickerController.delegate = cameraControllerDelegate
+            suspendCancellableCoroutine<UIImage?> { continuation ->
+                cameraControllerDelegate = CameraControllerDelegate(
+                    onImagePicked = { image ->
+                        try {
+                            continuation.resume(
+                                requireAppleCameraImage(image),
+                            )
+                        } catch (failure: FileKitDialogException) {
+                            continuation.resumeWithException(failure)
+                        }
+                    },
+                    onPickerCancelled = { continuation.resume(null) },
+                )
 
-            presentation.cameraDevice?.let { pickerController.cameraDevice = it }
+                val pickerController = UIImagePickerController()
+                pickerController.sourceType = cameraSource
+                pickerController.delegate = cameraControllerDelegate
 
-            presentation.presenter.presentViewController(
-                pickerController,
-                animated = true,
-                completion = null,
-            )
+                presentation.cameraDevice?.let { pickerController.cameraDevice = it }
+
+                presentation.presenter.presentViewController(
+                    pickerController,
+                    animated = true,
+                    completion = null,
+                )
+            }
+        } finally {
+            presenterWindow?.detach()
         }
     } ?: return null
 
@@ -524,9 +533,6 @@ private fun activeAppleViewController(): UIViewController? =
 private fun FileKitDialogSettings.presenterViewController(
     activeViewController: () -> UIViewController? = ::activeAppleViewController,
 ): UIViewController? = presenter ?: activeViewController()
-
-private fun FileKitOpenCameraSettings.presenterViewController(): UIViewController? =
-    presenter ?: UIApplication.sharedApplication.topMostViewController()
 
 private fun FileKitShareSettings.presenterViewController(): UIViewController? =
     presenter ?: UIApplication.sharedApplication.topMostViewController()

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitOpenCameraSettings.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKitOpenCameraSettings.ios.kt
@@ -5,7 +5,10 @@ import platform.UIKit.UIViewController
 /**
  * iOS implementation of [FileKitOpenCameraSettings].
  *
- * @property presenter The view controller used to present the camera picker.
+ * @property presenter The view controller used to present the camera picker. When null, FileKit
+ * presents the camera from a dedicated window placed above the app's windows, which keeps the
+ * picker compatible with hosts whose dialogs live in their own window, such as Compose
+ * Multiplatform 1.11+.
  */
 public actual class FileKitOpenCameraSettings(
     public val presenter: UIViewController? = null,

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/util/CameraPresenterWindow.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/util/CameraPresenterWindow.kt
@@ -1,0 +1,47 @@
+package io.github.vinceglb.filekit.dialogs.util
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.UIKit.UIApplication
+import platform.UIKit.UIColor
+import platform.UIKit.UIScreen
+import platform.UIKit.UIViewController
+import platform.UIKit.UIWindow
+import platform.UIKit.UIWindowLevelAlert
+import platform.UIKit.UIWindowScene
+
+/**
+ * Hosts the camera presentation in a dedicated transparent [UIWindow].
+ *
+ * Since Compose Multiplatform 1.11, Compose dialogs and popups live in their own window placed
+ * above modally presented view controllers. Presenting the fullscreen camera from the top-most
+ * view controller of the main window puts it underneath such windows, which corrupts touch
+ * handling app-wide after the dismissal. Presenting from a dedicated key window above alerts
+ * avoids that; the previous key window is restored once the capture flow finishes.
+ */
+internal class CameraPresenterWindow {
+    private val hostViewController = UIViewController()
+    private var window: UIWindow? = null
+    private var previousKeyWindow: UIWindow? = null
+
+    @OptIn(ExperimentalForeignApi::class)
+    fun attach(): UIViewController {
+        val application = UIApplication.sharedApplication
+        previousKeyWindow = application.keyWindow
+        val scene = application.connectedScenes.firstNotNullOfOrNull { it as? UIWindowScene }
+        val newWindow = scene?.let(::UIWindow) ?: UIWindow(frame = UIScreen.mainScreen.bounds)
+        newWindow.rootViewController = hostViewController
+        newWindow.windowLevel = UIWindowLevelAlert + 1.0
+        newWindow.backgroundColor = UIColor.clearColor
+        newWindow.makeKeyAndVisible()
+        window = newWindow
+        return hostViewController
+    }
+
+    fun detach() {
+        window?.setHidden(true)
+        window?.rootViewController = null
+        window = null
+        previousKeyWindow?.makeKeyAndVisible()
+        previousKeyWindow = null
+    }
+}

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/util/CameraPresenterWindow.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/util/CameraPresenterWindow.kt
@@ -3,7 +3,7 @@ package io.github.vinceglb.filekit.dialogs.util
 import kotlinx.cinterop.ExperimentalForeignApi
 import platform.UIKit.UIApplication
 import platform.UIKit.UIColor
-import platform.UIKit.UIScreen
+import platform.UIKit.UISceneActivationStateForegroundActive
 import platform.UIKit.UIViewController
 import platform.UIKit.UIWindow
 import platform.UIKit.UIWindowLevelAlert
@@ -24,11 +24,14 @@ internal class CameraPresenterWindow {
     private var previousKeyWindow: UIWindow? = null
 
     @OptIn(ExperimentalForeignApi::class)
-    fun attach(): UIViewController {
+    fun attach(): UIViewController? {
         val application = UIApplication.sharedApplication
-        previousKeyWindow = application.keyWindow
-        val scene = application.connectedScenes.firstNotNullOfOrNull { it as? UIWindowScene }
-        val newWindow = scene?.let(::UIWindow) ?: UIWindow(frame = UIScreen.mainScreen.bounds)
+        val scene = application.connectedScenes
+            .filterIsInstance<UIWindowScene>()
+            .firstOrNull { it.activationState == UISceneActivationStateForegroundActive }
+            ?: return null
+        previousKeyWindow = scene.keyWindow
+        val newWindow = UIWindow(windowScene = scene)
         newWindow.rootViewController = hostViewController
         newWindow.windowLevel = UIWindowLevelAlert + 1.0
         newWindow.backgroundColor = UIColor.clearColor


### PR DESCRIPTION
Fixes #638.

### Problem

When no explicit presenter is supplied, `openCameraPicker` presents the in-process fullscreen `UIImagePickerController` from `topMostViewController()` — i.e. in the app's main window. Hosts whose dialogs live in their own `UIWindow` above modal view controllers — Compose Multiplatform since 1.11 (JetBrains/compose-multiplatform-core#2270, [CMP-9772](https://youtrack.jetbrains.com/issue/CMP-9772)) — end up with the camera presented **underneath** the dialog window. After the picker dismissal, touch handling is corrupted app-wide: every tap shows the press indication but never completes a click, until process restart. The gallery path never hits this because `PHPickerViewController` is out-of-process.

The deliver-after-dismissal fix from #619 is necessary but not sufficient here: the corruption comes from the presentation itself happening below the dialog window.

### Fix

`CameraPresenterWindow` hosts the camera presentation in a FileKit-managed transparent `UIWindow`: created on the active scene, made key above `UIWindowLevelAlert`, attached right before presenting, and detached — restoring the previous key window — once the capture flow finishes. The `try`/`finally` covers every exit: photo delivered, cancellation, and `prepareAppleCameraPresentation` failures (camera unavailable, requested facing unavailable).

Apps passing an explicit presenter through `FileKitOpenCameraSettings(presenter = ...)` keep the exact previous behavior — the managed window is only created when `presenter` is null. This matches the JetBrains-recommended pattern of presenting native modals from an app-managed window when CMP dialog windows are involved.

### Testing

`:filekit-dialogs:compileKotlinIosSimulatorArm64` and `:filekit-dialogs:iosSimulatorArm64Test` pass. The dedicated-window presentation recipe itself is confirmed on a physical iPhone 15 (iOS 17, Compose Multiplatform 1.11.1): an equivalent implementation applied through `FileKitOpenCameraSettings(presenter = ...)` in our app fully resolves the touch corruption described in #638, with the camera, cancellation and error paths all restoring the previous key window correctly.