### PR TITLE
🐛 End the wait when a document picker sheet is swiped away

### DIFF
--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -218,8 +218,10 @@ internal actual suspend fun FileKit.platformOpenFileSaver(
         // Set the initial directory
         directory?.let { pickerController.directoryURL = NSURL.fileURLWithPath(it.path) }
 
-        // Assign the delegate to the picker controller
+        // Assign the delegate to the picker controller. It answers for the presentation as well,
+        // so a swipe that never reaches documentPickerWasCancelled still ends the wait.
         pickerController.delegate = documentPickerDelegate
+        pickerController.presentationController?.delegate = documentPickerDelegate
 
         // Present the picker controller
         presenter.presentViewController(
@@ -553,8 +555,10 @@ private suspend fun callPicker(
         // Set up the picker mode
         pickerController.allowsMultipleSelection = mode == Mode.Multiple
 
-        // Assign the delegate to the picker controller
+        // Assign the delegate to the picker controller. It answers for the presentation as well,
+        // so a swipe that never reaches documentPickerWasCancelled still ends the wait.
         pickerController.delegate = documentPickerDelegate
+        pickerController.presentationController?.delegate = documentPickerDelegate
 
         // Present the picker controller
         presentApplePickerController(

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/util/DocumentPickerDelegate.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/util/DocumentPickerDelegate.kt
@@ -1,31 +1,62 @@
 package io.github.vinceglb.filekit.dialogs.util
 
 import platform.Foundation.NSURL
+import platform.UIKit.UIAdaptivePresentationControllerDelegateProtocol
 import platform.UIKit.UIDocumentPickerDelegateProtocol
 import platform.UIKit.UIDocumentPickerViewController
+import platform.UIKit.UIPresentationController
 import platform.darwin.NSObject
 
 internal class DocumentPickerDelegate(
     private val onFilesPicked: (List<NSURL>) -> Unit,
     private val onPickerCancelled: () -> Unit,
 ) : NSObject(),
-    UIDocumentPickerDelegateProtocol {
+    UIDocumentPickerDelegateProtocol,
+    UIAdaptivePresentationControllerDelegateProtocol {
+    private var hasFinished = false
+
     override fun documentPicker(
         controller: UIDocumentPickerViewController,
         didPickDocumentAtURL: NSURL,
     ) {
-        onFilesPicked(listOf(didPickDocumentAtURL))
+        if (finishOnce()) {
+            onFilesPicked(listOf(didPickDocumentAtURL))
+        }
     }
 
     override fun documentPicker(
         controller: UIDocumentPickerViewController,
         didPickDocumentsAtURLs: List<*>,
     ) {
-        val res = didPickDocumentsAtURLs.mapNotNull { it as? NSURL }
-        onFilesPicked(res)
+        if (finishOnce()) {
+            onFilesPicked(didPickDocumentsAtURLs.mapNotNull { it as? NSURL })
+        }
     }
 
     override fun documentPickerWasCancelled(controller: UIDocumentPickerViewController) {
-        onPickerCancelled()
+        if (finishOnce()) {
+            onPickerCancelled()
+        }
+    }
+
+    /**
+     * Swiping the sheet away does not always reach [documentPickerWasCancelled] — notably when the
+     * dismissal starts before the presentation animation has finished. Without this the caller's
+     * continuation waits for a delegate call that never comes. See #138.
+     */
+    override fun presentationControllerDidDismiss(presentationController: UIPresentationController) {
+        if (finishOnce()) {
+            onPickerCancelled()
+        }
+    }
+
+    /**
+     * A dismissal often reports through both protocols, and the caller resumes a continuation that
+     * only accepts one answer, so every entry point above goes through this.
+     */
+    private fun finishOnce(): Boolean {
+        if (hasFinished) return false
+        hasFinished = true
+        return true
     }
 }

--- a/filekit-dialogs/src/iosTest/kotlin/io/github/vinceglb/filekit/dialogs/DocumentPickerDelegateTest.kt
+++ b/filekit-dialogs/src/iosTest/kotlin/io/github/vinceglb/filekit/dialogs/DocumentPickerDelegateTest.kt
@@ -1,0 +1,67 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+
+package io.github.vinceglb.filekit.dialogs
+
+import io.github.vinceglb.filekit.dialogs.util.DocumentPickerDelegate
+import platform.Foundation.NSURL
+import platform.UIKit.UIDocumentPickerViewController
+import platform.UIKit.UIPresentationController
+import platform.UIKit.UIViewController
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The caller resumes a continuation from these callbacks, and a continuation only accepts one
+ * answer, so what matters is that exactly one of them ever gets through.
+ */
+class DocumentPickerDelegateTest {
+    @Test
+    fun DocumentPickerDelegate_swipeDismissWithoutCancelCallback_reportsCancelled() {
+        val recorder = Recorder()
+
+        recorder.delegate.presentationControllerDidDismiss(presentationController())
+
+        assertEquals(expected = 0, actual = recorder.pickedCount)
+        assertEquals(expected = 1, actual = recorder.cancelledCount)
+    }
+
+    @Test
+    fun DocumentPickerDelegate_cancelThenSwipeDismiss_reportsCancelledOnce() {
+        val recorder = Recorder()
+
+        recorder.delegate.documentPickerWasCancelled(picker())
+        recorder.delegate.presentationControllerDidDismiss(presentationController())
+
+        assertEquals(expected = 1, actual = recorder.cancelledCount)
+    }
+
+    @Test
+    fun DocumentPickerDelegate_pickThenSwipeDismiss_reportsOnlyThePick() {
+        val recorder = Recorder()
+
+        recorder.delegate.documentPicker(picker(), didPickDocumentAtURL = NSURL(string = "file:///tmp/a.txt"))
+        recorder.delegate.presentationControllerDidDismiss(presentationController())
+
+        assertEquals(expected = 1, actual = recorder.pickedCount)
+        assertEquals(expected = 0, actual = recorder.cancelledCount)
+    }
+
+    private class Recorder {
+        var pickedCount = 0
+        var cancelledCount = 0
+
+        val delegate = DocumentPickerDelegate(
+            onFilesPicked = { pickedCount++ },
+            onPickerCancelled = { cancelledCount++ },
+        )
+    }
+
+    private fun picker(): UIDocumentPickerViewController =
+        UIDocumentPickerViewController(forOpeningContentTypes = emptyList<Any>())
+
+    private fun presentationController(): UIPresentationController =
+        UIPresentationController(
+            presentedViewController = UIViewController(nibName = null, bundle = null),
+            presentingViewController = null,
+        )
+}


### PR DESCRIPTION
Closes #138. Follows up on [my comment there](https://github.com/vinceglb/FileKit/issues/138#issuecomment-5306561836).

## The gap

`PHPickerViewController` gets a `UIAdaptivePresentationControllerDelegate` so a swipe dismissal resumes the caller. The two `UIDocumentPickerViewController` paths never got one:

| Line | Picker | `.delegate` | `presentationController.delegate` |
|---|---|---|---|
| 222 | `UIDocumentPickerViewController` (save) | ✅ | ❌ → now ✅ |
| 312 | `UIImagePickerController` (camera) | ✅ | ❌ (untouched) |
| 557 | `UIDocumentPickerViewController` (open) | ✅ | ❌ → now ✅ |
| 614–615 | `PHPickerViewController` | ✅ | ✅ |

So when `documentPickerWasCancelled` does not fire — which @derynia reports happens when the swipe starts before the presentation animation finishes — the `suspendCancellableCoroutine` waits forever and the tap looks dead.

## The change

Rather than a second delegate object mirroring `PhPickerDismissDelegate`, `DocumentPickerDelegate` now implements both protocols behind one `finishOnce()` guard.

That is deliberate. A dismissal frequently reports through *both* `documentPickerWasCancelled` and `presentationControllerDidDismiss`, and the call sites resume a continuation that accepts exactly one answer — a second resume throws `IllegalStateException`. One object with one guard makes double-resume impossible. (For what it's worth, the PHPicker pair has its guard only on `PhPickerDelegate`, not on `PhPickerDismissDelegate`.)

`presentationController?.delegate = …` is a no-op where there is no presentation controller, so styles without one behave exactly as before.

The camera path is left alone — it is full-screen and not what #138 describes.

## Verification, and its limits

**Tested:** three new tests in `filekit-dialogs/src/iosTest` covering the delegate contract — swipe-dismiss with no cancel callback reports cancelled; cancel followed by swipe-dismiss reports cancelled *once*; a pick followed by swipe-dismiss reports only the pick. 45 tests pass on `iosSimulatorArm64Test`, `compileKotlinIosArm64` clean. Disabling `finishOnce()` makes two of the three fail, so the guard is doing real work.

**Not tested — please read before merging:** I could not reproduce the original bug or observe the fix working on a simulator. Driving a mid-animation swipe needs synthetic UI events, and the environment I work in cannot grant the Accessibility permission that requires; two attempts got as far as a running sample app and no further. So this fix is argued from the delegate contract, the pattern already in this repo, and the reporter's description — **not from watching the symptom disappear.**

You said in October 2024 that you could reproduce it. If you can run that same reproduction against this branch, that is the check I was unable to do.

## Why it may matter more than a missing callback

Field report, cause unconfirmed: in an app I work on the iOS file picker intermittently stopped opening *at all*, and stayed broken until the app was killed. UIKit ignores `presentViewController()` while the presenter already has a `presentedViewController`, and that presenter is the root view controller — so one picker left presented breaks every later one. We patched the symptom by clearing stale presentations before launching, and never identified the trigger. If a mid-animation swipe can leave the controller presented while no delegate fires, this issue would explain it. I cannot prove that link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)