### PR TITLE
Fix iOS PHPicker multi-select copy collisions

### DIFF
--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -720,7 +720,12 @@ private fun callPhPicker(
                                 else -> {
                                     // Must copy the URL here because it becomes invalid outside the loadFileRepresentationForTypeIdentifier callback scope
                                     runCatching {
-                                        copyToTempFile(fileManager, url, tempRoot.lastPathComponent!!)
+                                        copyToTempFile(
+                                            fileManager = fileManager,
+                                            url = url,
+                                            id = tempRoot.lastPathComponent!!,
+                                            index = index,
+                                        )
                                     }.onSuccess(cont::resume)
                                         .onFailure { cont.resumeWithException(it) }
                                 }
@@ -786,18 +791,34 @@ private fun copyToTempFile(
     fileManager: NSFileManager,
     url: NSURL,
     id: String,
+    index: Int,
 ): NSURL {
-    // Get the temporary directory
-    val fileComponents = fileManager.temporaryDirectory.pathComponents
+    val fileName = url.lastPathComponent ?: "file"
+
+    // Use a per-asset subdirectory so lastPathComponent stays unchanged.
+    val directoryComponents = fileManager.temporaryDirectory.pathComponents
         ?.plus(id)
-        ?.plus(url.lastPathComponent)
+        ?.plus(index.toString())
         ?: throw FileKitPickerException("Failed to resolve the temporary directory for the selected file.")
 
-    // Create a file URL
+    val directoryUrl = NSURL.fileURLWithPathComponents(directoryComponents)
+        ?: throw FileKitPickerException("Failed to create a temporary directory for the selected file.")
+
+    requireApplePickerOperation(
+        message = "Failed to create a temporary directory for the selected file.",
+    ) { error ->
+        fileManager.createDirectoryAtURL(
+            url = directoryUrl,
+            withIntermediateDirectories = true,
+            attributes = null,
+            error = error,
+        )
+    }
+
+    val fileComponents = directoryComponents.plus(fileName)
     val fileUrl = NSURL.fileURLWithPathComponents(fileComponents)
         ?: throw FileKitPickerException("Failed to create a temporary URL for the selected file.")
 
-    // Write the data to the file URL
     requireApplePickerOperation(
         message = "Failed to copy the selected file to a temporary location.",
     ) { error ->

--- a/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
+++ b/filekit-dialogs/src/iosMain/kotlin/io/github/vinceglb/filekit/dialogs/FileKit.ios.kt
@@ -787,7 +787,7 @@ private fun <R> List<R>?.ifNullOrEmpty(block: () -> List<R>): List<R> =
     if (this.isNullOrEmpty()) block() else this
 
 @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
-private fun copyToTempFile(
+internal fun copyToTempFile(
     fileManager: NSFileManager,
     url: NSURL,
     id: String,

--- a/filekit-dialogs/src/iosTest/kotlin/io/github/vinceglb/filekit/dialogs/ApplePickerTempFileTest.kt
+++ b/filekit-dialogs/src/iosTest/kotlin/io/github/vinceglb/filekit/dialogs/ApplePickerTempFileTest.kt
@@ -1,0 +1,50 @@
+@file:Suppress("ktlint:standard:function-naming", "TestFunctionName")
+
+package io.github.vinceglb.filekit.dialogs
+
+import io.github.vinceglb.filekit.utils.toByteArray
+import io.github.vinceglb.filekit.utils.toNSData
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSUUID
+import platform.Foundation.temporaryDirectory
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalForeignApi::class)
+class ApplePickerTempFileTest {
+    @Test
+    fun ApplePicker_sameFilename_preservesBothFilesAndContents() {
+        val fileManager = NSFileManager.defaultManager
+        val id = NSUUID().UUIDString
+        val root = assertNotNull(fileManager.temporaryDirectory.URLByAppendingPathComponent(id))
+        val contents = listOf(byteArrayOf(1, 2, 3), byteArrayOf(4, 5, 6))
+
+        try {
+            val sources = contents.mapIndexed { index, bytes ->
+                val directory = assertNotNull(root.URLByAppendingPathComponent("source-$index"))
+                assertTrue(fileManager.createDirectoryAtURL(directory, true, null, null))
+                val source = assertNotNull(directory.URLByAppendingPathComponent("image.jpeg"))
+                assertTrue(fileManager.createFileAtPath(assertNotNull(source.path), bytes.toNSData(), null))
+                source
+            }
+
+            val copies = sources.mapIndexed { index, source ->
+                copyToTempFile(fileManager, source, id, index)
+            }
+
+            assertNotEquals(copies[0].path, copies[1].path)
+            copies.forEachIndexed { index, copy ->
+                assertEquals("image.jpeg", copy.lastPathComponent)
+                val data = assertNotNull(fileManager.contentsAtPath(assertNotNull(copy.path)))
+                assertContentEquals(contents[index], data.toByteArray())
+            }
+        } finally {
+            fileManager.removeItemAtURL(root, null)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #645

Copy each selected PHPicker asset into its own subdirectory so assets
that share lastPathComponent (e.g. image.jpeg) do not collide, while
preserving the original filename.